### PR TITLE
Backport scanner PR #22.

### DIFF
--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -646,7 +646,7 @@ load_checksums (kb_t kb)
       else
         g_snprintf (buffer, sizeof (buffer), "%s:%s/%s", prefix, base,
                     splits[1]);
-      kb_item_add_str (kb, buffer, splits[0]);
+      kb_item_set_str (kb, buffer, splits[0]);
       g_strfreev (splits);
     }
   fclose (file);


### PR DESCRIPTION
Use kb_item_set_str() to insert checksum.

This ensures that we don't get duplicate checksum values in the kb,
leading to occasional errors during checksum errors.