### PR TITLE
New filename placeholders

### DIFF
--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -400,6 +400,14 @@ gvm_export_file_name (const char *fname_format, const char *username,
       return NULL;
     }
 
+  fname_point = file_name_buf->str;
+  while (*fname_point != '\0')
+    {
+      if (*fname_point <= ' ')
+        *fname_point = '_';
+      fname_point ++;
+    }
+
   g_free (now_date_str);
   g_free (creation_date_str);
   g_free (creation_time_str);

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -340,10 +340,10 @@ gvm_export_file_name (const char *fname_format, const char *username,
             case 'c':
               g_string_append (file_name_buf, creation_time_str);
               break;
-              case 'd':
-                g_string_append_printf (file_name_buf, "%02d",
-                                        modification_time.tm_mday);
-                break;
+            case 'd':
+              g_string_append_printf (file_name_buf, "%02d",
+                                      modification_time.tm_mday);
+              break;
             case 'D':
               g_string_append (file_name_buf, now_date_str);
               break;
@@ -361,10 +361,10 @@ gvm_export_file_name (const char *fname_format, const char *username,
               g_string_append (file_name_buf,
                                name ? name : (type ? type : "unnamed"));
               break;
-              case 'o':
-                g_string_append_printf (file_name_buf, "%02d",
-                                        modification_time.tm_mon + 1);
-                break;
+            case 'o':
+              g_string_append_printf (file_name_buf, "%02d",
+                                      modification_time.tm_mon + 1);
+              break;
             case 'T':
               g_string_append (file_name_buf, type ? type : "resource");
               break;

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -338,6 +338,10 @@ gvm_export_file_name (const char *fname_format, const char *username,
             case 'c':
               g_string_append (file_name_buf, creation_time_str);
               break;
+              case 'd':
+                g_string_append_printf (file_name_buf, "%02d",
+                                        modification_time.tm_mday);
+                break;
             case 'D':
               g_string_append (file_name_buf, now_date_str);
               break;
@@ -355,6 +359,10 @@ gvm_export_file_name (const char *fname_format, const char *username,
               g_string_append (file_name_buf,
                                name ? name : (type ? type : "unnamed"));
               break;
+              case 'o':
+                g_string_append_printf (file_name_buf, "%02d",
+                                        modification_time.tm_mon + 1);
+                break;
             case 'T':
               g_string_append (file_name_buf, type ? type : "resource");
               break;
@@ -366,6 +374,10 @@ gvm_export_file_name (const char *fname_format, const char *username,
               break;
             case 'u':
               g_string_append (file_name_buf, username ? username : "");
+                break;
+              case 'Y':
+                g_string_append_printf (file_name_buf, "%04d",
+                                        modification_time.tm_year + 1900);
               break;
             case '%':
               g_string_append_c (file_name_buf, '%');

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -324,6 +324,8 @@ gvm_export_file_name (const char *fname_format, const char *username,
             format_state = 1;
           else if (*fname_point == '"')
             g_string_append (file_name_buf, "\\\"");
+          else if (*fname_point <= ' ')
+            g_string_append_c (file_name_buf, '_');
           else
             g_string_append_c (file_name_buf, *fname_point);
         }


### PR DESCRIPTION
This adds new placeholders in `gvm_export_file_name` for day, month and year of the modification date and makes it replace ASCII whitespace and control characters with underscores.