### PR TITLE
Generate documentation for all subdirectories

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -754,6 +754,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_SOURCE_DIR@/base \
+                         @CMAKE_SOURCE_DIR@/gmp \
+                         @CMAKE_SOURCE_DIR@/osp \
                          @CMAKE_SOURCE_DIR@/util
 
 # This tag can be used to specify the character encoding of the source files

--- a/doc/Doxyfile_full.in
+++ b/doc/Doxyfile_full.in
@@ -754,10 +754,9 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_SOURCE_DIR@/base \
-                         @CMAKE_SOURCE_DIR@/util \
-			 @CMAKE_SOURCE_DIR@/gmp \
-			 @CMAKE_SOURCE_DIR@/osp
-
+                         @CMAKE_SOURCE_DIR@/gmp \
+                         @CMAKE_SOURCE_DIR@/osp \
+                         @CMAKE_SOURCE_DIR@/util
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/Doxyfile_xml.in
+++ b/doc/Doxyfile_xml.in
@@ -754,6 +754,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_SOURCE_DIR@/base \
+                         @CMAKE_SOURCE_DIR@/gmp \
+                         @CMAKE_SOURCE_DIR@/osp \
                          @CMAKE_SOURCE_DIR@/util
 
 # This tag can be used to specify the character encoding of the source files


### PR DESCRIPTION
This commit make the `INPUT` of all `Doxyfile`s consistent. This enables
the generation of documentation for the subdirectories `gmp` and `osp`
which was previously only done for the `full` flavor.