### PR TITLE
Check if gcrypt is init'ed in gvm_auth_init

### DIFF
--- a/util/authutils.c
+++ b/util/authutils.c
@@ -112,6 +112,13 @@ gvm_auth_init ()
 
   /* Init Libgcrypt. */
 
+  /* Check if libgcrypt is already initialized */
+  if (gcry_control (GCRYCTL_ANY_INITIALIZATION_P))
+    {
+      initialized = TRUE;
+      return 0;
+    }
+
   /* Version check should be the very first call because it makes sure that
    * important subsystems are initialized.
    * We pass NULL to gcry_check_version to disable the internal version mismatch


### PR DESCRIPTION
This is done to avoid trying to initialize the memory pool twice.