### PR TITLE
[9.0] Correct name for netsnmp lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ if (NOT MINGW)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   message (STATUS "Looking for netsnmp...")
-  find_library (SNMP snmp)
+  find_library (SNMP netsnmp)
   message (STATUS "Looking for netsnmp... ${SNMP}")
   if (SNMP)
     execute_process (COMMAND net-snmp-config --libs


### PR DESCRIPTION
Backport of scanner PR https://github.com/greenbone/openvas-scanner/pull/165 to the openvas-libraries-9.0 branch.