### PR TITLE
New filename placeholders 9.0

### DIFF
--- a/base/openvas_file.c
+++ b/base/openvas_file.c
@@ -340,6 +340,8 @@ openvas_export_file_name (const char* fname_format, const char* username,
             format_state = 1;
           else if (*fname_point == '"')
             g_string_append (file_name_buf, "\\\"");
+          else if (*fname_point <= ' ')
+            g_string_append_c (file_name_buf, '_');
           else
             g_string_append_c (file_name_buf, *fname_point);
         }

--- a/base/openvas_file.c
+++ b/base/openvas_file.c
@@ -354,6 +354,10 @@ openvas_export_file_name (const char* fname_format, const char* username,
               case 'c':
                 g_string_append (file_name_buf, creation_time_str);
                 break;
+              case 'd':
+                g_string_append_printf (file_name_buf, "%02d",
+                                        modification_time.tm_mday);
+                break;
               case 'D':
                 g_string_append (file_name_buf, now_date_str);
                 break;
@@ -371,6 +375,10 @@ openvas_export_file_name (const char* fname_format, const char* username,
                 g_string_append (file_name_buf,
                                  name ? name : (type ? type : "unnamed"));
                 break;
+              case 'o':
+                g_string_append_printf (file_name_buf, "%02d",
+                                        modification_time.tm_mon + 1);
+                break;
               case 'T':
                 g_string_append (file_name_buf, type ? type : "resource");
                 break;
@@ -382,6 +390,10 @@ openvas_export_file_name (const char* fname_format, const char* username,
                 break;
               case 'u':
                 g_string_append (file_name_buf, username ? username : "");
+                break;
+              case 'Y':
+                g_string_append_printf (file_name_buf, "%04d",
+                                        modification_time.tm_year + 1900);
                 break;
               case '%':
                 g_string_append_c (file_name_buf, '%');

--- a/base/openvas_file.c
+++ b/base/openvas_file.c
@@ -416,6 +416,14 @@ openvas_export_file_name (const char* fname_format, const char* username,
       return NULL;
     }
 
+  fname_point = file_name_buf->str;
+  while (*fname_point != '\0')
+    {
+      if (*fname_point <= ' ')
+        *fname_point = '_';
+      fname_point ++;
+    }
+
   g_free (now_date_str);
   g_free (creation_date_str);
   g_free (creation_time_str);


### PR DESCRIPTION
This adds new placeholders in `openvas_export_file_name` for day, month and year of the modification date and makes it replace ASCII whitespace and control characters with underscores.