### PR TITLE
Use "nvticache10" value to identify cache KB.

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -479,8 +479,15 @@ redis_find (const char *kb_path, const char *key)
       else
         {
           freeReplyObject (rep);
-          if (key && kb_item_get_int (&kbr->kb, key) > 0)
-            return (kb_t) kbr;
+          if (key)
+            {
+              char *tmp = kb_item_get_str (&kbr->kb, key);
+              if (tmp)
+                {
+                  g_free (tmp);
+                  return (kb_t) kbr;
+                }
+            }
         }
       redisFree (kbr->rctx);
       i++;
@@ -1153,11 +1160,16 @@ redis_flush_all (kb_t kb, const char *except)
         {
           freeReplyObject (rep);
           /* Don't remove DB if it has "except" key. */
-          if (except && kb_item_get_int (kb, except) > 0)
+          if (except)
             {
-              i++;
-              redisFree (kbr->rctx);
-              continue;
+              char *tmp = kb_item_get_str (kb, except);
+              if (tmp)
+               {
+                 g_free (tmp);
+                 i++;
+                 redisFree (kbr->rctx);
+                 continue;
+               }
             }
           redis_delete_all (kbr);
           redis_release_db (kbr);

--- a/util/nvticache.h
+++ b/util/nvticache.h
@@ -38,6 +38,8 @@
 #include "../base/nvti.h"  /* for nvti_t */
 #include "kb.h"            /* for kb_t */
 
+#define NVTICACHE_STR "nvticache10"
+
 int
 nvticache_init (const char *, const char *);
 
@@ -127,5 +129,8 @@ nvticache_count (void);
 
 void
 nvticache_delete (const char *);
+
+char *
+nvticache_feed_version (void);
 
 #endif /* not _GVM_NVTICACHE_H */


### PR DESCRIPTION
So that an nvtcache from openvas-9 isn't wrongly used. Also store the
feed version in that key.