### PR TITLE
Add doc-strings to functions.

### DIFF
--- a/base/logging.c
+++ b/base/logging.c
@@ -339,6 +339,9 @@ gvm_log_silent (const char *log_domain, GLogLevelFlags log_level,
 
 static GMutex *logger_mutex = NULL;
 
+/**
+ * @brief Initialize logger_mutex mutex if it was not done before.
+ */
 static void
 gvm_log_lock_init (void)
 {
@@ -349,12 +352,18 @@ gvm_log_lock_init (void)
     }
 }
 
+/**
+ * @brief Try to lock logger_mutex.
+ */
 static void
 gvm_log_lock (void)
 {
   g_mutex_lock (logger_mutex);
 }
 
+/**
+ * @brief Unlock logger_mutex.
+ */
 static void
 gvm_log_unlock (void)
 {

--- a/base/networking.c
+++ b/base/networking.c
@@ -112,6 +112,11 @@ gvm_source_iface_init (const char *iface)
   return ret;
 }
 
+/**
+ * @brief Check if global_source @ref global_source_iface is set.
+ *
+ * @return 1 if set, 0 otherwise.
+ */
 int
 gvm_source_iface_is_set (void)
 {
@@ -261,6 +266,13 @@ addr6_to_str (const struct in6_addr *addr6, char *str)
     inet_ntop (AF_INET6, addr6, str, INET6_ADDRSTRLEN);
 }
 
+/**
+ * @brief Stringifies an IP address.
+ *
+ * @param[in]   addr6   IP address.
+ *
+ * @return      IP as string. NULL otherwise.
+ */
 char *
 addr6_as_str (const struct in6_addr *addr6)
 {

--- a/base/pwpolicy.c
+++ b/base/pwpolicy.c
@@ -224,9 +224,9 @@ search_file (const char *fname, const char *password)
 
 
 /**
- * @brief parse one line of a pettern file
+ * @brief Parse one line of a pettern file
  *
- * @param line     A nul terminated buffer with the content of the line.
+ * @param line     A null terminated buffer with the content of the line.
  *                 The line terminator has already been stripped. It may
  *                 be modified after return.
  * @param fname    The name of the pattern file for error reporting

--- a/doc/Doxyfile_full.in
+++ b/doc/Doxyfile_full.in
@@ -754,7 +754,9 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_SOURCE_DIR@/base \
-                         @CMAKE_SOURCE_DIR@/util
+                         @CMAKE_SOURCE_DIR@/util \
+			 @CMAKE_SOURCE_DIR@/gmp \
+			 @CMAKE_SOURCE_DIR@/osp
 
 
 # This tag can be used to specify the character encoding of the source files

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -62,7 +62,8 @@ osp_send_command (osp_connection_t *, entity_t *, const char *, ...)
     __attribute__((__format__(__printf__, 3, 4)));
 
 
-/* @brief Open a new connection to an OSP server.
+/**
+ * @brief Open a new connection to an OSP server.
  *
  * @param[in]   host    Host of OSP server.
  * @param[in]   port    Port of OSP server.
@@ -121,7 +122,8 @@ osp_connection_new (const char *host, int port, const char *cacert,
   return connection;
 }
 
-/* @brief Send a command to an OSP server.
+/**
+ * @brief Send a command to an OSP server.
  *
  * @param[in]   connection  Connection to OSP server.
  * @param[in]   command     OSP Command to send.
@@ -165,7 +167,8 @@ out:
   return rc;
 }
 
-/* @brief Close a connection to an OSP server.
+/**
+ * @brief Close a connection to an OSP server.
  *
  * @param[in]   connection  Connection to OSP server to close.
  */
@@ -183,7 +186,8 @@ osp_connection_close (osp_connection_t *connection)
   g_free (connection);
 }
 
-/* @brief Get the scanner version from an OSP server.
+/**
+ * @brief Get the scanner version from an OSP server.
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[out]  s_name      Parsed scanner name.
@@ -271,7 +275,8 @@ err_get_version:
   return 1;
 }
 
-/* @brief Delete a scan from an OSP server.
+/**
+ * @brief Delete a scan from an OSP server.
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[in]   scan_id     ID of scan to delete.
@@ -303,7 +308,8 @@ osp_delete_scan (osp_connection_t *connection, const char *scan_id)
   return ret;
 }
 
-/* @brief Get a scan from an OSP server.
+/**
+ * @brief Get a scan from an OSP server.
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[in]   scan_id     ID of scan to get.
@@ -356,7 +362,8 @@ osp_get_scan (osp_connection_t *connection, const char *scan_id,
   return progress;
 }
 
-/* @brief Stop a scan on an OSP server.
+/**
+ * @brief Stop a scan on an OSP server.
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[in]   scan_id     ID of scan to delete.
@@ -416,7 +423,8 @@ option_concat_as_xml (gpointer key, gpointer value, gpointer pstr)
   *(char **) pstr = tmp;
 }
 
-/* @brief Start an OSP scan against a target.
+/**
+ * @brief Start an OSP scan against a target.
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[in]   target      Target host to scan.
@@ -472,7 +480,8 @@ osp_start_scan (osp_connection_t *connection, const char *target,
     }
 }
 
-/* @brief Get an OSP parameter's type from its string format.
+/**
+ * @brief Get an OSP parameter's type from its string format.
  *
  * @param[in]   str     OSP parameter in string format.
  *
@@ -502,6 +511,13 @@ osp_param_str_to_type (const char *str)
   return 0;
 }
 
+/**
+ * @brief Get an OSP parameter in string format form its type.
+ *
+ * @param[in]   param     OSP parameter.
+ *
+ * @return OSP parameter in string format.
+ */
 const char *
 osp_param_type_str (const osp_param_t *param)
 {
@@ -529,7 +545,8 @@ osp_param_type_str (const osp_param_t *param)
   return NULL;
 }
 
-/* @brief Get an OSP scanner's details.
+/**
+ * @brief Get an OSP scanner's details.
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[out]  desc        Scanner's description.
@@ -588,7 +605,8 @@ osp_get_scanner_details (osp_connection_t *connection, char **desc,
   return 0;
 }
 
-/* @brief Create a new OSP parameter.
+/**
+ * @brief Create a new OSP parameter.
  *
  * @return New OSP parameter.
  */
@@ -598,7 +616,8 @@ osp_param_new (void)
   return g_malloc0 (sizeof (osp_param_t));
 }
 
-/* @brief Get an OSP parameter's id.
+/**
+ * @brief Get an OSP parameter's id.
  *
  * @param[in]   param   OSP parameter.
  *
@@ -612,7 +631,8 @@ osp_param_id (const osp_param_t *param)
   return param->id;
 }
 
-/* @brief Get an OSP parameter's name.
+/**
+ * @brief Get an OSP parameter's name.
  *
  * @param[in]   param   OSP parameter.
  *
@@ -626,7 +646,8 @@ osp_param_name (const osp_param_t *param)
   return param->name;
 }
 
-/* @brief Get an OSP parameter's description.
+/**
+ * @brief Get an OSP parameter's description.
  *
  * @param[in]   param   OSP parameter.
  *
@@ -640,7 +661,8 @@ osp_param_desc (const osp_param_t *param)
   return param->desc;
 }
 
-/* @brief Get an OSP parameter's default value.
+/**
+ * @brief Get an OSP parameter's default value.
  *
  * @param[in]   param   OSP parameter.
  *
@@ -654,7 +676,8 @@ osp_param_default (const osp_param_t *param)
   return param->def;
 }
 
-/* @brief Get an OSP parameter's mandatory value.
+/**
+ * @brief Get an OSP parameter's mandatory value.
  *
  * @param[in]   param   OSP parameter.
  *
@@ -668,7 +691,8 @@ osp_param_mandatory (const osp_param_t *param)
   return param->mandatory;
 }
 
-/* @brief Free an OSP parameter.
+/**
+ * @brief Free an OSP parameter.
  *
  * @param[in] param OSP parameter to destroy.
  */

--- a/util/authutils.c
+++ b/util/authutils.c
@@ -47,7 +47,9 @@ static const gchar *authentication_methods[] = { "file",
                                                  "radius_connect",
                                                  NULL };
 
-/** @brief Flag whether the config file was read. */
+/**
+ * @brief Flag whether the config file was read.
+ */
 static gboolean initialized = FALSE;
 
 /**

--- a/util/nvticache.c
+++ b/util/nvticache.c
@@ -640,6 +640,10 @@ nvticache_count ()
   return kb_item_count (cache_kb, "nvt:*");
 }
 
+/**
+ * @brief Delete NVT from the cache.
+ * @param[in] oid OID to match.
+ */
 void
 nvticache_delete (const char *oid)
 {

--- a/util/serverutils.c
+++ b/util/serverutils.c
@@ -244,6 +244,10 @@ unload_gnutls_file(gnutls_datum_t *data)
 static char *cert_pub_mem = NULL;
 static char *cert_priv_mem = NULL;
 
+/**
+ * @brief  Save cert_pub_mem with public certificate.
+ * @param[in] data The DER or PEM encoded certificate.
+ */
 static void
 set_cert_pub_mem (const char *data)
 {
@@ -252,6 +256,10 @@ set_cert_pub_mem (const char *data)
   cert_pub_mem = g_strdup (data);
 }
 
+/**
+ * @brief Save cert_priv_mem with private certificate.
+ * @param[in] data The DER or PEM encoded certificate.
+ */
 static void
 set_cert_priv_mem (const char *data)
 {
@@ -260,18 +268,39 @@ set_cert_priv_mem (const char *data)
   cert_priv_mem = g_strdup (data);
 }
 
+/**
+ * @brief Get private certificate from @ref cert_priv_mem.
+ * @return The DER or PEM encoded certificate.
+ */
 static const char *
 get_cert_priv_mem ()
 {
   return cert_priv_mem;
 }
 
+/**
+ * @brief Get public certificate from @ref cert_pub_mem.
+ * @return The DER or PEM encoded certificate.
+ */
 static const char *
 get_cert_pub_mem ()
 {
   return cert_pub_mem;
 }
 
+/**
+ * @brief Callback function to be called in order to retrieve the
+          certificate to be used in the handshake.
+ * @param[in] session Pointer to GNUTLS session. Not in used. Can be NULL.
+ * @param[in] req_ca_rdn Contains a list with the CA names that
+ *            the server considers trusted. Not in used. Can be NULL.
+ * @param[in] nreqs Number of CA requested.  Not in used. Can be NULL.
+ * @param[in] sign_algos contains a list with server's acceptable public key
+ *            algorithms. Not in used. Can be NULL.
+ * @param[in] sign_algos_length Algos list length. Not in used. Can be NULL.
+ * @param[out] st Should contain the certificates and private keys
+ * @return 0 on success, non-null otherwise.
+ */
 static int
 client_cert_callback (gnutls_session_t session,
                       const gnutls_datum_t * req_ca_rdn, int nreqs,
@@ -1106,6 +1135,11 @@ gvm_connection_sendf_xml_quiet (gvm_connection_t *connection,
   return rc;
 }
 
+/**
+ * @brief Initialize a server session.
+ * @param[in]  server_credentials  Credentials to be allocated.
+ * @return 0 on success, -1 on error.
+ */
 static int
 server_new_gnutls_init (gnutls_certificate_credentials_t *server_credentials)
 {
@@ -1127,6 +1161,15 @@ server_new_gnutls_init (gnutls_certificate_credentials_t *server_credentials)
   return 0;
 }
 
+/**
+ * @brief Set the server credencials.
+ * @param[in]  end_type Connection end type.
+ * @param[in]  priority TLS priority to be set. If no one is given, NORMAL is
+ *             default.
+ * @param[in]  server_credentials GNUTLS session.
+ * @param[in]  server_credentials Credentials to be set.
+ * @return 0 on success, -1 on error.
+ */
 static int
 server_new_gnutls_set (unsigned int end_type, const char *priority,
                        gnutls_session_t *server_session,


### PR DESCRIPTION
Add missing documentation to undocumented functions corresponding to
gvm_base and gvm_util libraries.
Add gmp and osp as path in doc/Doxyfile_full.in to generate the
corresponding documentation for gvm_osp and gvm_gmp libraries, since
before it was not  generated.