### PR TITLE
Backport r28888 and openvas-scanner PR #36.

### DIFF
--- a/nasl/nasl.h
+++ b/nasl/nasl.h
@@ -42,6 +42,9 @@ GSList *nasl_get_all_certificates (void);
 
 int add_nasl_inc_dir (const char *);
 
+void
+nasl_clean_inc (void);
+
 int
 exec_nasl_script (struct arglist *, const char *, const char *, int);
 int


### PR DESCRIPTION
Save parsed tree cells of included files for later re-usage. Reduces load-up time from ~3m30 to ~55s.