### PR TITLE
Add definition for NVTICACHE_STR.

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -54,6 +54,10 @@ pkg_check_modules (LIBSSH REQUIRED libssh>=0.6.0)
 # for kb we need libhiredis
 pkg_check_modules (REDIS hiredis>=0.10.1)
 
+# Set NVTICACHE name with the version
+set (NVTICACHE_STR "nvticache${PROJECT_VERSION}")
+add_definitions (-DNVTICACHE_STR="${NVTICACHE_STR}")
+
 #for gpgmeutils we need libgpgme
 set (GPGME_MIN_VERSION "1.1.2")
 message (STATUS "Looking for gpgme...")

--- a/util/nvticache.h
+++ b/util/nvticache.h
@@ -38,7 +38,9 @@
 #include "../base/nvti.h"  /* for nvti_t */
 #include "kb.h"            /* for kb_t */
 
+#ifndef NVTICACHE_STR
 #define NVTICACHE_STR "nvticache10"
+#endif
 
 int
 nvticache_init (const char *, const char *);


### PR DESCRIPTION
Use the gvm-libs release version in the name of the nvticache.