### PR TITLE
Backport greenbone/gvm-libs#167

### DIFF
--- a/misc/prefs.c
+++ b/misc/prefs.c
@@ -155,11 +155,13 @@ void
 prefs_config (const char *config)
 {
   settings_iterator_t settings;
+  char buffer[2048];
 
   if (!global_prefs)
     prefs_init ();
 
-  if (!init_settings_iterator_from_file (&settings, config, "Misc"))
+  strncpy (buffer, config, sizeof (buffer));
+  if (!init_settings_iterator_from_file (&settings, buffer, "Misc"))
     {
       while (settings_iterator_next (&settings))
           prefs_set (settings_iterator_name (&settings),
@@ -168,7 +170,7 @@ prefs_config (const char *config)
       cleanup_settings_iterator (&settings);
     }
 
-  prefs_set ("config_file", config);
+  prefs_set ("config_file", buffer);
 }
 
 /**


### PR DESCRIPTION
Fix lost of path to config file.
After sending -SIGHUP to the scanner to force a reload,
the path to the config file was overwritten. Now the configurations
in the config file are preserved.

Backport of https://github.com/greenbone/gvm-libs/pull/167