### PR TITLE
Nvticache filenames

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -1143,6 +1143,38 @@ next:
 }
 
 /**
+ * @brief Get all NVT OIDs.
+ * @param[in] kb  KB handle where to fetch the items.
+ * @return Linked list of all OIDs or NULL.
+ */
+static GSList *
+redis_get_oids (kb_t kb)
+{
+  struct kb_redis *kbr;
+  redisReply *rep;
+  GSList *list = NULL;
+  size_t i;
+
+  kbr = redis_kb (kb);
+  rep = redis_cmd (kbr, "KEYS nvt:*");
+  if (!rep)
+    return NULL;
+
+  if (rep->type != REDIS_REPLY_ARRAY)
+    {
+      freeReplyObject (rep);
+      return NULL;
+    }
+
+  /* Fetch OID values from key names nvt:OID. */
+  for (i = 0; i < rep->elements; i++)
+    list = g_slist_prepend (list, g_strdup (rep->element[i]->str + 4));
+  freeReplyObject (rep);
+
+  return list;
+}
+
+/**
  * @brief Count all items stored under a given pattern.
  *
  * @param[in] kb  KB handle where to count the items.
@@ -1574,6 +1606,7 @@ static const struct kb_operations KBRedisOperations = {
   .kb_get_int      = redis_get_int,
   .kb_get_nvt      = redis_get_nvt,
   .kb_get_nvt_all  = redis_get_nvt_all,
+  .kb_get_nvt_oids = redis_get_oids,
   .kb_push_str     = redis_push_str,
   .kb_pop_str      = redis_pop_str,
   .kb_get_all      = redis_get_all,

--- a/util/kb.h
+++ b/util/kb.h
@@ -72,6 +72,8 @@ enum kb_nvt_pos {
     NVT_FAMILY_POS,
     NVT_COPYRIGHT_POS,
     NVT_NAME_POS,
+    NVT_TIMESTAMP_POS,
+    NVT_OID_POS,
 };
 
 /**

--- a/util/kb.h
+++ b/util/kb.h
@@ -129,6 +129,7 @@ struct kb_operations
   int (*kb_get_int) (kb_t, const char *);
   char *(*kb_get_nvt) (kb_t, const char *, enum kb_nvt_pos);
   nvti_t *(*kb_get_nvt_all) (kb_t, const char *);
+  GSList *(*kb_get_nvt_oids) (kb_t);   /**< Get list of OIDs. */
   int (*kb_push_str) (kb_t, const char *, const char *);
   char *(*kb_pop_str) (kb_t, const char *);
   struct kb_item * (*kb_get_all) (kb_t, const char *);
@@ -462,6 +463,22 @@ kb_nvt_get_all (kb_t kb, const char *oid)
 
   return kb->kb_ops->kb_get_nvt_all (kb, oid);
 }
+
+/**
+ * @brief Get list of NVT OIDs.
+ * @param[in] kb        KB handle where NVTs are stored.
+ * @return Linked-list of OIDs, NULL otherwise.
+ */
+static inline GSList *
+kb_nvt_get_oids (kb_t kb)
+{
+  assert (kb);
+  assert (kb->kb_ops);
+  assert (kb->kb_ops->kb_get_nvt_oids);
+
+  return kb->kb_ops->kb_get_nvt_oids (kb);
+}
+
 
 /**
  * @brief Delete all entries under a given name.

--- a/util/nvticache.c
+++ b/util/nvticache.c
@@ -603,22 +603,9 @@ nvticache_get_prefs (const char *oid)
 GSList *
 nvticache_get_oids ()
 {
-  struct kb_item *kbi, *item;
-  GSList *list = NULL;
-
   assert (cache_kb);
 
-  kbi = item = kb_item_get_pattern (cache_kb, "filename:*:oid");
-  if (!kbi)
-    return NULL;
-
-  while (item)
-    {
-      list = g_slist_prepend (list, g_strdup (item->v_str));
-      item = item->next;
-    }
-  kb_item_free (kbi);
-  return list;
+  return kb_nvt_get_oids (cache_kb);
 }
 
 /**


### PR DESCRIPTION
-  Add kb_nvt_get_oids().

-  Store NVT timestamp and OID in a single list key.