### PR TITLE
Backport PR #109

### DIFF
--- a/misc/radius.c
+++ b/misc/radius.c
@@ -27,8 +27,14 @@
 
 #if defined(RADIUS_AUTH_FREERADIUS)
 #include <freeradius-client.h>
+#ifndef RC_CONFIG_FILE
+#define RC_DICTIONARY_FILE "/etc/radiusclient/dictionary"
+#endif
 #elif defined(RADIUS_AUTH_RADCLI)
 #include <radcli/radcli.h>
+#ifndef RC_CONFIG_FILE
+#define RC_DICTIONARY_FILE "/etc/radcli/dictionary"
+#endif
 #endif
 
 #include "../base/openvas_networking.h"
@@ -36,10 +42,6 @@
 
 #ifndef PW_MAX_MSG_SIZE
 #define PW_MAX_MSG_SIZE 4096
-#endif
-
-#ifndef RC_CONFIG_FILE
-#define RC_DICTIONARY_FILE "/etc/radiusclient/dictionary"
 #endif
 
 /**


### PR DESCRIPTION
￼￼
Backport PR #109
Add preprocessor directives to select the radius client dictionary path.