### PR TITLE
Update remains to minimum glib verison 2.42.

### DIFF
--- a/gmp/libgvm_gmp.pc.in
+++ b/gmp/libgvm_gmp.pc.in
@@ -6,6 +6,6 @@ includedir=@INCLUDEDIR@
 Name: gvmlibs-gmp
 Description: Greenbone Vulnerability Management Library gmp
 Version: @LIBGVMCONFIG_VERSION@
-Requires.private: glib-2.0 >= 2.32.0
+Requires.private: glib-2.0 >= 2.42.0
 Cflags: -I${includedir} -I${includedir}/gvm
 Libs: -L${libdir} -lgvm_gmp

--- a/osp/libgvm_osp.pc.in
+++ b/osp/libgvm_osp.pc.in
@@ -6,6 +6,6 @@ includedir=@INCLUDEDIR@
 Name: gvmlibs-osp
 Description: Greenbone Vulnerability Management Library osp
 Version: @LIBGVMCONFIG_VERSION@
-Requires.private: glib-2.0 >= 2.32.0
+Requires.private: glib-2.0 >= 2.42.0
 Cflags: -I${includedir} -I${includedir}/gvm
 Libs: -L${libdir} -lgvm_osp

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -139,9 +139,6 @@ gvm_file_copy (const gchar *source_file, const gchar *dest_file)
   GFile *sfile, *dfile;
   GError *error;
 
-#if !GLIB_CHECK_VERSION(2, 35, 0)
-  g_type_init ();
-#endif
   sfile = g_file_new_for_path (source_file);
   dfile = g_file_new_for_path (dest_file);
   error = NULL;

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -177,9 +177,6 @@ gvm_file_move (const gchar *source_file, const gchar *dest_file)
   GFile *sfile, *dfile;
   GError *error;
 
-#if !GLIB_CHECK_VERSION(2, 35, 0)
-  g_type_init ();
-#endif
   sfile = g_file_new_for_path (source_file);
   dfile = g_file_new_for_path (dest_file);
   error = NULL;


### PR DESCRIPTION
 * gmp/libgvm_gmp.pc.in: Update requirement from 2.32 to 2.42.

* osp/libgvm_osp.pc.in: Update requirement from 2.32 to 2.42.

* util/fileutils.c (gvm_file_move, gvm_file_copy ): Drop check for glib
  older 2.36 since we have minimum 2.42. Drop the respective deprecated code.