### PR TITLE
Check for non-null but empty exclude_hosts pref.

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1377,7 +1377,7 @@ gvm_vhosts_exclude (gvm_host_t *host, const char *excluded_str)
 
   vhost = host->vhosts;
   excluded = g_strsplit (excluded_str, ",", 0);
-  if (!excluded)
+  if (!excluded || !*excluded)
     return;
   while (vhost)
     {


### PR DESCRIPTION
Otherwise gvm_vhosts_exclude() would loop indefinitely.