### PR TITLE
Backport r30032.

### DIFF
--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -244,7 +244,6 @@ cell_cmp (lex_ctxt * lexic, tree_cell * c1, tree_cell * c2)
   long int x1, x2;
   char *s1, *s2;
   int len_s1, len_s2, len_min;
-  gchar *n1, *n2;
 
 #if NASL_DEBUG >= 0
   if (c1 == NULL || c1 == FAKE_CELL)
@@ -253,9 +252,6 @@ cell_cmp (lex_ctxt * lexic, tree_cell * c1, tree_cell * c2)
     nasl_perror (lexic, "cell_cmp: c2 == NULL !\n");
 #endif
 
-  n1 = cell2str (lexic, c1);
-  n2 = cell2str (lexic, c2);
-  
   /* We first convert the cell to atomic types. */
   c1 = cell2atom (lexic, c1);
   c2 = cell2atom (lexic, c2);
@@ -279,8 +275,6 @@ cell_cmp (lex_ctxt * lexic, tree_cell * c1, tree_cell * c2)
     {
       deref_cell (c1);
       deref_cell (c2);
-      g_free (n1);
-      g_free (n2);
       return 0;
     }
 
@@ -305,8 +299,6 @@ cell_cmp (lex_ctxt * lexic, tree_cell * c1, tree_cell * c2)
       {
         deref_cell (c1);
         deref_cell (c2);
-        g_free (n1);
-        g_free (n2);
         return -1;              /* NULL is smaller than anything else */
       }
   else if (typ2 == 0)           /* 2nd argument is null */
@@ -316,12 +308,14 @@ cell_cmp (lex_ctxt * lexic, tree_cell * c1, tree_cell * c2)
       {
         deref_cell (c1);
         deref_cell (c2);
-        g_free (n1);
-        g_free (n2);
         return 1;               /* Anything else is greater than NULL  */
       }
   else
     {
+      gchar *n1, *n2;
+
+      n1 = cell2str (lexic, c1);
+      n2 = cell2str (lexic, c2);
       nasl_perror (lexic, "cell_cmp: comparing '%s' of type %s and '%s' of "
                    "type %s does not make sense\n",
                    n1, nasl_type_name (typ1), n2, nasl_type_name (typ2));
@@ -331,8 +325,6 @@ cell_cmp (lex_ctxt * lexic, tree_cell * c1, tree_cell * c2)
       g_free (n2);
       return 0;
     }
-  g_free (n1);
-  g_free (n2);
 
 
   switch (typ)


### PR DESCRIPTION
Fix regression introduced in r29164. Don't call cell2str() before
cell2atom() as it leads to executing expressions such as incrementations
and function calls twice.