### PR TITLE
Change CI image used for documentation generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           path: ~/scan-build-report
   gen_xml_doc:
     docker:
-      - image: greenbone/code-metrics-doxy-coverage-debian-stretch
+      - image: greenbone/code-metrics-doxygen-debian-stretch
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This commit changes the CI image used for documentation generation, the
previously used image contained packages now superfluous due to the
changes in 7c1eb87.