### PR TITLE
Improvements for CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build_gcc_core:
     docker:
       - image: greenbone/build-env-gvm-libs-master-debian-stretch-gcc-core
     steps:
@@ -8,3 +8,19 @@ jobs:
       - run:
           name: Configure and Compile
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install
+  scan_build:
+    docker:
+      - image: greenbone/build-env-gvm-libs-master-debian-stretch-clang-core
+    steps:
+      - checkout
+      - run:
+          name: Configure and Scan Build
+          command: mkdir build && cd build/ && scan-build cmake -DCMAKE_BUILD_TYPE=Debug .. && scan-build -o ~/scan-build-report make
+      - store_artifacts:
+          path: ~/scan-build-report
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build_gcc_core
+      - scan_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,25 @@ jobs:
           command: mkdir build && cd build/ && scan-build cmake -DCMAKE_BUILD_TYPE=Debug .. && scan-build -o ~/scan-build-report make
       - store_artifacts:
           path: ~/scan-build-report
+  doc_coverage:
+    docker:
+      - image: greenbone/code-metrics-doxy-coverage-debian-stretch
+    steps:
+      - checkout
+      - run:
+          name: Generate documentation (XML)
+          command: mkdir build && cd build/ && cmake -DSKIP_SRC=1 .. && make doc-xml 2> ~/doxygen-stderr.txt
+      - run:
+          name: Establish coverage
+          command: ~/doxy-coverage/doxy-coverage.py ~/project/build/doc/generated/xml/ > ~/documentation-coverage.txt
+      - store_artifacts:
+          path: ~/doxygen-stderr.txt
+      - store_artifacts:
+          path: ~/documentation-coverage.txt
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build_gcc_core
       - scan_build
+      - doc_coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: wiegandm/gvm-libs-core-debian-stretch
+      - image: greenbone/build-env-gvm-libs-master-debian-stretch-gcc-core
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR updates the location of the Docker image used in the CI environment and adds two new build jobs.

1. A job for performing static analysis using `scan-build` (`ccc-analyzer`) and collecting the resulting report as a build artifact
1. A job for determining the coverage of the source code documentation using `doxygen` and `doxy-coverage`

Note that both jobs are currently mainly informational, i.e. issues found by scan-build will not cause the build to fail and decreasing documentation coverage will also be permitted as long as it stays above 80%. This can (and likely will) be changed easily in the future so that scan-build issues and drops in documentation coverage trigger a CI failure to be reported in GitHub.