### PR TITLE
util/nvticache.c (nvticache_free): Set src_path pointer to NULL.

### DIFF
--- a/util/nvticache.c
+++ b/util/nvticache.c
@@ -93,6 +93,7 @@ void
 nvticache_free (void)
 {
   g_free (src_path);
+  src_path = NULL;
   kb_delete (cache_kb);
   cache_kb = NULL;
 }

--- a/util/nvticache.h
+++ b/util/nvticache.h
@@ -122,9 +122,6 @@ nvticache_get_timeout (const char *);
 char *
 nvticache_get_dependencies (const char *);
 
-void
-nvticache_free (void);
-
 GSList *
 nvticache_get_oids (void);
 


### PR DESCRIPTION
util/nvticache.c (nvticache_free): Set src_path pointer to NULL.
util/nvticache.h: Remove double entry.