### PR TITLE
Backport PR #46.

### DIFF
--- a/base/kb_redis.c
+++ b/base/kb_redis.c
@@ -1044,7 +1044,7 @@ redis_add_nvt (kb_t kb, const nvti_t *nvt, const char *filename)
                    nvti_mandatory_keys (nvt) ?: "",
                    nvti_excluded_keys (nvt) ?: "",
                    nvti_required_udp_ports (nvt) ?: "",
-                   nvti_required_keys (nvt) ?: "",
+                   nvti_required_ports (nvt) ?: "",
                    nvti_dependencies (nvt) ?: "", nvti_tag (nvt) ?: "",
                    nvti_cve (nvt) ?: "", nvti_bid (nvt) ?: "",
                    nvti_xref (nvt) ?: "", nvti_category (nvt),


### PR DESCRIPTION
Fix value inserted in nvticache.

Use nvticache_required_ports() instead of nvticache_required_keys().