### PR TITLE
Update location of the Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: wiegandm/openvas-libraries-9.0-core-debian-jessie
+      - image: greenbone/build-env-gvm-libs-openvas-libraries-9.0-debian-jessie-gcc-core
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The name of the Docker image used for the CI step has changed to better
reflect its purpose and to refer to the image stored in the
organizational account instead of an individual user account on Docker
hub.