### PR TITLE
Fix #40: Check the version of libgcrypt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,13 @@ if (NOT MINGW)
     execute_process (COMMAND libgcrypt-config --cflags
       OUTPUT_VARIABLE GCRYPT_CFLAGS
       OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND libgcrypt-config --version
+      OUTPUT_VARIABLE GCRYPT_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message (STATUS "  found libgcrypt, version ${GCRYPT_VERSION}")
+    if (GCRYPT_VERSION VERSION_LESS "1.6")
+      message (SEND_ERROR "libgcrypt 1.6 or greater is required")
+    endif (GCRYPT_VERSION VERSION_LESS "1.6")
   endif (NOT GCRYPT)
 
 endif (NOT MINGW)

--- a/INSTALL
+++ b/INSTALL
@@ -22,7 +22,7 @@ General build environment:
 Specific development libraries:
 * libglib >= 2.32
 * libgnutls >= 3.2.15
-* libgcrypt
+* libgcrypt >= 1.6
 * zlib
 * libpcap
 * libgpgme >= 1.1.2


### PR DESCRIPTION
Previously CMake only checked for the presence of libgcrypt, causing
build failures when the installed libgcrypt was too old and did not
provide the required symbols.

This commit adds a version check for libgcrypt which will fail if the
version is below 1.6. This version requirement is now documented in the
INSTALL file as well.