### PR TITLE
Handle hostnames that resolve to multiple IPs.

### DIFF
--- a/base/networking.h
+++ b/base/networking.h
@@ -96,6 +96,9 @@ sockaddr_as_str (const struct sockaddr_storage *, char *);
 int
 gvm_resolve (const char *, void *, int);
 
+GSList *
+gvm_resolve_list (const char *);
+
 int
 gvm_resolve_as_addr6 (const char *, struct in6_addr *);
 


### PR DESCRIPTION
This will result in multiple target hosts, one for each IP, and with the
initial hostname added to the host's vhosts list, instead of only
considering the first returned IP as before.