### PR TITLE
Fix format-truncation warning in GCC 8.2.

### DIFF
--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -102,9 +102,13 @@ epoch2isotime (my_isotime_t timebuf, time_t atime)
       struct tm *tp;
 
       tp = gmtime (&atime);
-      snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
+      if (snprintf (timebuf, ISOTIME_SIZE, "%04d%02d%02dT%02d%02d%02d",
                 1900 + tp->tm_year, tp->tm_mon+1, tp->tm_mday,
-                tp->tm_hour, tp->tm_min, tp->tm_sec);
+                tp->tm_hour, tp->tm_min, tp->tm_sec) < 0)
+        {
+          *timebuf = '\0';
+          return;
+        }
     }
 }
 


### PR DESCRIPTION
Warning is erroneous, as the number of printed bytes is limited. Check
snprintf() return value to silence it.

without the
`*timebuf = '\0';`

The compiler optimizes-out the if() check.

Fixes #143