### PR TITLE
Fix various typos.

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -332,7 +332,7 @@ is_short_range_network (const char *str)
       return 0;
     }
 
-  /* Separate the addreses. */
+  /* Separate the addresses. */
   *end_str = '\0';
   end_str++;
 
@@ -618,7 +618,7 @@ is_long_range6_network (const char *str)
       return 0;
     }
 
-  /* Separate the addreses. */
+  /* Separate the addresses. */
   *second_str = '\0';
   second_str++;
 
@@ -998,7 +998,7 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
   /* Split comma-separated list into single host-specifications */
   split = g_strsplit (hosts->orig_str, ",", 0);
 
-  /* first element of the splitted list */
+  /* first element of the split list */
   host_element = split;
   while (*host_element)
     {
@@ -1141,7 +1141,7 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
             gvm_hosts_free (hosts);
             return NULL;
         }
-      host_element++; /* move on to next element of splitted list */
+      host_element++; /* move on to next element of split list */
       if (max_hosts > 0 && hosts->count > max_hosts)
         {
           g_strfreev (split);

--- a/base/logging.c
+++ b/base/logging.c
@@ -746,7 +746,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
 /**
  * @brief This function logs debug messages from gnutls.
  *
- * @param level GnuTLS log level (integer from 0 to 99 acoording to GnuTLS
+ * @param level GnuTLS log level (integer from 0 to 99 according to GnuTLS
  * documentation.
  * @param message GnuTLS log message.
  *

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1639,8 +1639,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/doc/Doxyfile_full.in
+++ b/doc/Doxyfile_full.in
@@ -1639,8 +1639,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/doc/Doxyfile_xml.in
+++ b/doc/Doxyfile_xml.in
@@ -1639,8 +1639,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/util/authutils.c
+++ b/util/authutils.c
@@ -117,7 +117,7 @@ gvm_auth_init ()
   /* Init Libgcrypt. */
 
   /* Version check should be the very first call because it makes sure that
-   * important subsystems are intialized.
+   * important subsystems are initialized.
    * We pass NULL to gcry_check_version to disable the internal version mismatch
    * test. */
   if (!gcry_check_version (NULL))
@@ -132,7 +132,7 @@ gvm_auth_init ()
 
   /* ... If required, other initialization goes here.  Note that the process
    * might still be running with increased privileges and that the secure
-   * memory has not been intialized. */
+   * memory has not been initialized. */
 
   /* Allocate a pool of 16k secure memory.  This make the secure memory
    * available and also drops privileges where needed. */
@@ -253,7 +253,7 @@ int
 gvm_authenticate_classic (const gchar *username, const gchar *password,
                           const gchar *hash_arg)
 {
-  int gcrypt_algorithm = GCRY_MD_MD5;   // FIX whatever configer used
+  int gcrypt_algorithm = GCRY_MD_MD5;   // FIX whatever configure used
   int ret;
   gchar *actual, *expect, *seed_pass;
   guchar *hash;

--- a/util/kb.c
+++ b/util/kb.c
@@ -456,7 +456,7 @@ redis_delete (kb_t kb)
 }
 
 /**
- * @brief Retrun the kb index
+ * @brief Return the kb index
  * @param[in] kb KB handle.
  * @return kb_index on success, null on error.
  */
@@ -673,7 +673,7 @@ err_cleanup:
 /**
  * @brief Execute a redis command.
  * @param[in] rtx Redis transaction handler.
- * @param[in] fmt Formated variable argument list with the cmd to be executed.
+ * @param[in] fmt Formatted variable argument list with the cmd to be executed.
  * @return 0 on success, -1 otherwise.
  */
 static int
@@ -845,7 +845,7 @@ redis2kbitem (const char *name, const redisReply *rep)
 /**
  * @brief Execute a redis command and get a redis reply.
  * @param[in] kbr Subclass of struct kb to connect to.
- * @param[in] fmt Formated variable argument list with the cmd to be executed.
+ * @param[in] fmt Formatted variable argument list with the cmd to be executed.
  * @return Redis reply on success, NULL otherwise.
  */
 static redisReply *

--- a/util/kb.h
+++ b/util/kb.h
@@ -571,7 +571,7 @@ static inline int kb_flush (kb_t kb, const char *except)
 }
 
 /**
- * @brief Retrun the kb index
+ * @brief Return the kb index
  * @param[in] kb KB handle.
  * @return kb_index on success, null on error.
  */

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -1260,7 +1260,7 @@ foreach_print_attribute_format (gpointer name, gpointer value, gpointer none)
 }
 
 /**
- * @brief Print an XML entity to stdout, recusively printing its children.
+ * @brief Print an XML entity to stdout, recursively printing its children.
  * @brief Does very basic indentation for pretty printing.
  *
  * This function is used as the (callback) GFunc in g_slist_foreach.


### PR DESCRIPTION
Fix various typos found by [codespell](https://github.com/codespell-project/codespell) 1.14

```
codespell . -S ".git,build" | grep -v "therefor"
```
(For some words the -S parameter doesn't work correctly)