### PR TITLE
Backport parts of scanner PR #34.

### DIFF
--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -363,6 +363,7 @@ tree_cell *
 script_mandatory_keys (lex_ctxt * lexic)
 {
   char *keys = get_str_var_by_num (lexic, 0);
+  char **splits = NULL, *re = get_str_var_by_name (lexic, "re");
   int i;
 
   if (keys == NULL)
@@ -375,12 +376,34 @@ script_mandatory_keys (lex_ctxt * lexic)
       return FAKE_CELL;
     }
 
+  if (re)
+    {
+      splits = g_strsplit (re, "=", 0);
+
+      if (!splits[0] || !splits[1] || !*splits[1] || splits[2])
+        {
+          nasl_perror (lexic, "Erroneous re argument");
+          return FAKE_CELL;
+        }
+    }
   for (i = 0; keys != NULL; i++)
     {
       keys = get_str_var_by_num (lexic, i);
-      nvti_add_mandatory_keys (arg_get_value (lexic->script_infos, "NVTI"), keys);
-    }
 
+      if (splits && keys && !strcmp (keys, splits[0]))
+        {
+          nvti_add_mandatory_keys (arg_get_value (lexic->script_infos, "NVTI"),
+                                   re);
+          re = NULL;
+        }
+      else
+        nvti_add_mandatory_keys (arg_get_value (lexic->script_infos, "NVTI"),
+                                 keys);
+    }
+  if (re)
+    nvti_add_mandatory_keys (arg_get_value (lexic->script_infos, "NVTI"), re);
+
+  g_strfreev (splits);
   return FAKE_CELL;
 }
 


### PR DESCRIPTION
Enable specifying a regex-based mandatory key.

When using script_mandatory_keys("foo", re:"bar=someregex"), the
mandatory key "bar" must be present in the KB, and contain a value that
matches the regex. Matching behaviour is case insensitive, like the nasl
'~' operator. eg. Faar is a valid value for fa*r.