### PR TITLE
[9.0] Enable GnuTLS RC4 and/or COMPAT

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -442,19 +442,19 @@ set_gnutls_protocol (gnutls_session_t session, openvas_encaps_t encaps,
   switch (encaps)
     {
       case OPENVAS_ENCAPS_SSLv3:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-SSL3.0";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-SSL3.0:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_TLSv1:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_TLSv11:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.1";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.1:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_TLSv12:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_SSLv23:        /* Compatibility mode */
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+VERS-SSL3.0";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+VERS-SSL3.0:+ARCFOUR-128:%COMPAT";
         break;
       default:
 #if DEBUG_SSL > 0
@@ -1083,7 +1083,7 @@ open_stream_connection (struct arglist *args, unsigned int port,
                         int transport, int timeout)
 {
   return open_stream_connection_ext (args, port, transport, timeout,
-                                     "NORMAL:+ARCFOUR-128");
+                                     "NORMAL:+ARCFOUR-128:%COMPAT");
 }
 
 /* Same as open_stream_auto_encaps but allows to force auto detection


### PR DESCRIPTION
Backport of https://github.com/greenbone/openvas-scanner/pull/207 and https://github.com/greenbone/openvas-scanner/pull/205 to the openvas-libraries-9.0 branch.

See also https://github.com/greenbone/openvas-scanner/issues/206