### PR TITLE
Reduce nvticache memory footprint in Redis.

### DIFF
--- a/util/kb.h
+++ b/util/kb.h
@@ -30,6 +30,8 @@
 #include <stddef.h>    /* for NULL */
 #include <sys/types.h> /* for size_t */
 
+#include "../base/nvti.h" /* for nvti_t */
+
 /**
  * @brief Default KB location.
  *
@@ -48,6 +50,29 @@ enum kb_item_type {
   KB_TYPE_STR,      /**< The kb_items v should then be interpreted as char*. */
   /* -- */
   KB_TYPE_CNT,
+};
+
+/**
+ * @brief Possible positions of nvt values in cache list.
+ */
+enum kb_nvt_pos {
+    NVT_FILENAME_POS,
+    NVT_REQUIRED_KEYS_POS,
+    NVT_MANDATORY_KEYS_POS,
+    NVT_EXCLUDED_KEYS_POS,
+    NVT_REQUIRED_UDP_PORTS_POS,
+    NVT_REQUIRED_PORTS_POS,
+    NVT_DEPENDENCIES_POS,
+    NVT_TAGS_POS,
+    NVT_CVES_POS,
+    NVT_BIDS_POS,
+    NVT_XREFS_POS,
+    NVT_CATEGORY_POS,
+    NVT_TIMEOUT_POS,
+    NVT_FAMILY_POS,
+    NVT_COPYRIGHT_POS,
+    NVT_NAME_POS,
+    NVT_VERSION_POS,
 };
 
 /**
@@ -103,12 +128,14 @@ struct kb_operations
   struct kb_item *(*kb_get_single) (kb_t, const char *, enum kb_item_type);
   char *(*kb_get_str) (kb_t, const char *);
   int (*kb_get_int) (kb_t, const char *);
+  char *(*kb_get_nvt) (kb_t, const char *, enum kb_nvt_pos);
   struct kb_item * (*kb_get_all) (kb_t, const char *);
   struct kb_item * (*kb_get_pattern) (kb_t, const char *);
   int (*kb_add_str) (kb_t, const char *, const char *, size_t);
   int (*kb_set_str) (kb_t, const char *, const char *, size_t);
   int (*kb_add_int) (kb_t, const char *, int);
   int (*kb_set_int) (kb_t, const char *, int);
+  int (*kb_add_nvt) (kb_t, const nvti_t *, const char *);
   int (*kb_del_items) (kb_t, const char *);
 
   /* Utils */
@@ -329,6 +356,40 @@ kb_item_set_int (kb_t kb, const char *name, int val)
   assert (kb->kb_ops->kb_set_int);
 
   return kb->kb_ops->kb_set_int (kb, name, val);
+}
+
+/**
+ * @brief Insert a new nvt.
+ * @param[in] kb        KB handle where to store the nvt.
+ * @param[in] nvt       nvt to store.
+ * @param[in] filename  Path to nvt to store.
+ * @return 0 on success, non-null on error.
+ */
+static inline int
+kb_nvt_add (kb_t kb, const nvti_t *nvt, const char *filename)
+{
+  assert (kb);
+  assert (kb->kb_ops);
+  assert (kb->kb_ops->kb_add_nvt);
+
+  return kb->kb_ops->kb_add_nvt (kb, nvt, filename);
+}
+
+/**
+ * @brief Get field of a NVT.
+ * @param[in] kb        KB handle where to store the nvt.
+ * @param[in] oid       OID of NVT to get from.
+ * @param[in] field     Name of field to get.
+ * @return Value of field, NULL otherwise.
+ */
+static inline char *
+kb_nvt_get (kb_t kb, const char *oid, enum kb_nvt_pos position)
+{
+  assert (kb);
+  assert (kb->kb_ops);
+  assert (kb->kb_ops->kb_add_nvt);
+
+  return kb->kb_ops->kb_get_nvt (kb, oid, position);
 }
 
 /**

--- a/util/nvticache.c
+++ b/util/nvticache.c
@@ -40,6 +40,7 @@
 #include <string.h>   /* for strcmp */
 #include <sys/stat.h> /* for stat, st_mtime */
 #include <time.h>     /* for time, time_t */
+#include <stdlib.h>     /* for atoi */
 
 #include "kb.h" /* for kb_del_items, kb_item_get_str, kb_item_add_int */
 
@@ -163,60 +164,6 @@ nvticache_save ()
 }
 
 /**
- * @brief Remove an NVT from the cache.
- *
- * @param oid       OID of the NVT to remove.
- *
- * @param filename  Filename of NVT to remove.
- */
-static void
-nvticache_remove (const char *oid, const char *filename)
-{
-  char pattern[2048];
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:filename", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:required_keys", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:mandatory_keys", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:excluded_keys", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:required_udp_ports", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:required_ports", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:dependencies", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:tags", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:cves", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:bids", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:xrefs", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:category", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:timeout", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:family", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:copyright", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:name", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:version", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:prefs", oid);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "filename:%s:oid", filename);
-  kb_del_items (cache_kb, pattern);
-  g_snprintf (pattern, sizeof (pattern), "filename:%s:timestamp", filename);
-  kb_del_items (cache_kb, pattern);
-}
-
-/**
  * @brief Add a NVT Information to the cache.
  *
  * @param nvti     The NVT Information to add
@@ -231,104 +178,25 @@ nvticache_remove (const char *oid, const char *filename)
 int
 nvticache_add (const nvti_t *nvti, const char *filename)
 {
-  char *oid, pattern[2048], *dummy;
+  char *oid, *dummy, pattern[4096];
   GSList *element;
 
   assert (cache_kb);
   /* Check for duplicate OID. */
   oid = nvti_oid (nvti);
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:filename", oid);
-  dummy = kb_item_get_str (cache_kb, pattern);
+  dummy = nvticache_get_filename (oid);
   if (dummy && strcmp (filename, dummy))
     g_warning ("NVT %s with duplicate OID %s will be replaced with %s",
                dummy, oid, filename);
   if (dummy)
-    nvticache_remove (oid, dummy);
+    {
+      g_snprintf (pattern, sizeof (pattern), "nvt:%s", oid);
+      kb_del_items (cache_kb, pattern);
+    }
+
   g_free (dummy);
 
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:filename", oid);
-  if (kb_item_add_str (cache_kb, pattern, filename, 0))
-    goto kb_fail;
-  if (nvti_required_keys (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:required_keys", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_required_keys (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_mandatory_keys (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:mandatory_keys", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_mandatory_keys (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_excluded_keys (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:excluded_keys", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_excluded_keys (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_required_udp_ports (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:required_udp_ports", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_required_udp_ports (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_required_ports (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:required_ports", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_required_ports (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_dependencies (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:dependencies", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_dependencies (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_tag (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:tags", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_tag (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_cve (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:cves", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_cve (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_bid (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:bids", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_bid (nvti), 0))
-        goto kb_fail;
-    }
-  if (nvti_xref (nvti))
-    {
-      g_snprintf (pattern, sizeof (pattern), "oid:%s:xrefs", oid);
-      if (kb_item_add_str (cache_kb, pattern, nvti_xref (nvti), 0))
-        goto kb_fail;
-    }
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:category", oid);
-  if (kb_item_add_int (cache_kb, pattern, nvti_category (nvti)))
-    goto kb_fail;
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:timeout", oid);
-  if (kb_item_add_int (cache_kb, pattern, nvti_timeout (nvti)))
-    goto kb_fail;
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:family", oid);
-  if (kb_item_add_str (cache_kb, pattern, nvti_family (nvti), 0))
-    goto kb_fail;
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:copyright", oid);
-  if (kb_item_add_str (cache_kb, pattern, nvti_copyright (nvti), 0))
-    goto kb_fail;
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:name", oid);
-  if (kb_item_add_str (cache_kb, pattern, nvti_name (nvti), 0))
-    goto kb_fail;
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:version", oid);
-  if (kb_item_add_str (cache_kb, pattern, nvti_version (nvti), 0))
-    goto kb_fail;
-  g_snprintf (pattern, sizeof (pattern), "filename:%s:oid", filename);
-  if (kb_item_add_str (cache_kb, pattern, oid, 0))
+  if (kb_nvt_add (cache_kb, nvti, filename))
     goto kb_fail;
   element = nvti->prefs;
   while (element)
@@ -363,12 +231,11 @@ kb_fail:
 char *
 nvticache_get_src (const char *oid)
 {
-  char *filename, *src, pattern[2048];
+  char *filename, *src;
 
   assert (cache_kb);
 
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:filename", oid);
-  filename = kb_item_get_str (cache_kb, pattern);
+  filename = kb_nvt_get (cache_kb, oid, NVT_FILENAME_POS);
   if (!filename)
     return NULL;
   src = g_build_filename (src_path, filename, NULL);
@@ -417,12 +284,8 @@ nvticache_get_oid (const char *filename)
 char *
 nvticache_get_filename (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:filename", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_FILENAME_POS);
 }
 
 /**
@@ -435,12 +298,8 @@ nvticache_get_filename (const char *oid)
 char *
 nvticache_get_required_keys (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:required_keys", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_REQUIRED_KEYS_POS);
 }
 
 /**
@@ -453,12 +312,8 @@ nvticache_get_required_keys (const char *oid)
 char *
 nvticache_get_mandatory_keys (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:mandatory_keys", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_MANDATORY_KEYS_POS);
 }
 
 /**
@@ -471,12 +326,8 @@ nvticache_get_mandatory_keys (const char *oid)
 char *
 nvticache_get_excluded_keys (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:excluded_keys", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_EXCLUDED_KEYS_POS);
 }
 
 /**
@@ -489,12 +340,8 @@ nvticache_get_excluded_keys (const char *oid)
 char *
 nvticache_get_required_udp_ports (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:required_udp_ports", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_REQUIRED_UDP_PORTS_POS);
 }
 
 /**
@@ -507,12 +354,8 @@ nvticache_get_required_udp_ports (const char *oid)
 char *
 nvticache_get_required_ports (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:required_ports", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_REQUIRED_PORTS_POS);
 }
 
 /**
@@ -525,12 +368,8 @@ nvticache_get_required_ports (const char *oid)
 char *
 nvticache_get_dependencies (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:dependencies", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_DEPENDENCIES_POS);
 }
 
 /**
@@ -543,12 +382,14 @@ nvticache_get_dependencies (const char *oid)
 int
 nvticache_get_category (const char *oid)
 {
-  char pattern[2048];
+  int category;
+  char *category_s;
 
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:category", oid);
-  return kb_item_get_int (cache_kb, pattern);
+  category_s = kb_nvt_get (cache_kb, oid, NVT_CATEGORY_POS);
+  category = atoi (category_s);
+  g_free (category_s);
+  return category;
 }
 
 /**
@@ -561,12 +402,14 @@ nvticache_get_category (const char *oid)
 int
 nvticache_get_timeout (const char *oid)
 {
-  char pattern[2048];
+  int timeout;
+  char *timeout_s;
 
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:timeout", oid);
-  return kb_item_get_int (cache_kb, pattern);
+  timeout_s = kb_nvt_get (cache_kb, oid, NVT_TIMEOUT_POS);
+  timeout = atoi (timeout_s);
+  g_free (timeout_s);
+  return timeout;
 }
 
 /**
@@ -579,12 +422,8 @@ nvticache_get_timeout (const char *oid)
 char *
 nvticache_get_name (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:name", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_NAME_POS);
 }
 
 /**
@@ -597,12 +436,8 @@ nvticache_get_name (const char *oid)
 char *
 nvticache_get_version (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:version", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_VERSION_POS);
 }
 
 /**
@@ -615,12 +450,8 @@ nvticache_get_version (const char *oid)
 char *
 nvticache_get_copyright (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:copyright", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_COPYRIGHT_POS);
 }
 
 /**
@@ -633,12 +464,8 @@ nvticache_get_copyright (const char *oid)
 char *
 nvticache_get_cves (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:cves", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_CVES_POS);
 }
 
 /**
@@ -651,12 +478,8 @@ nvticache_get_cves (const char *oid)
 char *
 nvticache_get_bids (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:bids", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_BIDS_POS);
 }
 
 /**
@@ -669,12 +492,8 @@ nvticache_get_bids (const char *oid)
 char *
 nvticache_get_xrefs (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:xrefs", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_XREFS_POS);
 }
 
 /**
@@ -687,12 +506,8 @@ nvticache_get_xrefs (const char *oid)
 char *
 nvticache_get_family (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:family", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_FAMILY_POS);
 }
 
 /**
@@ -705,12 +520,8 @@ nvticache_get_family (const char *oid)
 char *
 nvticache_get_tags (const char *oid)
 {
-  char pattern[2048];
-
   assert (cache_kb);
-
-  g_snprintf (pattern, sizeof (pattern), "oid:%s:tags", oid);
-  return kb_item_get_str (cache_kb, pattern);
+  return kb_nvt_get (cache_kb, oid, NVT_TAGS_POS);
 }
 
 /**


### PR DESCRIPTION
Use Redis lists to store NVT's metadata, instead of a separate sets with
repeated value names, for each information. Reduces Redis memory footprint
(~120M vs ~276M) and fresh load-up speed (~40sec vs ~52sec)

# Before:
$ time openvassd -C
real	0m52.348s
user	0m35.108s
sys	0m8.008s

redis /tmp/redis.sock[1]> info memory
 Memory
used_memory:290317280
used_memory_human:276.87M
used_memory_rss:302620672
used_memory_rss_human:288.60M

# After:
$ time openvassd -C
real	0m40.362s
user	0m31.848s
sys	0m4.116s

redis /tmp/redis.sock[1]> info memory
 Memory
used_memory:125899440
used_memory_human:120.07M
used_memory_rss:133787648
used_memory_rss_human:127.59M
