### PR TITLE
Check if gcrypt is init'ed in openvas_auth_init (9.0)

### DIFF
--- a/misc/openvas_auth.c
+++ b/misc/openvas_auth.c
@@ -122,6 +122,13 @@ openvas_auth_init ()
 
   /* Init Libgcrypt. */
 
+  /* Check if libgcrypt is already initialized */
+  if (gcry_control (GCRYCTL_ANY_INITIALIZATION_P))
+    {
+      initialized = TRUE;
+      return 0;
+    }
+
   /* Version check should be the very first call because it makes sure that
    * important subsystems are intialized.
    * We pass NULL to gcry_check_version to disable the internal version mismatch


### PR DESCRIPTION
This is done to avoid trying to initialize the memory pool twice.