### PR TITLE
Require glib>=2.30 for GHmac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ message ("-- Install prefix: ${CMAKE_INSTALL_PREFIX}")
 ## TODO Also check for headers where needed.
 
 pkg_check_modules (GNUTLS REQUIRED gnutls>=2.12)
-pkg_check_modules (GLIB REQUIRED glib-2.0>=2.16)
+pkg_check_modules (GLIB REQUIRED glib-2.0>=2.30)
 pkg_check_modules (REDIS hiredis>=0.10.1)
 if (NOT OPENVAS_OMP_ONLY)
   pkg_check_modules (OPENVAS_WMICLIENT libopenvas_wmiclient>=0.0.1)


### PR DESCRIPTION
GHmac and its functions are used in nasl/nasl_crypto.c. They got
introduced in glib with version 2.30 (see
https://developer.gnome.org/glib/stable/glib-Data-HMACs.html for details).
Therefore update the minimum required glib version.