### PR TITLE
Remove fix for negative coverage counts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,15 +44,12 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install coverxygen codecov
+            pip install 'coverxygen>=1.3.1' codecov
       - run:
           name: Establish documentation coverage
           command: |
             . venv/bin/activate
             python -m coverxygen --src-dir /root/project --xml-dir /tmp/workspace/xml --output lcov.info
-      - run:
-          name: Fix negative coverage counts
-          command: sed -i -e 's/,-1$/,0/g' lcov.info
       - run:
           name: Upload coverage to Codecov
           command: |


### PR DESCRIPTION
This commit removes the CI step for fixing the negative coverage counts
emitted by coverxygen as this fixed in versions >= 1.3.1 (see psycofdj/coverxygen#7).