### PR TITLE
Use shields.io badge for doc coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # gvm-libs
 
 [![GitHub releases](https://img.shields.io/github/release/greenbone/gvm-libs.svg)](https://github.com/greenbone/gvm-libs/releases)
-[![Code Documentation Coverage](https://codecov.io/gh/greenbone/gvm-libs/branch/master/graphs/badge.svg?flag=documentation)](https://codecov.io/gh/greenbone/gvm-libs)`(Documentation Coverage)`
+[![Code Documentation Coverage](https://img.shields.io/codecov/c/github/greenbone/gvm-libs.svg?label=Doc%20Coverage&logo=codecov)](https://codecov.io/gh/greenbone/gvm-libs)
 [![CircleCI](https://circleci.com/gh/greenbone/gvm-libs/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/gvm-libs/tree/master)
 
 This is the libraries module for the Greenbone Vulnerability Management Solution.


### PR DESCRIPTION
This way we can have a more clear description that this is actually the documentation coverage and not code test coverage.

Remove the text, that clarifies that before, but looks sloppy.