### PR TITLE
Remove old TODO.

### DIFF
--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -80,13 +80,10 @@ gvm_file_check_is_dir (const char *name)
  * @param[in]  pathname  The name of the file to be deleted from the filesystem.
  *
  * @return 0 if the name was successfully deleted, -1 if an error occurred.
- *         Please note that errno is currently not guaranteed to contain the correct
- *         value if -1 is returned.
  */
 int
 gvm_file_remove_recurse (const gchar * pathname)
 {
-  /** @todo Set errno when we return -1 to maintain remove() compatibility. */
   if (gvm_file_check_is_dir (pathname) == 1)
     {
       GError *error = NULL;


### PR DESCRIPTION
Remove old TODO. (Since 2010-04-20)

Since g_remove() is a wrapper for remove(), the behavior of this function
is dependent on how remove() works for the current system.
After some test (no permissions, file not exist, dir not exist), the set
errno corresponds with the case.