### PR TITLE
Resolve TODO

### DIFF
--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -83,7 +83,6 @@ gmp_task_status (entity_t response)
   return NULL;
 }
 
-/** @todo Use this in the other functions. */
 /**
  * @brief Read response and convert status of response to a return value.
  *
@@ -731,6 +730,7 @@ gmp_start_task_report (gnutls_session_t* session, const char* task_id,
                        char** report_id)
 {
   int ret;
+  entity_t entity;
   if (gvm_server_sendf (session,
                         "<start_task task_id=\"%s\"/>",
                         task_id)
@@ -739,7 +739,7 @@ gmp_start_task_report (gnutls_session_t* session, const char* task_id,
 
   /* Read the response. */
 
-  entity_t entity = NULL;
+  entity = NULL;
   ret = gmp_check_response (session, entity);
 
   if (ret == 0)
@@ -938,15 +938,18 @@ gmp_read_create_response (gnutls_session_t* session, gchar **uuid)
 int
 gmp_stop_task (gnutls_session_t* session, const char* id)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session,
                         "<stop_task task_id=\"%s\"/>",
                         id)
       == -1)
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -984,6 +987,7 @@ gmp_resume_task_report (gnutls_session_t* session, const char* task_id,
                         char** report_id)
 {
   int ret;
+  entity_t entity;
   if (gvm_server_sendf (session,
                         "<resume_task task_id=\"%s\"/>",
                         task_id)
@@ -992,7 +996,7 @@ gmp_resume_task_report (gnutls_session_t* session, const char* task_id,
 
   /* Read the response. */
 
-  entity_t entity = NULL;
+  entity = NULL;
   ret = gmp_check_response (session, entity);
 
   if (ret == 0)
@@ -1087,15 +1091,18 @@ int
 gmp_delete_task_ext (gnutls_session_t* session, const char* id,
                      gmp_delete_opts_t opts)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session,
                         "<delete_task task_id=\"%s\" ultimate=\"%d\"/>",
                         id, opts.ultimate)
       == -1)
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -1263,6 +1270,9 @@ gmp_modify_task_file (gnutls_session_t* session, const char* id,
                       const char* name, const void* content,
                       gsize content_len)
 {
+  entity_t entity;
+  int ret;
+
   if (name == NULL)
     return -1;
 
@@ -1300,9 +1310,9 @@ gmp_modify_task_file (gnutls_session_t* session, const char* id,
   if (gvm_server_sendf (session, "</modify_task>"))
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -1317,12 +1327,15 @@ gmp_modify_task_file (gnutls_session_t* session, const char* id,
 int
 gmp_delete_task (gnutls_session_t* session, const char* id)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session, "<delete_task task_id=\"%s\"/>", id) == -1)
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -1483,15 +1496,18 @@ gmp_delete_port_list_ext (gnutls_session_t* session,
                           const char* id,
                           gmp_delete_opts_t opts)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session,
                         "<delete_port_list port_list_id=\"%s\" ultimate=\"%d\"/>",
                         id, opts.ultimate)
       == -1)
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -1506,12 +1522,15 @@ gmp_delete_port_list_ext (gnutls_session_t* session,
 int
 gmp_delete_report (gnutls_session_t *session, const char *id)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session, "<delete_report report_id=\"%s\"/>", id))
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -1662,15 +1681,18 @@ gmp_delete_target_ext (gnutls_session_t* session,
                        const char* id,
                        gmp_delete_opts_t opts)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session,
                         "<delete_target target_id=\"%s\" ultimate=\"%d\"/>",
                         id, opts.ultimate)
       == -1)
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -1688,15 +1710,18 @@ gmp_delete_config_ext (gnutls_session_t* session,
                        const char* id,
                        gmp_delete_opts_t opts)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session,
                         "<delete_config config_id=\"%s\" ultimate=\"%d\"/>",
                         id, opts.ultimate)
       == -1)
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 
@@ -1953,6 +1978,9 @@ gmp_delete_lsc_credential_ext (gnutls_session_t* session,
                                const char* id,
                                gmp_delete_opts_t opts)
 {
+  entity_t entity;
+  int ret;
+
   if (gvm_server_sendf (session,
                         "<delete_credential credential_id=\"%s\""
                         " ultimate=\"%d\"/>",
@@ -1960,9 +1988,9 @@ gmp_delete_lsc_credential_ext (gnutls_session_t* session,
       == -1)
     return -1;
 
-  entity_t entity = NULL;
-  int ret = gmp_check_response (session, entity);
-  free_entity(entity);
+  entity = NULL;
+  ret = gmp_check_response (session, entity);
+  free_entity (entity);
   return ret;
 }
 

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -816,11 +816,10 @@ gmp_start_task_report_c (gvm_connection_t *connection, const char *task_id,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_check_response (gnutls_session_t* session)
+gmp_check_response (gnutls_session_t* session, entity_t entity)
 {
   int ret;
   const char* status;
-  entity_t entity;
 
   /* Read the response. */
 
@@ -842,7 +841,6 @@ gmp_check_response (gnutls_session_t* session)
     }
   if (status[0] == '2')
     {
-      free_entity (entity);
       return 0;
     }
   ret = (int) strtol (status, NULL, 10);
@@ -969,7 +967,10 @@ gmp_stop_task (gnutls_session_t* session, const char* id)
       == -1)
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -1127,7 +1128,10 @@ gmp_delete_task_ext (gnutls_session_t* session, const char* id,
       == -1)
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -1377,7 +1381,10 @@ gmp_modify_task_file (gnutls_session_t* session, const char* id,
   if (gvm_server_sendf (session, "</modify_task>"))
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -1394,7 +1401,10 @@ gmp_delete_task (gnutls_session_t* session, const char* id)
   if (gvm_server_sendf (session, "<delete_task task_id=\"%s\"/>", id) == -1)
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -1584,7 +1594,10 @@ gmp_delete_port_list_ext (gnutls_session_t* session,
       == -1)
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -1601,7 +1614,10 @@ gmp_delete_report (gnutls_session_t *session, const char *id)
   if (gvm_server_sendf (session, "<delete_report report_id=\"%s\"/>", id))
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -1757,7 +1773,10 @@ gmp_delete_target_ext (gnutls_session_t* session,
       == -1)
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -1780,7 +1799,10 @@ gmp_delete_config_ext (gnutls_session_t* session,
       == -1)
     return -1;
 
-  return gmp_check_response (session);
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**
@@ -2043,7 +2065,11 @@ gmp_delete_lsc_credential_ext (gnutls_session_t* session,
       == -1)
     return -1;
 
-  return gmp_check_response (session);
+  
+  entity_t entity = NULL;
+  int ret = gmp_check_response (session, entity);
+  free_entity(entity);
+  return ret;
 }
 
 /**

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -730,6 +730,7 @@ int
 gmp_start_task_report (gnutls_session_t* session, const char* task_id,
                        char** report_id)
 {
+  int ret;
   if (gvm_server_sendf (session,
                         "<start_task task_id=\"%s\"/>",
                         task_id)
@@ -739,23 +740,9 @@ gmp_start_task_report (gnutls_session_t* session, const char* task_id,
   /* Read the response. */
 
   entity_t entity = NULL;
-  if (read_entity (session, &entity)) return -1;
+  ret = gmp_check_response (session, entity);
 
-  /* Check the response. */
-
-  const char* status = entity_attribute (entity, "status");
-  if (status == NULL)
-    {
-      free_entity (entity);
-      return -1;
-    }
-  if (strlen (status) == 0)
-    {
-      free_entity (entity);
-      return -1;
-    }
-  char first = status[0];
-  if (first == '2')
+  if (ret == 0)
     {
       if (report_id)
         {
@@ -769,9 +756,11 @@ gmp_start_task_report (gnutls_session_t* session, const char* task_id,
             }
         }
       free_entity (entity);
-      return 0;
+      return ret;
     }
-  free_entity (entity);
+  else if (ret == -1)
+    return ret;
+
   return 1;
 }
 

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -2087,9 +2087,6 @@ int
 gmp_get_system_reports (gnutls_session_t* session, const char* name, int brief,
                         entity_t *reports)
 {
-  int ret;
-  const char *status_code;
-
   if (name)
     {
       if (gvm_server_sendf (session,
@@ -2105,29 +2102,8 @@ gmp_get_system_reports (gnutls_session_t* session, const char* name, int brief,
            == -1)
     return -1;
 
-  /* Read the response. */
-
-  *reports = NULL;
-  if (read_entity (session, reports)) return -1;
-
-  /* Check the response. */
-
-  status_code = entity_attribute (*reports, "status");
-  if (status_code == NULL)
-    {
-      free_entity (*reports);
-      return -1;
-    }
-  if (strlen (status_code) == 0)
-    {
-      free_entity (*reports);
-      return -1;
-    }
-  if (status_code[0] == '2') return 0;
-  ret = (int) strtol (status_code, NULL, 10);
-  free_entity (*reports);
-  if (errno == ERANGE) return -1;
-  return ret;
+  /* Read and check the response. */
+  return gmp_check_response (session, *reports);
 }
 
 /**
@@ -2145,9 +2121,7 @@ gmp_get_system_reports_ext (gnutls_session_t* session,
                             gmp_get_system_reports_opts_t opts,
                             entity_t *reports)
 {
-  const char* status_code;
   GString *request;
-  int ret;
 
   request = g_string_new ("<get_system_reports");
 
@@ -2177,27 +2151,6 @@ gmp_get_system_reports_ext (gnutls_session_t* session,
     }
   g_string_free (request, 1);
 
-  /* Read the response. */
-
-  *reports = NULL;
-  if (read_entity (session, reports)) return -1;
-
-  /* Check the response. */
-
-  status_code = entity_attribute (*reports, "status");
-  if (status_code == NULL)
-    {
-      free_entity (*reports);
-      return -1;
-    }
-  if (strlen (status_code) == 0)
-    {
-      free_entity (*reports);
-      return -1;
-    }
-  if (status_code[0] == '2') return 0;
-  ret = (int) strtol (status_code, NULL, 10);
-  free_entity (*reports);
-  if (errno == ERANGE) return -1;
-  return ret;
+  /* Read and check the response. */
+  return gmp_check_response (session, *reports);
 }


### PR DESCRIPTION
gmp_check_response() takes a new argument entity_t type to allow the used of this function for another ones which needs to retrieve the entity.

All functions which already call gmp_check_response() has been updated appropriately.

