### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,44 @@
+---
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignEscapedNewlines: Left
+AlignOperands: 'true'
+AlignTrailingComments: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: 'false'
+BinPackArguments: 'true'
+BinPackParameters: 'true'
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: GNU
+BreakBeforeTernaryOperators: 'true'
+BreakStringLiterals: 'true'
+ColumnLimit: '80'
+ContinuationIndentWidth: '2'
+DerivePointerAlignment: 'false'
+IncludeBlocks: Regroup
+IndentCaseLabels: 'false'
+IndentWidth: '2'
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+PointerAlignment: Right
+ReflowComments: 'true'
+SortIncludes: 'true'
+SpaceAfterCStyleCast: 'true'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: Always
+SpaceInEmptyParentheses: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+UseTab: Never
+
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,20 @@ endif (NOT BUILD_STATIC)
 ## Retrieve git revision (at configure time)
 find_package (Git)
 
+## make format
+message (STATUS "Looking for clang-format...")
+find_program (CLANG_FORMAT clang-format)
+
+if (CLANG_FORMAT)
+  message (STATUS "Looking for clang-format... ${CLANG_FORMAT}")
+  add_custom_target(format COMMAND ${CLANG_FORMAT} "-i" "./base/*.c" "./gmp/*.c"
+                    "./osp/*.c" "./util/*.c" "./base/*.h" "./gmp/*.h" "./osp/*.h"
+                    "./util/*.h" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+else (CLANG_FORMAT)
+  message (STATUS "clang-format not found...")
+endif (CLANG_FORMAT)
+
+
 macro (Git_GET_REVISION dir variable)
   execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
                   WORKING_DIRECTORY ${dir}

--- a/base/array.c
+++ b/base/array.c
@@ -41,7 +41,7 @@ make_array ()
  * @param[in]  array  Pointer to array.
  */
 void
-array_reset (array_t ** array)
+array_reset (array_t **array)
 {
   array_free (*array);
   *array = make_array ();
@@ -55,7 +55,7 @@ array_reset (array_t ** array)
  * @param[in]  array  Pointer to array.
  */
 void
-array_free (GPtrArray * array)
+array_free (GPtrArray *array)
 {
   if (array)
     {
@@ -73,7 +73,7 @@ array_free (GPtrArray * array)
  * @param[in]  pointer  Pointer.
  */
 void
-array_add (array_t * array, gpointer pointer)
+array_add (array_t *array, gpointer pointer)
 {
   if (array)
     g_ptr_array_add (array, pointer);
@@ -85,7 +85,7 @@ array_add (array_t * array, gpointer pointer)
  * @param[in]  array    Array.
  */
 void
-array_terminate (array_t * array)
+array_terminate (array_t *array)
 {
   if (array)
     g_ptr_array_add (array, NULL);

--- a/base/array.h
+++ b/base/array.h
@@ -29,14 +29,19 @@
 
 typedef GPtrArray array_t;
 
-GPtrArray *make_array ();
+GPtrArray *
+make_array ();
 
-void array_reset (array_t ** array);
+void
+array_reset (array_t **array);
 
-void array_free (GPtrArray * array);
+void
+array_free (GPtrArray *array);
 
-void array_add (array_t * array, gpointer pointer);
+void
+array_add (array_t *array, gpointer pointer);
 
-void array_terminate (array_t * array);
+void
+array_terminate (array_t *array);
 
 #endif /* not _GVM_ARRAY_H */

--- a/base/credentials.c
+++ b/base/credentials.c
@@ -28,7 +28,6 @@
 
 #include <string.h>
 
-
 /**
  * @brief Free credentials.
  *
@@ -37,7 +36,7 @@
  * @param[in]  credentials  Pointer to the credentials.
  */
 void
-free_credentials (credentials_t * credentials)
+free_credentials (credentials_t *credentials)
 {
   g_free (credentials->username);
   g_free (credentials->password);
@@ -56,7 +55,7 @@ free_credentials (credentials_t * credentials)
  * @param[in]  length       Length of the text.
  */
 void
-append_to_credentials_username (credentials_t * credentials, const char *text,
+append_to_credentials_username (credentials_t *credentials, const char *text,
                                 gsize length)
 {
   gvm_append_text (&credentials->username, text, length);
@@ -70,7 +69,7 @@ append_to_credentials_username (credentials_t * credentials, const char *text,
  * @param[in]  length       Length of the text.
  */
 void
-append_to_credentials_password (credentials_t * credentials, const char *text,
+append_to_credentials_password (credentials_t *credentials, const char *text,
                                 gsize length)
 {
   gvm_append_text (&credentials->password, text, length);

--- a/base/credentials.h
+++ b/base/credentials.h
@@ -50,12 +50,15 @@ typedef struct
   ///< Role of user.
 } credentials_t;
 
-void free_credentials (credentials_t * credentials);
+void
+free_credentials (credentials_t *credentials);
 
-void append_to_credentials_username (credentials_t * credentials,
-                                     const char *text, gsize length);
+void
+append_to_credentials_username (credentials_t *credentials, const char *text,
+                                gsize length);
 
-void append_to_credentials_password (credentials_t * credentials,
-                                     const char *text, gsize length);
+void
+append_to_credentials_password (credentials_t *credentials, const char *text,
+                                gsize length);
 
 #endif /* _GVM_CREDENTIALS_H */

--- a/base/cvss.c
+++ b/base/cvss.c
@@ -62,47 +62,49 @@
 #include <glib.h>
 
 
+// clang-format off
 /**
  * @brief AccessVector (AV) Constants.
  */
-#define AV_NETWORK          1.0    /**< Access Vector Network. */
-#define AV_ADJACENT_NETWORK 0.646  /**< Access Vector Adjacent Network. */
-#define AV_LOCAL            0.395  /**< Access Vector Local. */
+#define AV_NETWORK          1.0   /**< Access Vector Network. */
+#define AV_ADJACENT_NETWORK 0.646 /**< Access Vector Adjacent Network. */
+#define AV_LOCAL            0.395 /**< Access Vector Local. */
 
 /**
  * @brief AccessComplexity (AC) Constants.
  */
-#define AC_LOW    0.71  /**< Access Complexity Low. */
-#define AC_MEDIUM 0.61  /**< Access Complexity Medium. */
-#define AC_HIGH   0.35  /**< Access Complexity High. */
+#define AC_LOW    0.71 /**< Access Complexity Low. */
+#define AC_MEDIUM 0.61 /**< Access Complexity Medium. */
+#define AC_HIGH   0.35 /**< Access Complexity High. */
 
 /**
  * @brief Authentication (Au) Constants.
  */
-#define Au_MULTIPLE_INSTANCES 0.45   /**< Authentication multiple instances. */
-#define Au_SINGLE_INSTANCE    0.56   /**< Authentication single instances. */
-#define Au_NONE               0.704  /**< No Authentication. */
+#define Au_MULTIPLE_INSTANCES 0.45  /**< Authentication multiple instances. */
+#define Au_SINGLE_INSTANCE    0.56  /**< Authentication single instances. */
+#define Au_NONE               0.704 /**< No Authentication. */
 
 /**
  * @brief ConfidentialityImpact (C) Constants.
  */
-#define C_NONE     0.0    /**< No Confidentiality Impact. */
-#define C_PARTIAL  0.275  /**< Partial Confidentiality Impact. */
-#define C_COMPLETE 0.660  /**< Complete Confidentiality Impact. */
+#define C_NONE     0.0   /**< No Confidentiality Impact. */
+#define C_PARTIAL  0.275 /**< Partial Confidentiality Impact. */
+#define C_COMPLETE 0.660 /**< Complete Confidentiality Impact. */
 
 /**
  * @brief IntegrityImpact (I) Constants.
  */
-#define I_NONE     0.0    /**< No Integrity Impact. */
-#define I_PARTIAL  0.275  /**< Partial Integrity Impact. */
-#define I_COMPLETE 0.660  /**< Complete Integrity Impact. */
+#define I_NONE     0.0   /**< No Integrity Impact. */
+#define I_PARTIAL  0.275 /**< Partial Integrity Impact. */
+#define I_COMPLETE 0.660 /**< Complete Integrity Impact. */
 
 /**
  * @brief AvailabilityImpact (A) Constants.
  */
-#define A_NONE     0.0    /**< No Availability Impact. */
-#define A_PARTIAL  0.275  /**< Partial Availability Impact. */
-#define A_COMPLETE 0.660  /**< Complete Availability Impact. */
+#define A_NONE     0.0   /**< No Availability Impact. */
+#define A_PARTIAL  0.275 /**< Partial Availability Impact. */
+#define A_COMPLETE 0.660 /**< Complete Availability Impact. */
+// clang-format on
 
 /**
  * @brief Base metrics.

--- a/base/cvss.c
+++ b/base/cvss.c
@@ -26,9 +26,14 @@
  * vector.
  *
  * The base equation is the foundation of CVSS scoring. The base equation is:
- * BaseScore6 = round_to_1_decimal(((0.6*Impact)+(0.4*Exploitability)–1.5)*f(Impact))
- * Impact = 10.41*(1-(1-ConfImpact)*(1-IntegImpact)*(1-AvailImpact))
- * Exploitability = 20* AccessVector*AccessComplexity*Authentication
+ * BaseScore6
+ *   = round_to_1_decimal(((0.6*Impact)+(0.4*Exploitability)–1.5)*f(Impact))
+ *
+ * Impact
+ *   = 10.41*(1-(1-ConfImpact)*(1-IntegImpact)*(1-AvailImpact))
+ *
+ * Exploitability
+ *   = 20* AccessVector*AccessComplexity*Authentication
  *
  * f(impact)= 0 if Impact=0, 1.176 otherwise
  * AccessVector     = case AccessVector of
@@ -57,10 +62,8 @@
  *                       complete:          0.660
  */
 
-#include <string.h>
-
 #include <glib.h>
-
+#include <string.h>
 
 // clang-format off
 /**
@@ -111,12 +114,12 @@
  */
 enum base_metrics
 {
-  A,   /**< Availability Impact. */
-  I,   /**< Integrity Impact. */
-  C,   /**< Confidentiality Impact. */
-  Au,  /**< Authentication. */
-  AC,  /**< Access Complexity. */
-  AV   /**< Access Vector. */
+  A,  /**< Availability Impact. */
+  I,  /**< Integrity Impact. */
+  C,  /**< Confidentiality Impact. */
+  Au, /**< Authentication. */
+  AC, /**< Access Complexity. */
+  AV  /**< Access Vector. */
 };
 
 /**
@@ -141,38 +144,43 @@ struct cvss
   double authentication;    /**< Authentication. */
 };
 
-
 static const struct impact_item impact_map[][3] = {
-  [A] = {
-         {"N", A_NONE},
-         {"P", A_PARTIAL},
-         {"C", A_COMPLETE},
-         },
-  [I] = {
-         {"N", I_NONE},
-         {"P", I_PARTIAL},
-         {"C", I_COMPLETE},
-         },
-  [C] = {
-         {"N", C_NONE},
-         {"P", C_PARTIAL},
-         {"C", C_COMPLETE},
-         },
-  [Au] = {
-          {"N", Au_NONE},
-          {"M", Au_MULTIPLE_INSTANCES},
-          {"S", Au_SINGLE_INSTANCE},
-          },
-  [AV] = {
-          {"N", AV_NETWORK},
-          {"A", AV_ADJACENT_NETWORK},
-          {"L", AV_LOCAL},
-          },
-  [AC] = {
-          {"L", AC_LOW},
-          {"M", AC_MEDIUM},
-          {"H", AC_HIGH},
-          },
+  [A] =
+    {
+      {"N", A_NONE},
+      {"P", A_PARTIAL},
+      {"C", A_COMPLETE},
+    },
+  [I] =
+    {
+      {"N", I_NONE},
+      {"P", I_PARTIAL},
+      {"C", I_COMPLETE},
+    },
+  [C] =
+    {
+      {"N", C_NONE},
+      {"P", C_PARTIAL},
+      {"C", C_COMPLETE},
+    },
+  [Au] =
+    {
+      {"N", Au_NONE},
+      {"M", Au_MULTIPLE_INSTANCES},
+      {"S", Au_SINGLE_INSTANCE},
+    },
+  [AV] =
+    {
+      {"N", AV_NETWORK},
+      {"A", AV_ADJACENT_NETWORK},
+      {"L", AV_LOCAL},
+    },
+  [AC] =
+    {
+      {"L", AC_LOW},
+      {"M", AC_MEDIUM},
+      {"H", AC_HIGH},
+    },
 };
 
 /**
@@ -186,7 +194,7 @@ static const struct impact_item impact_map[][3] = {
 static int
 toenum (const char *str, enum base_metrics *res)
 {
-  int rc = 0;                   /* let's be optimistic */
+  int rc = 0; /* let's be optimistic */
 
   if (g_strcmp0 (str, "A") == 0)
     *res = A;
@@ -219,10 +227,10 @@ toenum (const char *str, enum base_metrics *res)
 static double
 get_impact_subscore (const struct cvss *cvss)
 {
-  return (10.41 * (1 -
-                   (1 - cvss->conf_impact) *
-                   (1 - cvss->integ_impact) *
-                   (1 - cvss->avail_impact)));
+  return (10.41
+          * (1
+             - (1 - cvss->conf_impact) * (1 - cvss->integ_impact)
+                 * (1 - cvss->avail_impact)));
 }
 
 /**
@@ -236,8 +244,8 @@ get_impact_subscore (const struct cvss *cvss)
 static double
 get_exploitability_subscore (const struct cvss *cvss)
 {
-  return (20 * cvss->access_vector * cvss->access_complexity *
-          cvss->authentication);
+  return (20 * cvss->access_vector * cvss->access_complexity
+          * cvss->authentication);
 }
 
 /**

--- a/base/cvss.h
+++ b/base/cvss.h
@@ -29,6 +29,7 @@
 
 #include <glib.h>
 
-double get_cvss_score_from_base_metrics (const char *);
+double
+get_cvss_score_from_base_metrics (const char *);
 
 #endif /* not _GVM_CVSS_H */

--- a/base/drop_privileges.c
+++ b/base/drop_privileges.c
@@ -40,12 +40,11 @@
  * @return \p errorcode
  */
 static gint
-drop_privileges_error (GError ** error, gint errorcode, const gchar * message)
+drop_privileges_error (GError **error, gint errorcode, const gchar *message)
 {
   g_set_error (error, GVM_DROP_PRIVILEGES, errorcode, "%s", message);
   return errorcode;
 }
-
 
 /**
  * @brief Drop privileges.
@@ -64,10 +63,9 @@ drop_privileges_error (GError ** error, gint errorcode, const gchar * message)
  *         otherwise and returns the error code.
  */
 int
-drop_privileges (gchar * username, GError ** error)
+drop_privileges (gchar *username, GError **error)
 {
-  g_return_val_if_fail (*error == NULL,
-                        GVM_DROP_PRIVILEGES_ERROR_ALREADY_SET);
+  g_return_val_if_fail (*error == NULL, GVM_DROP_PRIVILEGES_ERROR_ALREADY_SET);
 
   if (username == NULL)
     username = "nobody";
@@ -79,20 +77,17 @@ drop_privileges (gchar * username, GError ** error)
       if ((user_pw = getpwnam (username)))
         {
           if (initgroups (username, user_pw->pw_gid) != 0)
-            return drop_privileges_error
-                    (error,
-                     GVM_DROP_PRIVILEGES_FAIL_SUPPLEMENTARY,
-                     "Failed to drop supplementary groups privileges!\n");
+            return drop_privileges_error (
+              error, GVM_DROP_PRIVILEGES_FAIL_SUPPLEMENTARY,
+              "Failed to drop supplementary groups privileges!\n");
           if (setgid (user_pw->pw_gid) != 0)
-            return drop_privileges_error
-                    (error,
-                     GVM_DROP_PRIVILEGES_FAIL_DROP_GID,
-                     "Failed to drop group privileges!\n");
+            return drop_privileges_error (error,
+                                          GVM_DROP_PRIVILEGES_FAIL_DROP_GID,
+                                          "Failed to drop group privileges!\n");
           if (setuid (user_pw->pw_uid) != 0)
-            return drop_privileges_error
-                    (error,
-                     GVM_DROP_PRIVILEGES_FAIL_DROP_UID,
-                     "Failed to drop user privileges!\n");
+            return drop_privileges_error (error,
+                                          GVM_DROP_PRIVILEGES_FAIL_DROP_UID,
+                                          "Failed to drop user privileges!\n");
         }
       else
         {
@@ -105,8 +100,7 @@ drop_privileges (gchar * username, GError ** error)
     }
   else
     {
-      return drop_privileges_error (error,
-                                    GVM_DROP_PRIVILEGES_FAIL_NOT_ROOT,
+      return drop_privileges_error (error, GVM_DROP_PRIVILEGES_FAIL_NOT_ROOT,
                                     "Only root can drop its privileges.");
     }
 }

--- a/base/drop_privileges.h
+++ b/base/drop_privileges.h
@@ -30,7 +30,8 @@
 /**
  * @brief The GQuark for privilege dropping errors.
  */
-#define GVM_DROP_PRIVILEGES g_quark_from_static_string ("gvm-drop-privileges-error-quark")
+#define GVM_DROP_PRIVILEGES \
+  g_quark_from_static_string ("gvm-drop-privileges-error-quark")
 
 /**
  * @brief Definition of the return code ERROR_ALREADY_SET.
@@ -67,6 +68,7 @@
  */
 #define GVM_DROP_PRIVILEGES_FAIL_SUPPLEMENTARY 5
 
-int drop_privileges (gchar * username, GError ** error);
+int
+drop_privileges (gchar *username, GError **error);
 
 #endif

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -33,17 +33,18 @@
 
 /* Static values */
 
-enum host_type {
-  HOST_TYPE_NAME = 0,       /* Hostname eg. foo */
-  HOST_TYPE_IPV4,           /* eg. 192.168.1.1 */
-  HOST_TYPE_CIDR_BLOCK,     /* eg. 192.168.15.0/24 */
-  HOST_TYPE_RANGE_SHORT,    /* eg. 192.168.15.10-20 */
-  HOST_TYPE_RANGE_LONG,     /* eg. 192.168.15.10-192.168.18.3 */
-  HOST_TYPE_IPV6,           /* eg. ::1 */
-  HOST_TYPE_CIDR6_BLOCK,    /* eg. ::ffee/120 */
-  HOST_TYPE_RANGE6_LONG,    /* eg. ::1:200:7-::1:205:500 */
-  HOST_TYPE_RANGE6_SHORT,   /* eg. ::1-fe10 */
-  HOST_TYPE_MAX             /* Boundary checking. */
+enum host_type
+{
+  HOST_TYPE_NAME = 0,     /* Hostname eg. foo */
+  HOST_TYPE_IPV4,         /* eg. 192.168.1.1 */
+  HOST_TYPE_CIDR_BLOCK,   /* eg. 192.168.15.0/24 */
+  HOST_TYPE_RANGE_SHORT,  /* eg. 192.168.15.10-20 */
+  HOST_TYPE_RANGE_LONG,   /* eg. 192.168.15.10-192.168.18.3 */
+  HOST_TYPE_IPV6,         /* eg. ::1 */
+  HOST_TYPE_CIDR6_BLOCK,  /* eg. ::ffee/120 */
+  HOST_TYPE_RANGE6_LONG,  /* eg. ::1:200:7-::1:205:500 */
+  HOST_TYPE_RANGE6_SHORT, /* eg. ::1-fe10 */
+  HOST_TYPE_MAX           /* Boundary checking. */
 };
 
 /* Typedefs */
@@ -61,13 +62,14 @@ typedef struct gvm_hosts gvm_hosts_t;
  */
 struct gvm_host
 {
-  union {
-    gchar *name;            /**< Hostname. */
-    struct in_addr addr;    /**< IPv4 address */
-    struct in6_addr addr6;  /**< IPv6 address */
+  union
+  {
+    gchar *name;           /**< Hostname. */
+    struct in_addr addr;   /**< IPv4 address */
+    struct in6_addr addr6; /**< IPv6 address */
   };
-  enum host_type type;  /**< HOST_TYPE_NAME, HOST_TYPE_IPV4 or HOST_TYPE_IPV6. */
-  GSList *vhosts;       /**< List of hostnames/vhosts attached to this host. */
+  enum host_type type; /**< HOST_TYPE_NAME, HOST_TYPE_IPV4 or HOST_TYPE_IPV6. */
+  GSList *vhosts;      /**< List of hostnames/vhosts attached to this host. */
 };
 
 /**
@@ -75,8 +77,8 @@ struct gvm_host
  */
 struct gvm_vhost
 {
-  char *value;      /**< Hostname string. */
-  char *source;     /**< Source of the value eg. DNS-Resolution. */
+  char *value;  /**< Hostname string. */
+  char *source; /**< Source of the value eg. DNS-Resolution. */
 };
 
 /**
@@ -87,16 +89,16 @@ struct gvm_vhost
  */
 struct gvm_hosts
 {
-  gchar *orig_str;          /**< Original hosts definition string. */
-  GList *hosts;             /**< Hosts objects list. */
-  GList *current;           /**< Current host object in iteration. */
-  unsigned int count;       /**< Number of single host objects in hosts list. */
-  unsigned int removed;     /**< Number of duplicate/excluded values. */
+  gchar *orig_str;      /**< Original hosts definition string. */
+  GList *hosts;         /**< Hosts objects list. */
+  GList *current;       /**< Current host object in iteration. */
+  unsigned int count;   /**< Number of single host objects in hosts list. */
+  unsigned int removed; /**< Number of duplicate/excluded values. */
 };
 
 /* Function prototypes. */
 
- /* gvm_hosts_t related */
+/* gvm_hosts_t related */
 gvm_hosts_t *
 gvm_hosts_new (const gchar *);
 
@@ -142,7 +144,7 @@ gvm_hosts_count (const gvm_hosts_t *);
 unsigned int
 gvm_hosts_removed (const gvm_hosts_t *);
 
- /* gvm_host_t related */
+/* gvm_host_t related */
 
 int
 gvm_host_in_hosts (const gvm_host_t *, const struct in6_addr *,

--- a/base/logging.c
+++ b/base/logging.c
@@ -47,17 +47,17 @@
  */
 typedef struct
 {
-  gchar *log_domain;            ///< Affected logdomain e.g libnasl.
-  gchar *prepend_string;        ///< Prepend this string before every message.
-  gchar *prepend_time_format;   ///< If prependstring has %t, format for strftime.
-  gchar *log_file;              ///< Where to log to.
-  GLogLevelFlags *default_level;        ///< What severity level to use as default.
-  GIOChannel *log_channel;      ///< Gio Channel - FD holder for logfile.
-  gchar *syslog_facility;       ///< Syslog facility to use for syslog logging.
-  gchar *syslog_ident;          ///< Syslog ident to use for syslog logging.
-  gchar *prepend_separator;     ///< If prependstring has %s, used this symbol as separator.
+  gchar *log_domain;          ///< Affected logdomain e.g libnasl.
+  gchar *prepend_string;      ///< Prepend this string before every message.
+  gchar *prepend_time_format; ///< If prependstring has %t, format for strftime.
+  gchar *log_file;            ///< Where to log to.
+  GLogLevelFlags *default_level; ///< What severity level to use as default.
+  GIOChannel *log_channel;       ///< Gio Channel - FD holder for logfile.
+  gchar *syslog_facility;        ///< Syslog facility to use for syslog logging.
+  gchar *syslog_ident;           ///< Syslog ident to use for syslog logging.
+  gchar *prepend_separator; ///< If prependstring has %s, used this symbol as
+                            ///< separator.
 } gvm_logging_t;
-
 
 /**
  * @brief Returns time as specified in time_fmt strftime format.
@@ -71,7 +71,7 @@ typedef struct
  *         This value must be freed using glib's g_free.
  */
 gchar *
-get_time (gchar * time_fmt)
+get_time (gchar *time_fmt)
 {
   time_t now;
   struct tm *ts;
@@ -95,7 +95,7 @@ get_time (gchar * time_fmt)
  * @return Log level integer if level matches a level name, else 0.
  */
 static gint
-level_int_from_string (const gchar * level)
+level_int_from_string (const gchar *level)
 {
   if (level && strlen (level) > 0)
     {
@@ -122,10 +122,11 @@ level_int_from_string (const gchar * level)
  *
  * @param facility Facility name.
  *
- * @return Facility integer if facility matches a facility name, else LOG_LOCAL0.
+ * @return Facility integer if facility matches a facility name, else
+ * LOG_LOCAL0.
  */
 static gint
-facility_int_from_string (const gchar * facility)
+facility_int_from_string (const gchar *facility)
 {
   if (facility && strlen (facility) > 0)
     {
@@ -151,7 +152,7 @@ facility_int_from_string (const gchar * facility)
  *         is returned.
  */
 GSList *
-load_log_configuration (gchar * config_file)
+load_log_configuration (gchar *config_file)
 {
   GKeyFile *key_file;
   GKeyFileFlags flags;
@@ -202,7 +203,6 @@ load_log_configuration (gchar * config_file)
       log_domain_entry->syslog_ident = NULL;
       log_domain_entry->prepend_separator = NULL;
 
-
       /* Look for the prepend string. */
       if (g_key_file_has_key (key_file, *group, "prepend", &error))
         {
@@ -220,9 +220,8 @@ load_log_configuration (gchar * config_file)
       /* Look for the prepend time format string. */
       if (g_key_file_has_key (key_file, *group, "prepend_time_format", &error))
         {
-          log_domain_entry->prepend_time_format =
-            g_key_file_get_value (key_file, *group, "prepend_time_format",
-                                  &error);
+          log_domain_entry->prepend_time_format = g_key_file_get_value (
+            key_file, *group, "prepend_time_format", &error);
         }
 
       /* Look for the log file string. */
@@ -260,7 +259,7 @@ load_log_configuration (gchar * config_file)
             g_key_file_get_value (key_file, *group, "syslog_ident", &error);
         }
       else
-        log_domain_entry->syslog_ident =  g_strdup (*group);
+        log_domain_entry->syslog_ident = g_strdup (*group);
 
       /* Attach the struct to the list. */
       log_domain_list = g_slist_prepend (log_domain_list, log_domain_entry);
@@ -281,7 +280,7 @@ load_log_configuration (gchar * config_file)
  * @param log_domain_list Head of the link list.
  */
 void
-free_log_configuration (GSList * log_domain_list)
+free_log_configuration (GSList *log_domain_list)
 {
   GSList *log_domain_list_tmp;
 
@@ -316,7 +315,6 @@ free_log_configuration (GSList * log_domain_list)
 
       /* Go to the next item. */
       log_domain_list_tmp = g_slist_next (log_domain_list_tmp);
-
     }
   /* Free the link list. */
   g_slist_free (log_domain_list);
@@ -332,7 +330,7 @@ free_log_configuration (GSList * log_domain_list)
  */
 void
 gvm_log_silent (const char *log_domain, GLogLevelFlags log_level,
-                    const char *message, gpointer gvm_log_config_list)
+                const char *message, gpointer gvm_log_config_list)
 {
   (void) log_domain;
   (void) log_level;
@@ -423,7 +421,6 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
    */
   if (gvm_log_config_list != NULL && log_domain != NULL)
     {
-
       /* Go to the head of the list. */
       log_domain_list_tmp = (GSList *) gvm_log_config_list;
 
@@ -467,7 +464,6 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
    */
   if (gvm_log_config_list != NULL && log_domain != NULL)
     {
-
       /* Go to the head of the list. */
       log_domain_list_tmp = (GSList *) gvm_log_config_list;
 
@@ -508,10 +504,8 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
   if (default_level < log_level)
     return;
 
-
   /* Prepend buf is a newly allocated empty string. Makes life easier. */
   prepend_buf = g_strdup ("");
-
 
   /* Make the tmp pointer (for iteration) point to the format string. */
   tmp = prepend_format;
@@ -523,9 +517,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
         {
           /* Use g_strdup, a new string returned. Store it in a tmp var until
            * we free the old one. */
-          prepend_tmp =
-            g_strdup_printf ("%s%d", prepend_buf,
-                             (int) getpid ());
+          prepend_tmp = g_strdup_printf ("%s%d", prepend_buf, (int) getpid ());
           /* Free the old string. */
           g_free (prepend_buf);
           /* Point the buf ptr to the new string. */
@@ -542,9 +534,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
           /* Use g_strdup. New string returned. Store it in a tmp var until
            * we free the old one.
            */
-          prepend_tmp =
-            g_strdup_printf ("%s%s", prepend_buf,
-                             prepend_tmp1);
+          prepend_tmp = g_strdup_printf ("%s%s", prepend_buf, prepend_tmp1);
           /* Free the time tmp var. */
           g_free (prepend_tmp1);
           /* Free the old string. */
@@ -559,9 +549,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
           /* Use g_strdup. New string returned. Store it in a tmp var until
            * we free the old one.
            */
-          prepend_tmp =
-            g_strdup_printf ("%s%s", prepend_buf,
-                             log_separator);
+          prepend_tmp = g_strdup_printf ("%s%s", prepend_buf, log_separator);
           /* Free the old string. */
           g_free (prepend_buf);
           /* Point the buf ptr to the new string. */
@@ -623,12 +611,12 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
    * LF and there is not only the LF, remove the LF to avoid empty
    * lines in the log.
    */
-  messagelen = message? strlen (message) : 0;
-  if (messagelen > 1 && message[messagelen-1] == '\n')
+  messagelen = message ? strlen (message) : 0;
+  if (messagelen > 1 && message[messagelen - 1] == '\n')
     messagelen--;
-  tmpstr = g_strdup_printf ("%s%s%s%s %.*s\n",
-                            log_domain ? log_domain : "", log_separator,
-                            prepend, log_separator, messagelen, message);
+  tmpstr = g_strdup_printf ("%s%s%s%s %.*s\n", log_domain ? log_domain : "",
+                            log_separator, prepend, log_separator, messagelen,
+                            message);
   g_free (prepend);
 
   gvm_log_lock ();
@@ -701,7 +689,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
               g_error_free (error);
 
               /* Ensure directory exists. */
-              if (g_mkdir_with_parents (dir, 0755))     /* "rwxr-xr-x" */
+              if (g_mkdir_with_parents (dir, 0755)) /* "rwxr-xr-x" */
                 {
                   g_warning ("Failed to create log file directory %s: %s", dir,
                              strerror (errno));
@@ -729,13 +717,11 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
       g_io_channel_write_chars (channel, (const gchar *) tmpstr, -1, NULL,
                                 &error);
       g_io_channel_flush (channel, NULL);
-
     }
   gvm_log_unlock ();
   g_free (tmpstr);
   g_free (prepend_buf);
 }
-
 
 /**
  * @brief This function logs debug messages from gnutls.
@@ -754,7 +740,6 @@ log_func_for_gnutls (int level, const char *message)
   g_log ("x  gnutls", G_LOG_LEVEL_INFO, "tls(%d): %s", level, message);
 }
 
-
 /**
  * @brief Sets up routing of logdomains to log handlers.
  *
@@ -763,7 +748,7 @@ log_func_for_gnutls (int level, const char *message)
  * @param gvm_log_config_list A pointer to the configuration linked list.
  */
 void
-setup_log_handlers (GSList * gvm_log_config_list)
+setup_log_handlers (GSList *gvm_log_config_list)
 {
   GSList *log_domain_list_tmp;
   if (gvm_log_config_list != NULL)
@@ -786,16 +771,13 @@ setup_log_handlers (GSList * gvm_log_config_list)
 
           if (g_ascii_strcasecmp (log_domain_entry->log_domain, "*"))
             {
-              g_log_set_handler (log_domain_entry->log_domain,
-                                 (GLogLevelFlags) (G_LOG_LEVEL_DEBUG |
-                                                   G_LOG_LEVEL_INFO |
-                                                   G_LOG_LEVEL_MESSAGE |
-                                                   G_LOG_LEVEL_WARNING |
-                                                   G_LOG_LEVEL_CRITICAL |
-                                                   G_LOG_LEVEL_ERROR |
-                                                   G_LOG_FLAG_FATAL |
-                                                   G_LOG_FLAG_RECURSION),
-                                 (GLogFunc) logfunc, gvm_log_config_list);
+              g_log_set_handler (
+                log_domain_entry->log_domain,
+                (GLogLevelFlags) (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO
+                                  | G_LOG_LEVEL_MESSAGE | G_LOG_LEVEL_WARNING
+                                  | G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_ERROR
+                                  | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION),
+                (GLogFunc) logfunc, gvm_log_config_list);
             }
           else
             {
@@ -807,11 +789,11 @@ setup_log_handlers (GSList * gvm_log_config_list)
           log_domain_list_tmp = g_slist_next (log_domain_list_tmp);
         }
     }
-  g_log_set_handler ("",
-                     (GLogLevelFlags) (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO |
-                                       G_LOG_LEVEL_MESSAGE | G_LOG_LEVEL_WARNING
-                                       | G_LOG_LEVEL_CRITICAL |
-                                       G_LOG_LEVEL_ERROR | G_LOG_FLAG_FATAL |
-                                       G_LOG_FLAG_RECURSION),
-                     (GLogFunc) gvm_log_func, gvm_log_config_list);
+  g_log_set_handler (
+    "",
+    (GLogLevelFlags) (G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO | G_LOG_LEVEL_MESSAGE
+                      | G_LOG_LEVEL_WARNING | G_LOG_LEVEL_CRITICAL
+                      | G_LOG_LEVEL_ERROR | G_LOG_FLAG_FATAL
+                      | G_LOG_FLAG_RECURSION),
+    (GLogFunc) gvm_log_func, gvm_log_config_list);
 }

--- a/base/logging.h
+++ b/base/logging.h
@@ -27,17 +27,24 @@
 
 #include <glib.h> /* for GSList, gchar, GLogLevelFlags, gpointer */
 
-GSList *load_log_configuration (gchar *);
+GSList *
+load_log_configuration (gchar *);
 
-void free_log_configuration (GSList *);
+void
+free_log_configuration (GSList *);
 
-gchar *get_time (gchar *);
+gchar *
+get_time (gchar *);
 
-void gvm_log_silent (const char *, GLogLevelFlags, const char *, gpointer);
-void gvm_log_func (const char *, GLogLevelFlags, const char *, gpointer);
+void
+gvm_log_silent (const char *, GLogLevelFlags, const char *, gpointer);
+void
+gvm_log_func (const char *, GLogLevelFlags, const char *, gpointer);
 
-void log_func_for_gnutls (int, const char *);
+void
+log_func_for_gnutls (int, const char *);
 
-void setup_log_handlers (GSList *);
+void
+setup_log_handlers (GSList *);
 
 #endif /* not _GVM_LOGGING_H */

--- a/base/networking.c
+++ b/base/networking.c
@@ -42,18 +42,18 @@
 #define s6_addr32 __u6_addr.__u6_addr32
 #endif
 
- /* Global variables */
+/* Global variables */
 
 /* Source interface name eg. eth1. */
-char global_source_iface[IFNAMSIZ] = { '\0' };
+char global_source_iface[IFNAMSIZ] = {'\0'};
 
 /* Source IPv4 address. */
-struct in_addr global_source_addr = { .s_addr = 0 };
+struct in_addr global_source_addr = {.s_addr = 0};
 
 /* Source IPv6 address. */
-struct in6_addr global_source_addr6 = { .s6_addr32 = { 0, 0, 0, 0 } };
+struct in6_addr global_source_addr6 = {.s6_addr32 = {0, 0, 0, 0}};
 
- /* Source Interface/Address related functions. */
+/* Source Interface/Address related functions. */
 
 /**
  * @brief Initializes the source network interface name and related information.
@@ -85,8 +85,8 @@ gvm_source_iface_init (const char *iface)
         {
           if (ifa->ifa_addr->sa_family == AF_INET)
             {
-              struct in_addr *addr = &((struct sockaddr_in *)
-                                       ifa->ifa_addr)->sin_addr;
+              struct in_addr *addr =
+                &((struct sockaddr_in *) ifa->ifa_addr)->sin_addr;
 
               memcpy (&global_source_addr, addr, sizeof (global_source_addr));
               ret = 0;
@@ -229,7 +229,7 @@ gvm_source_addr6_str (void)
   return str;
 }
 
- /* Miscellaneous functions. */
+/* Miscellaneous functions. */
 
 /**
  * @brief Maps an IPv4 address as an IPv6 address.
@@ -302,14 +302,14 @@ sockaddr_as_str (const struct sockaddr_storage *addr, char *str)
   if (addr->ss_family == AF_INET)
     {
       struct sockaddr_in *saddr = (struct sockaddr_in *) addr;
-      inet_ntop (AF_INET,  &saddr->sin_addr, str, INET6_ADDRSTRLEN);
+      inet_ntop (AF_INET, &saddr->sin_addr, str, INET6_ADDRSTRLEN);
     }
   else if (addr->ss_family == AF_INET6)
     {
       struct sockaddr_in6 *s6addr = (struct sockaddr_in6 *) addr;
       if (IN6_IS_ADDR_V4MAPPED (&s6addr->sin6_addr))
-        inet_ntop (AF_INET, &s6addr->sin6_addr.s6_addr[12],
-                   str, INET6_ADDRSTRLEN);
+        inet_ntop (AF_INET, &s6addr->sin6_addr.s6_addr[12], str,
+                   INET6_ADDRSTRLEN);
       else
         inet_ntop (AF_INET6, &s6addr->sin6_addr, str, INET6_ADDRSTRLEN);
     }
@@ -323,8 +323,7 @@ sockaddr_as_str (const struct sockaddr_storage *addr, char *str)
     }
   else
     {
-      g_snprintf (str, INET6_ADDRSTRLEN,
-                  "type_%d_socket", addr->ss_family);
+      g_snprintf (str, INET6_ADDRSTRLEN, "type_%d_socket", addr->ss_family);
     }
 }
 
@@ -457,14 +456,15 @@ gvm_resolve_as_addr6 (const char *name, struct in6_addr *ip6)
  * @return 0 success, 1 failed.
  */
 int
-validate_port_range (const char* port_range)
+validate_port_range (const char *port_range)
 {
   gchar **split, **point, *range, *range_start;
 
   if (!port_range)
     return 1;
 
-  while (*port_range && isblank (*port_range)) port_range++;
+  while (*port_range && isblank (*port_range))
+    port_range++;
   if (*port_range == '\0')
     return 1;
 
@@ -472,7 +472,8 @@ validate_port_range (const char* port_range)
   range = range_start = g_strdup (port_range);
   while (*range)
     {
-      if (*range == '\n') *range = ',';
+      if (*range == '\n')
+        *range = ',';
       range++;
     }
 
@@ -509,13 +510,15 @@ validate_port_range (const char* port_range)
           /* Check the first number. */
 
           first = element;
-          while (*first && isblank (*first)) first++;
+          while (*first && isblank (*first))
+            first++;
           if (*first == '-')
             goto fail;
 
           errno = 0;
           number1 = strtol (first, &end, 10);
-          while (*end && isblank (*end)) end++;
+          while (*end && isblank (*end))
+            end++;
           if (errno || (*end != '-'))
             goto fail;
           if (number1 == 0)
@@ -525,13 +528,15 @@ validate_port_range (const char* port_range)
 
           /* Check the second number. */
 
-          while (*hyphen && isblank (*hyphen)) hyphen++;
+          while (*hyphen && isblank (*hyphen))
+            hyphen++;
           if (*hyphen == '\0')
             goto fail;
 
           errno = 0;
           number2 = strtol (hyphen, &end, 10);
-          while (*end && isblank (*end)) end++;
+          while (*end && isblank (*end))
+            end++;
           if (errno || *end)
             goto fail;
           if (number2 == 0)
@@ -551,13 +556,15 @@ validate_port_range (const char* port_range)
           /* Check the single number. */
 
           only = element;
-          while (*only && isblank (*only)) only++;
+          while (*only && isblank (*only))
+            only++;
           /* Empty ranges are OK. */
           if (*only)
             {
               errno = 0;
               number = strtol (only, &end, 10);
-              while (*end && isblank (*end)) end++;
+              while (*end && isblank (*end))
+                end++;
               if (errno || *end)
                 goto fail;
               if (number == 0)
@@ -572,7 +579,7 @@ validate_port_range (const char* port_range)
   g_strfreev (split);
   return 0;
 
- fail:
+fail:
   g_strfreev (split);
   return 1;
 }
@@ -584,7 +591,7 @@ validate_port_range (const char* port_range)
  *
  * @return Range array.
  */
-array_t*
+array_t *
 port_range_ranges (const char *port_range)
 {
   gchar **split, **point, *range_start, *current;
@@ -596,7 +603,8 @@ port_range_ranges (const char *port_range)
 
   ranges = make_array ();
 
-  while (*port_range && isblank (*port_range)) port_range++;
+  while (*port_range && isblank (*port_range))
+    port_range++;
 
   /* Accepts T: and U: before any of the ranges.  This toggles the remaining
    * ranges, as in nmap.  Treats a leading naked range as TCP, whereas nmap
@@ -606,7 +614,8 @@ port_range_ranges (const char *port_range)
   range_start = current = g_strdup (port_range);
   while (*current)
     {
-      if (*current == '\n') *current = ',';
+      if (*current == '\n')
+        *current = ',';
       current++;
     }
 
@@ -637,19 +646,21 @@ port_range_ranges (const char *port_range)
         }
 
       /* Skip any space that followed the type specifier. */
-      while (*element && isblank (*element)) element++;
+      while (*element && isblank (*element))
+        element++;
 
       hyphen = strchr (element, '-');
       if (hyphen)
         {
           *hyphen = '\0';
           hyphen++;
-          while (*hyphen && isblank (*hyphen)) hyphen++;
-          assert (*hyphen);  /* Validation checks this. */
+          while (*hyphen && isblank (*hyphen))
+            hyphen++;
+          assert (*hyphen); /* Validation checks this. */
 
           /* A range. */
 
-          range = (range_t*) g_malloc0 (sizeof (range_t));
+          range = (range_t *) g_malloc0 (sizeof (range_t));
 
           range->start = atoi (element);
           range->end = atoi (hyphen);
@@ -662,7 +673,7 @@ port_range_ranges (const char *port_range)
         {
           /* A single port. */
 
-          range = (range_t*) g_malloc0 (sizeof (range_t));
+          range = (range_t *) g_malloc0 (sizeof (range_t));
 
           range->start = atoi (element);
           range->end = range->start;

--- a/base/networking.h
+++ b/base/networking.h
@@ -25,9 +25,9 @@
 #ifndef _GVM_NETWORKING_H
 #define _GVM_NETWORKING_H
 
-#include <netdb.h>           /* for struct in6_addr */
+#include "array.h" /* for array_t */
 
-#include "array.h"           /* for array_t */
+#include <netdb.h> /* for struct in6_addr */
 
 /**
  * @brief Possible port types.
@@ -104,7 +104,7 @@ gvm_resolve_as_addr6 (const char *, struct in6_addr *);
 int
 validate_port_range (const char *);
 
-array_t*
+array_t *
 port_range_ranges (const char *);
 
 int

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -33,7 +33,6 @@
  * \verbinclude COPYING
  */
 
-
 /**
  * @file
  * @brief Implementation of API to handle NVT Info datasets
@@ -45,11 +44,11 @@
  * management etc.
  */
 
-#include <stdio.h>
-
 #include "nvti.h"
 
-#undef  G_LOG_DOMAIN
+#include <stdio.h>
+
+#undef G_LOG_DOMAIN
 #define G_LOG_DOMAIN "lib  nvti"
 
 /**
@@ -66,7 +65,7 @@
  *         released using @ref nvtpref_free .
  */
 nvtpref_t *
-nvtpref_new (gchar * name, gchar * type, gchar * dflt)
+nvtpref_new (gchar *name, gchar *type, gchar *dflt)
 {
   nvtpref_t *np = g_malloc0 (sizeof (nvtpref_t));
 
@@ -89,7 +88,7 @@ nvtpref_new (gchar * name, gchar * type, gchar * dflt)
  * @param np The structure to be freed.
  */
 void
-nvtpref_free (nvtpref_t * np)
+nvtpref_free (nvtpref_t *np)
 {
   if (!np)
     return;
@@ -112,7 +111,7 @@ nvtpref_free (nvtpref_t * np)
  * @return The name string. Don't free this.
  */
 gchar *
-nvtpref_name (const nvtpref_t * np)
+nvtpref_name (const nvtpref_t *np)
 {
   return (np ? np->name : NULL);
 }
@@ -126,7 +125,7 @@ nvtpref_name (const nvtpref_t * np)
  * @return The type string. Don't free this.
  */
 gchar *
-nvtpref_type (const nvtpref_t * np)
+nvtpref_type (const nvtpref_t *np)
 {
   return (np ? np->type : NULL);
 }
@@ -140,7 +139,7 @@ nvtpref_type (const nvtpref_t * np)
  * @return The default string. Don't free this.
  */
 gchar *
-nvtpref_default (const nvtpref_t * np)
+nvtpref_default (const nvtpref_t *np)
 {
   return (np ? np->dflt : NULL);
 }
@@ -165,7 +164,7 @@ nvti_new (void)
  * @param n The structure to be freed.
  */
 void
-nvti_free (nvti_t * n)
+nvti_free (nvti_t *n)
 {
   if (!n)
     return;
@@ -217,7 +216,7 @@ nvti_free (nvti_t * n)
  * @return The OID string. Don't free this.
  */
 gchar *
-nvti_oid (const nvti_t * n)
+nvti_oid (const nvti_t *n)
 {
   return (n ? n->oid : NULL);
 }
@@ -231,7 +230,7 @@ nvti_oid (const nvti_t * n)
  * @return The name string. Don't free this.
  */
 gchar *
-nvti_name (const nvti_t * n)
+nvti_name (const nvti_t *n)
 {
   return (n ? n->name : NULL);
 }
@@ -245,7 +244,7 @@ nvti_name (const nvti_t * n)
  * @return The CVE list as string. Don't free this.
  */
 gchar *
-nvti_cve (const nvti_t * n)
+nvti_cve (const nvti_t *n)
 {
   return (n ? n->cve : NULL);
 }
@@ -259,7 +258,7 @@ nvti_cve (const nvti_t * n)
  * @return The bid list as string. Don't free this.
  */
 gchar *
-nvti_bid (const nvti_t * n)
+nvti_bid (const nvti_t *n)
 {
   return (n ? n->bid : NULL);
 }
@@ -273,7 +272,7 @@ nvti_bid (const nvti_t * n)
  * @return The xref string. Don't free this.
  */
 gchar *
-nvti_xref (const nvti_t * n)
+nvti_xref (const nvti_t *n)
 {
   return (n ? n->xref : NULL);
 }
@@ -287,7 +286,7 @@ nvti_xref (const nvti_t * n)
  * @return The tags string. Don't free this.
  */
 gchar *
-nvti_tag (const nvti_t * n)
+nvti_tag (const nvti_t *n)
 {
   return (n ? n->tag : NULL);
 }
@@ -301,7 +300,7 @@ nvti_tag (const nvti_t * n)
  * @return The cvss_base string. Don't free this.
  */
 gchar *
-nvti_cvss_base (const nvti_t * n)
+nvti_cvss_base (const nvti_t *n)
 {
   return (n ? n->cvss_base : NULL);
 }
@@ -315,7 +314,7 @@ nvti_cvss_base (const nvti_t * n)
  * @return The dependencies string. Don't free this.
  */
 gchar *
-nvti_dependencies (const nvti_t * n)
+nvti_dependencies (const nvti_t *n)
 {
   return (n ? n->dependencies : NULL);
 }
@@ -329,7 +328,7 @@ nvti_dependencies (const nvti_t * n)
  * @return The required keys string. Don't free this.
  */
 gchar *
-nvti_required_keys (const nvti_t * n)
+nvti_required_keys (const nvti_t *n)
 {
   return (n ? n->required_keys : NULL);
 }
@@ -343,7 +342,7 @@ nvti_required_keys (const nvti_t * n)
  * @return The mandatory keys string. Don't free this.
  */
 gchar *
-nvti_mandatory_keys (const nvti_t * n)
+nvti_mandatory_keys (const nvti_t *n)
 {
   return (n ? n->mandatory_keys : NULL);
 }
@@ -357,7 +356,7 @@ nvti_mandatory_keys (const nvti_t * n)
  * @return The excluded keys string. Don't free this.
  */
 gchar *
-nvti_excluded_keys (const nvti_t * n)
+nvti_excluded_keys (const nvti_t *n)
 {
   return (n ? n->excluded_keys : NULL);
 }
@@ -371,7 +370,7 @@ nvti_excluded_keys (const nvti_t * n)
  * @return The required ports string. Don't free this.
  */
 gchar *
-nvti_required_ports (const nvti_t * n)
+nvti_required_ports (const nvti_t *n)
 {
   return (n ? n->required_ports : NULL);
 }
@@ -385,7 +384,7 @@ nvti_required_ports (const nvti_t * n)
  * @return The required udp ports string. Don't free this.
  */
 gchar *
-nvti_required_udp_ports (const nvti_t * n)
+nvti_required_udp_ports (const nvti_t *n)
 {
   return (n ? n->required_udp_ports : NULL);
 }
@@ -399,7 +398,7 @@ nvti_required_udp_ports (const nvti_t * n)
  * @return The family name string. Don't free this.
  */
 gchar *
-nvti_family (const nvti_t * n)
+nvti_family (const nvti_t *n)
 {
   return (n ? n->family : NULL);
 }
@@ -412,7 +411,7 @@ nvti_family (const nvti_t * n)
  * @return The number of preferences.
  */
 guint
-nvti_pref_len (const nvti_t * n)
+nvti_pref_len (const nvti_t *n)
 {
   return (n ? g_slist_length (n->prefs) : 0);
 }
@@ -427,7 +426,7 @@ nvti_pref_len (const nvti_t * n)
  * @return The number of preferences. NULL if
  */
 const nvtpref_t *
-nvti_pref (const nvti_t * n, guint p)
+nvti_pref (const nvti_t *n, guint p)
 {
   return (n ? g_slist_nth_data (n->prefs, p) : NULL);
 }
@@ -441,7 +440,7 @@ nvti_pref (const nvti_t * n, guint p)
  * @return The timeout integer number. A value <= 0 indicates it is not set.
  */
 gint
-nvti_timeout (const nvti_t * n)
+nvti_timeout (const nvti_t *n)
 {
   return (n ? n->timeout : -1);
 }
@@ -454,7 +453,7 @@ nvti_timeout (const nvti_t * n)
  * @return The category integer code. A value <= 0 indicates it is not set.
  */
 gint
-nvti_category (const nvti_t * n)
+nvti_category (const nvti_t *n)
 {
   return (n ? n->category : -1);
 }
@@ -469,9 +468,9 @@ nvti_category (const nvti_t * n)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_oid (nvti_t * n, const gchar * oid)
+nvti_set_oid (nvti_t *n, const gchar *oid)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->oid)
@@ -490,9 +489,9 @@ nvti_set_oid (nvti_t * n, const gchar * oid)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_name (nvti_t * n, const gchar * name)
+nvti_set_name (nvti_t *n, const gchar *name)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->name)
@@ -511,9 +510,9 @@ nvti_set_name (nvti_t * n, const gchar * name)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_cve (nvti_t * n, const gchar * cve)
+nvti_set_cve (nvti_t *n, const gchar *cve)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->cve)
@@ -532,9 +531,9 @@ nvti_set_cve (nvti_t * n, const gchar * cve)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_bid (nvti_t * n, const gchar * bid)
+nvti_set_bid (nvti_t *n, const gchar *bid)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->bid)
@@ -553,9 +552,9 @@ nvti_set_bid (nvti_t * n, const gchar * bid)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_xref (nvti_t * n, const gchar * xref)
+nvti_set_xref (nvti_t *n, const gchar *xref)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->xref)
@@ -577,9 +576,9 @@ nvti_set_xref (nvti_t * n, const gchar * xref)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_tag (nvti_t * n, const gchar * tag)
+nvti_set_tag (nvti_t *n, const gchar *tag)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->tag)
@@ -601,9 +600,9 @@ nvti_set_tag (nvti_t * n, const gchar * tag)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_cvss_base (nvti_t * n, const gchar * cvss_base)
+nvti_set_cvss_base (nvti_t *n, const gchar *cvss_base)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->cvss_base)
@@ -620,14 +619,15 @@ nvti_set_cvss_base (nvti_t * n, const gchar * cvss_base)
  *
  * @param n The NVT Info structure.
  *
- * @param dependencies The dependencies to set. A copy will be created from this.
+ * @param dependencies The dependencies to set. A copy will be created from
+ * this.
  *
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_dependencies (nvti_t * n, const gchar * dependencies)
+nvti_set_dependencies (nvti_t *n, const gchar *dependencies)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->dependencies)
@@ -644,14 +644,15 @@ nvti_set_dependencies (nvti_t * n, const gchar * dependencies)
  *
  * @param n The NVT Info structure.
  *
- * @param required_keys The required keys to set. A copy will be created from this.
+ * @param required_keys The required keys to set. A copy will be created from
+ * this.
  *
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_required_keys (nvti_t * n, const gchar * required_keys)
+nvti_set_required_keys (nvti_t *n, const gchar *required_keys)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->required_keys)
@@ -668,14 +669,15 @@ nvti_set_required_keys (nvti_t * n, const gchar * required_keys)
  *
  * @param n The NVT Info structure.
  *
- * @param mandatory_keys The mandatory keys to set. A copy will be created from this.
+ * @param mandatory_keys The mandatory keys to set. A copy will be created from
+ * this.
  *
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_mandatory_keys (nvti_t * n, const gchar * mandatory_keys)
+nvti_set_mandatory_keys (nvti_t *n, const gchar *mandatory_keys)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->mandatory_keys)
@@ -692,14 +694,15 @@ nvti_set_mandatory_keys (nvti_t * n, const gchar * mandatory_keys)
  *
  * @param n The NVT Info structure.
  *
- * @param excluded_keys The excluded keys to set. A copy will be created from this.
+ * @param excluded_keys The excluded keys to set. A copy will be created from
+ * this.
  *
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_excluded_keys (nvti_t * n, const gchar * excluded_keys)
+nvti_set_excluded_keys (nvti_t *n, const gchar *excluded_keys)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->excluded_keys)
@@ -716,14 +719,15 @@ nvti_set_excluded_keys (nvti_t * n, const gchar * excluded_keys)
  *
  * @param n The NVT Info structure.
  *
- * @param required_ports The required ports to set. A copy will be created from this.
+ * @param required_ports The required ports to set. A copy will be created from
+ * this.
  *
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_required_ports (nvti_t * n, const gchar * required_ports)
+nvti_set_required_ports (nvti_t *n, const gchar *required_ports)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->required_ports)
@@ -740,14 +744,15 @@ nvti_set_required_ports (nvti_t * n, const gchar * required_ports)
  *
  * @param n The NVT Info structure.
  *
- * @param required_udp_ports The required udp ports to set. A copy will be created from this.
+ * @param required_udp_ports The required udp ports to set. A copy will be
+ * created from this.
  *
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_required_udp_ports (nvti_t * n, const gchar * required_udp_ports)
+nvti_set_required_udp_ports (nvti_t *n, const gchar *required_udp_ports)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->required_udp_ports)
@@ -769,9 +774,9 @@ nvti_set_required_udp_ports (nvti_t * n, const gchar * required_udp_ports)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_family (nvti_t * n, const gchar * family)
+nvti_set_family (nvti_t *n, const gchar *family)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   if (n->family)
@@ -790,9 +795,9 @@ nvti_set_family (nvti_t * n, const gchar * family)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_timeout (nvti_t * n, const gint timeout)
+nvti_set_timeout (nvti_t *n, const gint timeout)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   n->timeout = timeout;
@@ -809,9 +814,9 @@ nvti_set_timeout (nvti_t * n, const gint timeout)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_set_category (nvti_t * n, const gint category)
+nvti_set_category (nvti_t *n, const gint category)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   n->category = category;
@@ -828,20 +833,22 @@ nvti_set_category (nvti_t * n, const gint category)
  * @return 0 for success. 1 if n was NULL, 2 if cve_id was NULL.
  */
 int
-nvti_add_cve (nvti_t * n, const gchar * cve_id)
+nvti_add_cve (nvti_t *n, const gchar *cve_id)
 {
-  gchar * old;
+  gchar *old;
 
-  if (! n) return (1);
-  if (! cve_id) return (2);
+  if (!n)
+    return (1);
+  if (!cve_id)
+    return (2);
 
   old = n->cve;
 
   if (old)
-  {
-    n->cve = g_strdup_printf ("%s, %s", old, cve_id);
-    g_free (old);
-  }
+    {
+      n->cve = g_strdup_printf ("%s, %s", old, cve_id);
+      g_free (old);
+    }
   else
     n->cve = g_strdup (cve_id);
 
@@ -858,20 +865,22 @@ nvti_add_cve (nvti_t * n, const gchar * cve_id)
  * @return 0 for success. 1 if n was NULL. 2 if bid_id was NULL.
  */
 int
-nvti_add_bid (nvti_t * n, const gchar * bid_id)
+nvti_add_bid (nvti_t *n, const gchar *bid_id)
 {
-  gchar * old;
+  gchar *old;
 
-  if (! n) return (1);
-  if (! bid_id) return (2);
+  if (!n)
+    return (1);
+  if (!bid_id)
+    return (2);
 
   old = n->bid;
 
   if (old)
-  {
-    n->bid = g_strdup_printf ("%s, %s", old, bid_id);
-    g_free (old);
-  }
+    {
+      n->bid = g_strdup_printf ("%s, %s", old, bid_id);
+      g_free (old);
+    }
   else
     n->bid = g_strdup (bid_id);
 
@@ -888,20 +897,22 @@ nvti_add_bid (nvti_t * n, const gchar * bid_id)
  * @return 0 for success. 1 if n was NULL. 2 if key was NULL.
  */
 int
-nvti_add_required_keys (nvti_t * n, const gchar * key)
+nvti_add_required_keys (nvti_t *n, const gchar *key)
 {
-  gchar * old;
+  gchar *old;
 
-  if (! n) return (1);
-  if (! key) return (2);
+  if (!n)
+    return (1);
+  if (!key)
+    return (2);
 
   old = n->required_keys;
 
   if (old)
-  {
-    n->required_keys = g_strdup_printf ("%s, %s", old, key);
-    g_free (old);
-  }
+    {
+      n->required_keys = g_strdup_printf ("%s, %s", old, key);
+      g_free (old);
+    }
   else
     n->required_keys = g_strdup (key);
 
@@ -918,20 +929,22 @@ nvti_add_required_keys (nvti_t * n, const gchar * key)
  * @return 0 for success. 1 if n was NULL. 2 if key was NULL.
  */
 int
-nvti_add_mandatory_keys (nvti_t * n, const gchar * key)
+nvti_add_mandatory_keys (nvti_t *n, const gchar *key)
 {
-  gchar * old;
+  gchar *old;
 
-  if (! n) return (1);
-  if (! key) return (2);
+  if (!n)
+    return (1);
+  if (!key)
+    return (2);
 
   old = n->mandatory_keys;
 
   if (old)
-  {
-    n->mandatory_keys = g_strdup_printf ("%s, %s", old, key);
-    g_free (old);
-  }
+    {
+      n->mandatory_keys = g_strdup_printf ("%s, %s", old, key);
+      g_free (old);
+    }
   else
     n->mandatory_keys = g_strdup (key);
 
@@ -948,20 +961,22 @@ nvti_add_mandatory_keys (nvti_t * n, const gchar * key)
  * @return 0 for success. 1 if n was NULL. 2 if key was NULL.
  */
 int
-nvti_add_excluded_keys (nvti_t * n, const gchar * key)
+nvti_add_excluded_keys (nvti_t *n, const gchar *key)
 {
-  gchar * old;
+  gchar *old;
 
-  if (! n) return (1);
-  if (! key) return (2);
+  if (!n)
+    return (1);
+  if (!key)
+    return (2);
 
   old = n->excluded_keys;
 
   if (old)
-  {
-    n->excluded_keys = g_strdup_printf ("%s, %s", old, key);
-    g_free (old);
-  }
+    {
+      n->excluded_keys = g_strdup_printf ("%s, %s", old, key);
+      g_free (old);
+    }
   else
     n->excluded_keys = g_strdup (key);
 
@@ -978,20 +993,22 @@ nvti_add_excluded_keys (nvti_t * n, const gchar * key)
  * @return 0 for success. 1 if n was NULL. 2 if port was NULL.
  */
 int
-nvti_add_required_ports (nvti_t * n, const gchar * port)
+nvti_add_required_ports (nvti_t *n, const gchar *port)
 {
-  gchar * old;
+  gchar *old;
 
-  if (! n) return (1);
-  if (! port) return (2);
+  if (!n)
+    return (1);
+  if (!port)
+    return (2);
 
   old = n->required_ports;
 
   if (old)
-  {
-    n->required_ports = g_strdup_printf ("%s, %s", old, port);
-    g_free (old);
-  }
+    {
+      n->required_ports = g_strdup_printf ("%s, %s", old, port);
+      g_free (old);
+    }
   else
     n->required_ports = g_strdup (port);
 
@@ -1008,20 +1025,22 @@ nvti_add_required_ports (nvti_t * n, const gchar * port)
  * @return 0 for success. 1 if n was NULL. 2 if port was NULL.
  */
 int
-nvti_add_required_udp_ports (nvti_t * n, const gchar * port)
+nvti_add_required_udp_ports (nvti_t *n, const gchar *port)
 {
-  gchar * old;
+  gchar *old;
 
-  if (! n) return (1);
-  if (! port) return (2);
+  if (!n)
+    return (1);
+  if (!port)
+    return (2);
 
   old = n->required_udp_ports;
 
   if (old)
-  {
-    n->required_udp_ports = g_strdup_printf ("%s, %s", old, port);
-    g_free (old);
-  }
+    {
+      n->required_udp_ports = g_strdup_printf ("%s, %s", old, port);
+      g_free (old);
+    }
   else
     n->required_udp_ports = g_strdup (port);
 
@@ -1038,9 +1057,9 @@ nvti_add_required_udp_ports (nvti_t * n, const gchar * port)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_add_pref (nvti_t * n, nvtpref_t * np)
+nvti_add_pref (nvti_t *n, nvtpref_t *np)
 {
-  if (! n)
+  if (!n)
     return (-1);
 
   n->prefs = g_slist_append (n->prefs, np);
@@ -1078,7 +1097,7 @@ nvtis_new (void)
  * @param nvtis The collection of NVT Infos.
  */
 void
-nvtis_free (nvtis_t * nvtis)
+nvtis_free (nvtis_t *nvtis)
 {
   if (nvtis)
     g_hash_table_destroy (nvtis);
@@ -1091,7 +1110,7 @@ nvtis_free (nvtis_t * nvtis)
  * @param nvti  The NVT Info to add.
  */
 void
-nvtis_add (nvtis_t * nvtis, nvti_t * nvti)
+nvtis_add (nvtis_t *nvtis, nvti_t *nvti)
 {
   if (nvti)
     g_hash_table_insert (nvtis, (gpointer) nvti_oid (nvti), (gpointer) nvti);
@@ -1106,7 +1125,7 @@ nvtis_add (nvtis_t * nvtis, nvti_t * nvti)
  * @return The NVT Info, if found, else NULL.
  */
 nvti_t *
-nvtis_lookup (nvtis_t * nvtis, const char *oid)
+nvtis_lookup (nvtis_t *nvtis, const char *oid)
 {
   return g_hash_table_lookup (nvtis, oid);
 }

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -37,16 +37,21 @@
  */
 typedef struct nvtpref
 {
-  gchar *type;                  ///< Preference type
-  gchar *name;                  ///< Name of the preference
-  gchar *dflt;                  ///< Default value of the preference
+  gchar *type; ///< Preference type
+  gchar *name; ///< Name of the preference
+  gchar *dflt; ///< Default value of the preference
 } nvtpref_t;
 
-nvtpref_t *nvtpref_new (gchar *, gchar *, gchar *);
-void nvtpref_free (nvtpref_t *);
-gchar *nvtpref_name (const nvtpref_t *);
-gchar *nvtpref_type (const nvtpref_t *);
-gchar *nvtpref_default (const nvtpref_t *);
+nvtpref_t *
+nvtpref_new (gchar *, gchar *, gchar *);
+void
+nvtpref_free (nvtpref_t *);
+gchar *
+nvtpref_name (const nvtpref_t *);
+gchar *
+nvtpref_type (const nvtpref_t *);
+gchar *
+nvtpref_default (const nvtpref_t *);
 
 /**
  * @brief The structure of a information record that corresponds to a NVT.
@@ -56,79 +61,124 @@ gchar *nvtpref_default (const nvtpref_t *);
  */
 typedef struct nvti
 {
-  gchar *oid;                /**< @brief Object ID */
-  gchar *name;               /**< @brief The name */
+  gchar *oid;  /**< @brief Object ID */
+  gchar *name; /**< @brief The name */
 
-  gchar *cve;               /**< @brief List of CVEs, this NVT corresponds to */
-  gchar *bid;               /**< @brief List of Bugtraq IDs, this NVT
-                                        corresponds to */
-  gchar *xref;              /**< @brief List of Cross-references, this NVT
-                                        corresponds to */
-  gchar *tag;               /**< @brief List of tags attached to this NVT */
-  gchar *cvss_base;         /**< @brief CVSS base score for this NVT. */
+  gchar *cve;       /**< @brief List of CVEs, this NVT corresponds to */
+  gchar *bid;       /**< @brief List of Bugtraq IDs, this NVT
+                                corresponds to */
+  gchar *xref;      /**< @brief List of Cross-references, this NVT
+                                corresponds to */
+  gchar *tag;       /**< @brief List of tags attached to this NVT */
+  gchar *cvss_base; /**< @brief CVSS base score for this NVT. */
 
-  gchar *dependencies;      /**< @brief List of dependencies of this NVT */
-  gchar *required_keys;     /**< @brief List of required KB keys of this NVT */
-  gchar *mandatory_keys;    /**< @brief List of mandatory KB keys of this NVT */
-  gchar *excluded_keys;     /**< @brief List of excluded KB keys of this NVT */
-  gchar *required_ports;    /**< @brief List of required ports of this NVT */
-  gchar *required_udp_ports;/**< @brief List of required UDP ports of this NVT*/
+  gchar *dependencies;   /**< @brief List of dependencies of this NVT */
+  gchar *required_keys;  /**< @brief List of required KB keys of this NVT */
+  gchar *mandatory_keys; /**< @brief List of mandatory KB keys of this NVT */
+  gchar *excluded_keys;  /**< @brief List of excluded KB keys of this NVT */
+  gchar *required_ports; /**< @brief List of required ports of this NVT */
+  gchar
+    *required_udp_ports; /**< @brief List of required UDP ports of this NVT*/
 
-  GSList *prefs;            /**< @brief Collection of NVT preferences */
+  GSList *prefs; /**< @brief Collection of NVT preferences */
 
   // The following are not settled yet.
-  gint timeout;             /**< @brief Default timeout time for this NVT */
-  gint category;            /**< @brief The category, this NVT belongs to */
-  gchar *family;            /**< @brief Family the NVT belongs to */
+  gint timeout;  /**< @brief Default timeout time for this NVT */
+  gint category; /**< @brief The category, this NVT belongs to */
+  gchar *family; /**< @brief Family the NVT belongs to */
 } nvti_t;
 
-nvti_t *nvti_new (void);
-void nvti_free (nvti_t *);
+nvti_t *
+nvti_new (void);
+void
+nvti_free (nvti_t *);
 
-gchar *nvti_oid (const nvti_t *);
-gchar *nvti_name (const nvti_t *);
-gchar *nvti_cve (const nvti_t *);
-gchar *nvti_bid (const nvti_t *);
-gchar *nvti_xref (const nvti_t *);
-gchar *nvti_tag (const nvti_t *);
-gchar *nvti_cvss_base (const nvti_t *);
-gchar *nvti_dependencies (const nvti_t *);
-gchar *nvti_required_keys (const nvti_t *);
-gchar *nvti_mandatory_keys (const nvti_t *);
-gchar *nvti_excluded_keys (const nvti_t *);
-gchar *nvti_required_ports (const nvti_t *);
-gchar *nvti_required_udp_ports (const nvti_t *);
-gint nvti_timeout (const nvti_t *);
-gint nvti_category (const nvti_t *);
-gchar *nvti_family (const nvti_t *);
-guint nvti_pref_len (const nvti_t *);
-const nvtpref_t *nvti_pref (const nvti_t *, guint);
+gchar *
+nvti_oid (const nvti_t *);
+gchar *
+nvti_name (const nvti_t *);
+gchar *
+nvti_cve (const nvti_t *);
+gchar *
+nvti_bid (const nvti_t *);
+gchar *
+nvti_xref (const nvti_t *);
+gchar *
+nvti_tag (const nvti_t *);
+gchar *
+nvti_cvss_base (const nvti_t *);
+gchar *
+nvti_dependencies (const nvti_t *);
+gchar *
+nvti_required_keys (const nvti_t *);
+gchar *
+nvti_mandatory_keys (const nvti_t *);
+gchar *
+nvti_excluded_keys (const nvti_t *);
+gchar *
+nvti_required_ports (const nvti_t *);
+gchar *
+nvti_required_udp_ports (const nvti_t *);
+gint
+nvti_timeout (const nvti_t *);
+gint
+nvti_category (const nvti_t *);
+gchar *
+nvti_family (const nvti_t *);
+guint
+nvti_pref_len (const nvti_t *);
+const nvtpref_t *
+nvti_pref (const nvti_t *, guint);
 
-int nvti_set_oid (nvti_t *, const gchar *);
-int nvti_set_name (nvti_t *, const gchar *);
-int nvti_set_cve (nvti_t *, const gchar *);
-int nvti_set_bid (nvti_t *, const gchar *);
-int nvti_set_xref (nvti_t *, const gchar *);
-int nvti_set_tag (nvti_t *, const gchar *);
-int nvti_set_cvss_base (nvti_t *, const gchar *);
-int nvti_set_dependencies (nvti_t *, const gchar *);
-int nvti_set_required_keys (nvti_t *, const gchar *);
-int nvti_set_mandatory_keys (nvti_t *, const gchar *);
-int nvti_set_excluded_keys (nvti_t *, const gchar *);
-int nvti_set_required_ports (nvti_t *, const gchar *);
-int nvti_set_required_udp_ports (nvti_t *, const gchar *);
-int nvti_set_timeout (nvti_t *, const gint);
-int nvti_set_category (nvti_t *, const gint);
-int nvti_set_family (nvti_t *, const gchar *);
+int
+nvti_set_oid (nvti_t *, const gchar *);
+int
+nvti_set_name (nvti_t *, const gchar *);
+int
+nvti_set_cve (nvti_t *, const gchar *);
+int
+nvti_set_bid (nvti_t *, const gchar *);
+int
+nvti_set_xref (nvti_t *, const gchar *);
+int
+nvti_set_tag (nvti_t *, const gchar *);
+int
+nvti_set_cvss_base (nvti_t *, const gchar *);
+int
+nvti_set_dependencies (nvti_t *, const gchar *);
+int
+nvti_set_required_keys (nvti_t *, const gchar *);
+int
+nvti_set_mandatory_keys (nvti_t *, const gchar *);
+int
+nvti_set_excluded_keys (nvti_t *, const gchar *);
+int
+nvti_set_required_ports (nvti_t *, const gchar *);
+int
+nvti_set_required_udp_ports (nvti_t *, const gchar *);
+int
+nvti_set_timeout (nvti_t *, const gint);
+int
+nvti_set_category (nvti_t *, const gint);
+int
+nvti_set_family (nvti_t *, const gchar *);
 
-int nvti_add_cve (nvti_t *, const gchar *);
-int nvti_add_bid (nvti_t *, const gchar *);
-int nvti_add_required_keys (nvti_t *, const gchar *);
-int nvti_add_mandatory_keys (nvti_t *, const gchar *);
-int nvti_add_excluded_keys (nvti_t *, const gchar *);
-int nvti_add_required_ports (nvti_t *, const gchar *);
-int nvti_add_required_udp_ports (nvti_t *, const gchar *);
-int nvti_add_pref (nvti_t *, nvtpref_t *);
+int
+nvti_add_cve (nvti_t *, const gchar *);
+int
+nvti_add_bid (nvti_t *, const gchar *);
+int
+nvti_add_required_keys (nvti_t *, const gchar *);
+int
+nvti_add_mandatory_keys (nvti_t *, const gchar *);
+int
+nvti_add_excluded_keys (nvti_t *, const gchar *);
+int
+nvti_add_required_ports (nvti_t *, const gchar *);
+int
+nvti_add_required_udp_ports (nvti_t *, const gchar *);
+int
+nvti_add_pref (nvti_t *, nvtpref_t *);
 
 /* Collections of NVT Infos. */
 

--- a/base/pidfile.c
+++ b/base/pidfile.c
@@ -49,7 +49,7 @@
  * @return 0 for success, anything else indicates an error.
  */
 int
-pidfile_create (gchar * daemon_name)
+pidfile_create (gchar *daemon_name)
 {
   gchar *name_pid = g_strconcat (daemon_name, ".pid", NULL);
   gchar *pidfile_name = g_build_filename (GVM_PID_DIR, name_pid, NULL);
@@ -78,7 +78,7 @@ pidfile_create (gchar * daemon_name)
  * @param[in]  daemon_name The name of the daemon
  */
 void
-pidfile_remove (gchar * daemon_name)
+pidfile_remove (gchar *daemon_name)
 {
   gchar *name_pid = g_strconcat (daemon_name, ".pid", NULL);
   gchar *pidfile_name = g_build_filename (GVM_PID_DIR, name_pid, NULL);

--- a/base/pidfile.h
+++ b/base/pidfile.h
@@ -27,7 +27,9 @@
 
 #include <glib.h>
 
-int pidfile_create (gchar *);
-void pidfile_remove (gchar *);
+int
+pidfile_create (gchar *);
+void
+pidfile_remove (gchar *);
 
 #endif /* not _GVM_PIDFILE_H */

--- a/base/prefs.c
+++ b/base/prefs.c
@@ -25,13 +25,12 @@
  * module.
  */
 
-#include <string.h> /* for strlen() */
-#include <stdlib.h> /* for atoi() */
-#include <stdio.h>  /* for printf() */
-#include <glib.h>   /* for gchar */
-
 #include "settings.h" /* for init_settings_iterator_from_file */
 
+#include <glib.h>   /* for gchar */
+#include <stdio.h>  /* for printf() */
+#include <stdlib.h> /* for atoi() */
+#include <string.h> /* for strlen() */
 
 static GHashTable *global_prefs = NULL;
 
@@ -49,8 +48,8 @@ prefs_init (void)
   if (global_prefs)
     g_hash_table_destroy (global_prefs);
 
-  global_prefs = g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
-                                        g_free);
+  global_prefs =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   prefs_set ("cgi_path", "/cgi-bin:/scripts");
   prefs_set ("checks_read_timeout", "5");
   prefs_set ("unscanned_closed", "yes");
@@ -88,7 +87,7 @@ preferences_get (void)
  *         preference is not of type string.
  */
 const gchar *
-prefs_get (const gchar * key)
+prefs_get (const gchar *key)
 {
   if (!global_prefs)
     prefs_init ();
@@ -108,7 +107,7 @@ prefs_get (const gchar * key)
  *         Any other type or non-existing key is false.
  */
 int
-prefs_get_bool (const gchar * key)
+prefs_get_bool (const gchar *key)
 {
   gchar *str;
 
@@ -128,10 +127,10 @@ prefs_get_bool (const gchar * key)
  * @param key    The identifier for the preference. A copy of this will
  *               be created if necessary.
  *
- * @param value  The value to set. A copy of this will be created. 
+ * @param value  The value to set. A copy of this will be created.
  */
 void
-prefs_set (const gchar * key, const gchar * value)
+prefs_set (const gchar *key, const gchar *value)
 {
   if (!global_prefs)
     prefs_init ();
@@ -157,8 +156,8 @@ prefs_config (const char *config)
   if (!init_settings_iterator_from_file (&settings, buffer, "Misc"))
     {
       while (settings_iterator_next (&settings))
-          prefs_set (settings_iterator_name (&settings),
-                     settings_iterator_value (&settings));
+        prefs_set (settings_iterator_name (&settings),
+                   settings_iterator_value (&settings));
 
       cleanup_settings_iterator (&settings);
     }
@@ -197,7 +196,7 @@ int
 prefs_nvt_timeout (const char *oid)
 {
   char *pref_name = g_strdup_printf ("timeout.%s", oid);
-  const char * val = prefs_get (pref_name);
+  const char *val = prefs_get (pref_name);
   int timeout = (val ? atoi (val) : 0);
 
   g_free (pref_name);

--- a/base/prefs.h
+++ b/base/prefs.h
@@ -29,12 +29,18 @@
 
 #include <glib.h> /* for gchar */
 
-void prefs_config (const char *);
-const gchar * prefs_get (const gchar * key);
-int prefs_get_bool (const gchar * key);
-void prefs_set (const gchar *, const gchar *);
-void prefs_dump (void);
-int prefs_nvt_timeout (const char *);
+void
+prefs_config (const char *);
+const gchar *
+prefs_get (const gchar *key);
+int
+prefs_get_bool (const gchar *key);
+void
+prefs_set (const gchar *, const gchar *);
+void
+prefs_dump (void);
+int
+prefs_nvt_timeout (const char *);
 
 GHashTable *
 preferences_get (void);

--- a/base/proctitle.c
+++ b/base/proctitle.c
@@ -24,10 +24,9 @@
 
 #include "proctitle.h"
 
-#include <glib.h>   /* for g_free, g_malloc0, g_strdup */
+#include <glib.h> /* for g_free, g_malloc0, g_strdup */
 #include <stdio.h>
 #include <string.h> /* for strlen, strdup, bzero, strncpy */
-
 #include <sys/param.h>
 
 /**
@@ -68,7 +67,8 @@ proctitle_init (int argc, char **argv)
 #endif
 
   /* Move environ to new memory, to be able to reuse older one. */
-  while (envp[i]) i++;
+  while (envp[i])
+    i++;
   environ = g_malloc0 (sizeof (char *) * (i + 1));
   if (current_environ)
     g_free (current_environ);
@@ -79,9 +79,9 @@ proctitle_init (int argc, char **argv)
 
   old_argv = argv;
   if (i > 0)
-    argv_len = envp[i-1] + strlen (envp[i-1]) - old_argv[0];
+    argv_len = envp[i - 1] + strlen (envp[i - 1]) - old_argv[0];
   else
-    argv_len = old_argv[argc-1] + strlen (old_argv[argc-1]) - old_argv[0];
+    argv_len = old_argv[argc - 1] + strlen (old_argv[argc - 1]) - old_argv[0];
 
   /* Seems like these are in the moved environment, so reset them.  Idea from
    * proctitle.cpp in KDE libs.  */

--- a/base/proctitle.h
+++ b/base/proctitle.h
@@ -32,4 +32,3 @@ void
 proctitle_set (const char *, ...);
 
 #endif /* not _GVM_PROCTITLE_H */
-

--- a/base/pwpolicy.c
+++ b/base/pwpolicy.c
@@ -25,17 +25,17 @@
  * file.
  */
 
+#include "pwpolicy.h"
+
 #include <errno.h> /* for errno */
 #include <glib.h>  /* for g_strdup_printf, g_ascii_strcasecmp, g_free, ... */
 #include <stdio.h> /* for fclose, fgets, fopen, FILE, ferror, EOF, getc */
 #include <stdlib.h>
 #include <string.h> /* for strstr, strlen, strncmp */
 
-#include "pwpolicy.h"
-
 #ifndef DIM
-# define DIM(v)		     (sizeof(v)/sizeof((v)[0]))
-# define DIMof(type,member)   DIM(((type *)0)->member)
+#define DIM(v) (sizeof (v) / sizeof ((v)[0]))
+#define DIMof(type, member) DIM (((type *) 0)->member)
 #endif
 
 #undef G_LOG_DOMAIN
@@ -112,8 +112,6 @@
  */
 static gboolean disable_password_policy;
 
-
-
 /**
  * @return A malloced string to be returned on read and configuration
  * errors.
@@ -123,7 +121,6 @@ policy_checking_failed (void)
 {
   return g_strdup ("Password policy checking failed (internal error)");
 }
-
 
 /**
  * @brief Check whether a string starts with a keyword
@@ -157,7 +154,6 @@ is_keyword (char *string, const char *keyword)
   return NULL;
 }
 
-
 /**
  * @brief Search a file for a matching line
  *
@@ -181,21 +177,21 @@ search_file (const char *fname, const char *password)
   if (!fp)
     return -1;
 
-  while (fgets (line, DIM(line)-1, fp))
+  while (fgets (line, DIM (line) - 1, fp))
     {
       size_t len;
 
       len = strlen (line);
-      if (!len || line[len-1] != '\n')
+      if (!len || line[len - 1] != '\n')
         {
           /* Incomplete last line or line too long.  Eat until end of
              line. */
-          while ( (c=getc (fp)) != EOF && c != '\n')
+          while ((c = getc (fp)) != EOF && c != '\n')
             ;
           continue;
         }
       line[--len] = 0; /* Chop the LF. */
-      if (len && line[len-1] == '\r')
+      if (len && line[len - 1] == '\r')
         line[--len] = 0; /* Chop an optional CR. */
       if (!len)
         continue; /* Empty */
@@ -216,7 +212,6 @@ search_file (const char *fname, const char *password)
   return 0; /* Not found.  */
 }
 
-
 /**
  * @brief Parse one line of a pettern file
  *
@@ -234,8 +229,8 @@ search_file (const char *fname, const char *password)
  *         description.
  */
 static char *
-parse_pattern_line (char *line, const char *fname, int lineno,
-                    char **descp, const char *password, const char *username)
+parse_pattern_line (char *line, const char *fname, int lineno, char **descp,
+                    const char *password, const char *username)
 {
   char *ret = NULL;
   char *p;
@@ -272,8 +267,8 @@ parse_pattern_line (char *line, const char *fname, int lineno,
           sret = search_file (p, password);
           if (sret == -1)
             {
-              g_warning ("error searching '%s' (requested at line %d): %s",
-                         p, lineno, g_strerror (errno));
+              g_warning ("error searching '%s' (requested at line %d): %s", p,
+                         lineno, g_strerror (errno));
               ret = policy_checking_failed ();
             }
           else if (sret && *descp)
@@ -305,8 +300,8 @@ parse_pattern_line (char *line, const char *fname, int lineno,
         }
       else
         {
-          g_warning ("error reading '%s', line %d: %s",
-                     fname, lineno, "unknown processing instruction");
+          g_warning ("error reading '%s', line %d: %s", fname, lineno,
+                     "unknown processing instruction");
           ret = policy_checking_failed ();
         }
     }
@@ -322,15 +317,15 @@ parse_pattern_line (char *line, const char *fname, int lineno,
         line++;
       line++;
       n = strlen (line);
-      if (n && line[n-1] == '/')
-        line[n-1] = 0;
+      if (n && line[n - 1] == '/')
+        line[n - 1] = 0;
       if (((!g_regex_match_simple (line, password, G_REGEX_CASELESS, 0)) ^ rev))
         ret = NULL;
       else if (*descp)
         ret = g_strdup_printf ("Weak password (%s)", *descp);
       else
-        ret = g_strdup_printf ("Weak password (see '%s' line %d)",
-                               fname, lineno);
+        ret =
+          g_strdup_printf ("Weak password (see '%s' line %d)", fname, lineno);
     }
   else /* Simple string.  */
     {
@@ -339,13 +334,12 @@ parse_pattern_line (char *line, const char *fname, int lineno,
       else if (*descp)
         ret = g_strdup_printf ("Weak password (%s)", *descp);
       else
-        ret = g_strdup_printf ("Weak password (see '%s' line %d)",
-                               fname, lineno);
+        ret =
+          g_strdup_printf ("Weak password (see '%s' line %d)", fname, lineno);
     }
 
   return ret;
 }
-
 
 /**
  * @brief Validate a password against the pattern file
@@ -381,25 +375,24 @@ gvm_validate_password (const char *password, const char *username)
     }
   lineno = 0;
   ret = NULL;
-  while (fgets (line, DIM(line)-1, fp))
+  while (fgets (line, DIM (line) - 1, fp))
     {
       size_t len;
 
       lineno++;
       len = strlen (line);
-      if (!len || line[len-1] != '\n')
+      if (!len || line[len - 1] != '\n')
         {
-          g_warning ("error reading '%s', line %d: %s",
-                     patternfile, lineno,
-                     len? "line too long":"line without a LF");
+          g_warning ("error reading '%s', line %d: %s", patternfile, lineno,
+                     len ? "line too long" : "line without a LF");
           ret = policy_checking_failed ();
           break;
         }
       line[--len] = 0; /* Chop the LF. */
-      if (len && line[len-1] == '\r')
+      if (len && line[len - 1] == '\r')
         line[--len] = 0; /* Chop an optional CR. */
-      ret = parse_pattern_line (line, patternfile, lineno, &desc,
-                                password, username);
+      ret = parse_pattern_line (line, patternfile, lineno, &desc, password,
+                                username);
       if (ret)
         break;
 
@@ -410,7 +403,6 @@ gvm_validate_password (const char *password, const char *username)
   g_free (desc);
   return ret;
 }
-
 
 /**
  * @brief Disable all password policy checking

--- a/base/pwpolicy.h
+++ b/base/pwpolicy.h
@@ -27,7 +27,9 @@
 #ifndef _GVM_PWPOLICY_H
 #define _GVM_PWPOLICY_H
 
-char *gvm_validate_password (const char *, const char *);
-void gvm_disable_password_policy (void);
+char *
+gvm_validate_password (const char *, const char *);
+void
+gvm_disable_password_policy (void);
 
 #endif /*_GVM_PWPOLICY_H*/

--- a/base/settings.c
+++ b/base/settings.c
@@ -37,8 +37,8 @@
  * @return 0 success, -1 error.
  */
 int
-settings_init_from_file (settings_t * settings, const gchar * filename,
-                         const gchar * group)
+settings_init_from_file (settings_t *settings, const gchar *filename,
+                         const gchar *group)
 {
   GError *error = NULL;
 
@@ -58,9 +58,10 @@ settings_init_from_file (settings_t * settings, const gchar * filename,
       gchar *contents_with_group = g_strjoin ("\n", "[Misc]", contents, NULL);
       settings->key_file = g_key_file_new ();
 
-      if (!g_key_file_load_from_data
-          (settings->key_file, contents_with_group, strlen (contents_with_group),
-           G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS, &error))
+      if (!g_key_file_load_from_data (
+            settings->key_file, contents_with_group,
+            strlen (contents_with_group),
+            G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS, &error))
         {
           g_warning ("Failed to load configuration from %s: %s", filename,
                      error->message);
@@ -85,7 +86,7 @@ settings_init_from_file (settings_t * settings, const gchar * filename,
  * @param[in]  settings  Settings structure.
  */
 void
-settings_cleanup (settings_t * settings)
+settings_cleanup (settings_t *settings)
 {
   g_free (settings->group_name);
   g_free (settings->file_name);
@@ -102,8 +103,8 @@ settings_cleanup (settings_t * settings)
  * @return 0 success, -1 error.
  */
 int
-init_settings_iterator_from_file (settings_iterator_t * iterator, const gchar *
-                                  filename, const gchar * group)
+init_settings_iterator_from_file (settings_iterator_t *iterator,
+                                  const gchar *filename, const gchar *group)
 {
   int ret;
   gsize keys_length;
@@ -113,9 +114,8 @@ init_settings_iterator_from_file (settings_iterator_t * iterator, const gchar *
   if (ret)
     return ret;
 
-  iterator->keys =
-    g_key_file_get_keys (iterator->settings.key_file, group, &keys_length,
-                         &error);
+  iterator->keys = g_key_file_get_keys (iterator->settings.key_file, group,
+                                        &keys_length, &error);
 
   if (iterator->keys == NULL)
     {
@@ -141,7 +141,7 @@ init_settings_iterator_from_file (settings_iterator_t * iterator, const gchar *
  * @param[in]  iterator  Settings iterator.
  */
 void
-cleanup_settings_iterator (settings_iterator_t * iterator)
+cleanup_settings_iterator (settings_iterator_t *iterator)
 {
   g_strfreev (iterator->keys);
   settings_cleanup (&iterator->settings);
@@ -155,7 +155,7 @@ cleanup_settings_iterator (settings_iterator_t * iterator)
  * @return TRUE if there was a next item, else FALSE.
  */
 gboolean
-settings_iterator_next (settings_iterator_t * iterator)
+settings_iterator_next (settings_iterator_t *iterator)
 {
   if (iterator->current_key == iterator->last_key)
     return FALSE;
@@ -171,7 +171,7 @@ settings_iterator_next (settings_iterator_t * iterator)
  * @return Name of current key.
  */
 const gchar *
-settings_iterator_name (settings_iterator_t * iterator)
+settings_iterator_name (settings_iterator_t *iterator)
 {
   return *iterator->current_key;
 }
@@ -184,7 +184,7 @@ settings_iterator_name (settings_iterator_t * iterator)
  * @return Value of current key.
  */
 const gchar *
-settings_iterator_value (settings_iterator_t * iterator)
+settings_iterator_value (settings_iterator_t *iterator)
 {
   return g_key_file_get_value (iterator->settings.key_file,
                                iterator->settings.group_name,

--- a/base/settings.h
+++ b/base/settings.h
@@ -40,24 +40,30 @@ typedef struct
   GKeyFile *key_file; /**< GKeyFile object where the file is load. */
 } settings_t;
 
-void settings_cleanup (settings_t *);
+void
+settings_cleanup (settings_t *);
 
 /**
  * @brief Struct holding options to iterate over a GKeyFile.
  */
 typedef struct
 {
-  gchar **keys;         /**< Keys. */
-  settings_t settings;  /**< Settings structure. */
-  gchar **current_key;  /**< Pointer to the current key. */
-  gchar **last_key;     /**< Pointer to the last keys. */
+  gchar **keys;        /**< Keys. */
+  settings_t settings; /**< Settings structure. */
+  gchar **current_key; /**< Pointer to the current key. */
+  gchar **last_key;    /**< Pointer to the last keys. */
 } settings_iterator_t;
 
-int init_settings_iterator_from_file (settings_iterator_t *, const gchar *,
-                                      const gchar *);
-void cleanup_settings_iterator (settings_iterator_t *);
-int settings_iterator_next (settings_iterator_t *);
-const gchar *settings_iterator_name (settings_iterator_t *);
-const gchar *settings_iterator_value (settings_iterator_t *);
+int
+init_settings_iterator_from_file (settings_iterator_t *, const gchar *,
+                                  const gchar *);
+void
+cleanup_settings_iterator (settings_iterator_t *);
+int
+settings_iterator_next (settings_iterator_t *);
+const gchar *
+settings_iterator_name (settings_iterator_t *);
+const gchar *
+settings_iterator_value (settings_iterator_t *);
 
 #endif /* not _GVM_SETTINGS_H */

--- a/base/strings.c
+++ b/base/strings.c
@@ -41,7 +41,7 @@
  * @param[in]  string  The string to append to the string in the variable.
  */
 void
-gvm_append_string (gchar ** var, const gchar * string)
+gvm_append_string (gchar **var, const gchar *string)
 {
   if (*var)
     {
@@ -71,7 +71,7 @@ gvm_append_string (gchar ** var, const gchar * string)
  * @param[in]  length  The length of string.
  */
 void
-gvm_append_text (gchar ** var, const gchar * string, gsize length)
+gvm_append_text (gchar **var, const gchar *string, gsize length)
 {
   if (*var)
     {
@@ -92,7 +92,7 @@ gvm_append_text (gchar ** var, const gchar * string, gsize length)
  *                  a string.
  */
 void
-gvm_free_string_var (gchar ** var)
+gvm_free_string_var (gchar **var)
 {
   g_free (*var);
   *var = NULL;

--- a/base/strings.h
+++ b/base/strings.h
@@ -27,10 +27,14 @@
 
 #include <glib.h>
 
-void gvm_append_string (gchar **, const gchar *);
-void gvm_append_text (gchar **, const gchar *, gsize);
-void gvm_free_string_var (gchar **);
+void
+gvm_append_string (gchar **, const gchar *);
+void
+gvm_append_text (gchar **, const gchar *, gsize);
+void
+gvm_free_string_var (gchar **);
 
-char *gvm_strip_space (char *, char *);
+char *
+gvm_strip_space (char *, char *);
 
 #endif /* not _GVM_STRINGS_H */

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -29,11 +29,11 @@
 
 #include "gmp.h"
 
-#include <errno.h>               /* for ERANGE, errno */
-#include <stdlib.h>              /* for NULL, strtol, atoi */
-#include <string.h>              /* for strlen, strdup */
-
 #include "../util/serverutils.h" /* for gvm_server_sendf, gvm_server_sendf_xml */
+
+#include <errno.h>  /* for ERANGE, errno */
+#include <stdlib.h> /* for NULL, strtol, atoi */
+#include <string.h> /* for strlen, strdup */
 
 #undef G_LOG_DOMAIN
 /**
@@ -41,14 +41,12 @@
  */
 #define G_LOG_DOMAIN "lib   gmp"
 
-#define GMP_FMT_BOOL_ATTRIB(var, attrib)            \
+#define GMP_FMT_BOOL_ATTRIB(var, attrib) \
   (var.attrib == 0 ? " " #attrib "=\"0\"" : " " #attrib "=\"1\"")
 
-#define GMP_FMT_STRING_ATTRIB(var, attrib) \
-  (var.attrib ? " " #attrib "= \"" : ""),  \
-  (var.attrib ? var.attrib : ""),          \
-  (var.attrib ? "\"" : "")
-
+#define GMP_FMT_STRING_ATTRIB(var, attrib)                                \
+  (var.attrib ? " " #attrib "= \"" : ""), (var.attrib ? var.attrib : ""), \
+    (var.attrib ? "\"" : "")
 
 /* GMP. */
 
@@ -60,14 +58,15 @@
  * @return The entity_text of the status entity if the entity is found, else
  *         NULL.
  */
-const char*
+const char *
 gmp_task_status (entity_t response)
 {
   entity_t task = entity_child (response, "task");
   if (task)
     {
       entity_t status = entity_child (task, "status");
-      if (status) return entity_text (status);
+      if (status)
+        return entity_text (status);
     }
   return NULL;
 }
@@ -81,15 +80,16 @@ gmp_task_status (entity_t response)
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_check_response (gnutls_session_t* session, entity_t *entity)
+gmp_check_response (gnutls_session_t *session, entity_t *entity)
 {
   int ret;
-  const char* status;
+  const char *status;
 
   /* Read the response. */
 
   *entity = NULL;
-  if (read_entity (session, entity)) return -1;
+  if (read_entity (session, entity))
+    return -1;
 
   /* Check the response. */
 
@@ -110,7 +110,8 @@ gmp_check_response (gnutls_session_t* session, entity_t *entity)
     }
   ret = (int) strtol (status, NULL, 10);
   free_entity (*entity);
-  if (errno == ERANGE) return -1;
+  if (errno == ERANGE)
+    return -1;
   return ret;
 }
 
@@ -128,7 +129,7 @@ int
 gmp_ping (gnutls_session_t *session, int timeout)
 {
   entity_t entity;
-  const char* status;
+  const char *status;
   char first;
   int ret;
 
@@ -143,12 +144,12 @@ gmp_ping (gnutls_session_t *session, int timeout)
   entity = NULL;
   switch (try_read_entity (session, timeout, &entity))
     {
-      case 0:
-        break;
-      case -4:
-        return 2;
-      default:
-        return -1;
+    case 0:
+      break;
+    case -4:
+      return 2;
+    default:
+      return -1;
     }
 
   /* Check the response. */
@@ -166,7 +167,8 @@ gmp_ping (gnutls_session_t *session, int timeout)
     }
   first = status[0];
   free_entity (entity);
-  if (first == '2') return 0;
+  if (first == '2')
+    return 0;
   return -1;
 }
 
@@ -186,7 +188,7 @@ int
 gmp_ping_c (gvm_connection_t *connection, int timeout, gchar **version)
 {
   entity_t entity;
-  const char* status;
+  const char *status;
   int ret;
 
   if (version && *version)
@@ -203,12 +205,12 @@ gmp_ping_c (gvm_connection_t *connection, int timeout, gchar **version)
   entity = NULL;
   switch (try_read_entity_c (connection, timeout, &entity))
     {
-      case 0:
-        break;
-      case -4:
-        return 2;
-      default:
-        return -1;
+    case 0:
+      break;
+    case -4:
+      return 2;
+    default:
+      return -1;
     }
 
   /* Check the response. */
@@ -255,9 +257,8 @@ gmp_ping_c (gvm_connection_t *connection, int timeout, gchar **version)
  *         -1 on error.
  */
 int
-gmp_authenticate (gnutls_session_t* session,
-                  const char* username,
-                  const char* password)
+gmp_authenticate (gnutls_session_t *session, const char *username,
+                  const char *password)
 {
   entity_t entity;
   int ret;
@@ -303,7 +304,7 @@ gmp_authenticate_info_ext (gnutls_session_t *session,
                            gmp_authenticate_info_opts_t opts)
 {
   entity_t entity;
-  const char* status;
+  const char *status;
   char first;
   int ret;
 
@@ -316,8 +317,7 @@ gmp_authenticate_info_ext (gnutls_session_t *session,
                                     "<username>%s</username>"
                                     "<password>%s</password>"
                                     "</credentials></authenticate>",
-                                    opts.username,
-                                    opts.password);
+                                    opts.username, opts.password);
   if (ret)
     return ret;
 
@@ -326,12 +326,12 @@ gmp_authenticate_info_ext (gnutls_session_t *session,
   entity = NULL;
   switch (try_read_entity (session, opts.timeout, &entity))
     {
-      case 0:
-        break;
-      case -4:
-        return 3;
-      default:
-        return -1;
+    case 0:
+      break;
+    case -4:
+      return 3;
+    default:
+      return -1;
     }
 
   /* Check the response. */
@@ -388,7 +388,7 @@ gmp_authenticate_info_ext_c (gvm_connection_t *connection,
                              gmp_authenticate_info_opts_t opts)
 {
   entity_t entity;
-  const char* status;
+  const char *status;
   char first;
   int ret;
 
@@ -404,8 +404,7 @@ gmp_authenticate_info_ext_c (gvm_connection_t *connection,
                                         "<password>%s</password>"
                                         "</credentials>"
                                         "</authenticate>",
-                                        opts.username,
-                                        opts.password);
+                                        opts.username, opts.password);
   if (ret)
     return ret;
 
@@ -414,12 +413,12 @@ gmp_authenticate_info_ext_c (gvm_connection_t *connection,
   entity = NULL;
   switch (try_read_entity_c (connection, opts.timeout, &entity))
     {
-      case 0:
-        break;
-      case -4:
-        return 3;
-      default:
-        return -1;
+    case 0:
+      break;
+    case -4:
+      return 3;
+    default:
+      return -1;
     }
 
   /* Check the response. */
@@ -480,9 +479,8 @@ gmp_authenticate_info_ext_c (gvm_connection_t *connection,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_create_task_ext (gnutls_session_t* session,
-                     gmp_create_task_opts_t opts,
-                     gchar** id)
+gmp_create_task_ext (gnutls_session_t *session, gmp_create_task_opts_t opts,
+                     gchar **id)
 {
   /* Create the GMP request. */
 
@@ -493,17 +491,15 @@ gmp_create_task_ext (gnutls_session_t* session,
     return -1;
 
   prefs = NULL;
-  start = g_markup_printf_escaped ("<create_task>"
-                                   "<config id=\"%s\"/>"
-                                   "<target id=\"%s\"/>"
-                                   "<name>%s</name>"
-                                   "<comment>%s</comment>"
-                                   "<alterable>%d</alterable>",
-                                   opts.config_id,
-                                   opts.target_id,
-                                   opts.name ? opts.name : "unnamed",
-                                   opts.comment ? opts.comment : "",
-                                   opts.alterable ? 1 : 0);
+  start = g_markup_printf_escaped (
+    "<create_task>"
+    "<config id=\"%s\"/>"
+    "<target id=\"%s\"/>"
+    "<name>%s</name>"
+    "<comment>%s</comment>"
+    "<alterable>%d</alterable>",
+    opts.config_id, opts.target_id, opts.name ? opts.name : "unnamed",
+    opts.comment ? opts.comment : "", opts.alterable ? 1 : 0);
 
   if (opts.hosts_ordering)
     hosts_ordering = g_strdup_printf ("<hosts_ordering>%s</hosts_ordering>",
@@ -512,22 +508,19 @@ gmp_create_task_ext (gnutls_session_t* session,
     hosts_ordering = NULL;
 
   if (opts.scanner_id)
-    scanner = g_strdup_printf ("<scanner id=\"%s\"/>",
-                               opts.scanner_id);
+    scanner = g_strdup_printf ("<scanner id=\"%s\"/>", opts.scanner_id);
   else
     scanner = NULL;
 
   if (opts.schedule_id)
     schedule = g_strdup_printf ("<schedule id=\"%s\"/>"
                                 "<schedule_periods>%d</schedule_periods>",
-                                opts.schedule_id,
-                                opts.schedule_periods);
+                                opts.schedule_id, opts.schedule_periods);
   else
     schedule = NULL;
 
   if (opts.slave_id)
-    slave = g_strdup_printf ("<slave id=\"%s\"/>",
-                             opts.slave_id);
+    slave = g_strdup_printf ("<slave id=\"%s\"/>", opts.slave_id);
   else
     slave = NULL;
 
@@ -550,25 +543,25 @@ gmp_create_task_ext (gnutls_session_t* session,
 
       if (opts.max_hosts)
         hosts = g_markup_printf_escaped ("<preference>"
-                                          "<scanner_name>"
-                                          "max_hosts"
-                                          "</scanner_name>"
-                                          "<value>"
-                                          "%s"
-                                          "</value>"
-                                          "</preference>",
-                                          opts.max_hosts);
-
-      if (opts.max_checks)
-        checks = g_markup_printf_escaped ("<preference>"
                                          "<scanner_name>"
-                                         "max_checks"
+                                         "max_hosts"
                                          "</scanner_name>"
                                          "<value>"
                                          "%s"
                                          "</value>"
                                          "</preference>",
-                                         opts.max_checks);
+                                         opts.max_hosts);
+
+      if (opts.max_checks)
+        checks = g_markup_printf_escaped ("<preference>"
+                                          "<scanner_name>"
+                                          "max_checks"
+                                          "</scanner_name>"
+                                          "<value>"
+                                          "%s"
+                                          "</value>"
+                                          "</preference>",
+                                          opts.max_checks);
 
       if (opts.source_iface)
         source_iface = g_markup_printf_escaped ("<preference>"
@@ -581,11 +574,10 @@ gmp_create_task_ext (gnutls_session_t* session,
                                                 "</preference>",
                                                 opts.source_iface);
 
-      prefs = g_strdup_printf ("<preferences>%s%s%s%s</preferences>",
-                               in_assets ? in_assets : "",
-                               checks ? checks : "",
-                               hosts ? hosts : "",
-                               source_iface ? source_iface : "");
+      prefs =
+        g_strdup_printf ("<preferences>%s%s%s%s</preferences>",
+                         in_assets ? in_assets : "", checks ? checks : "",
+                         hosts ? hosts : "", source_iface ? source_iface : "");
       g_free (in_assets);
       g_free (checks);
       g_free (hosts);
@@ -598,15 +590,12 @@ gmp_create_task_ext (gnutls_session_t* session,
       alerts = g_string_new ("");
       for (i = 0; i < opts.alert_ids->len; i++)
         {
-          char *alert = (char*)g_ptr_array_index (opts.alert_ids, i);
-          g_string_append_printf (alerts,
-                                  "<alert id=\"%s\"/>",
-                                  alert);
+          char *alert = (char *) g_ptr_array_index (opts.alert_ids, i);
+          g_string_append_printf (alerts, "<alert id=\"%s\"/>", alert);
         }
     }
   else
     alerts = g_string_new ("");
-
 
   if (opts.observers || opts.observer_groups)
     {
@@ -620,10 +609,9 @@ gmp_create_task_ext (gnutls_session_t* session,
           unsigned int i;
           for (i = 0; i < opts.observer_groups->len; i++)
             {
-              char *group = (char*) g_ptr_array_index (opts.observer_groups, i);
-              g_string_append_printf (observers,
-                                      "<group id=\"%s\"/>",
-                                      group);
+              char *group =
+                (char *) g_ptr_array_index (opts.observer_groups, i);
+              g_string_append_printf (observers, "<group id=\"%s\"/>", group);
             }
         }
       g_string_append (observers, "</observers>");
@@ -632,15 +620,11 @@ gmp_create_task_ext (gnutls_session_t* session,
     observers = g_string_new ("");
 
   /* Send the request. */
-  ret = gvm_server_sendf (session, "%s%s%s%s%s%s%s%s</create_task>",
-                          start,
-                          prefs ? prefs : "",
-                          hosts_ordering ? hosts_ordering : "",
-                          scanner ? scanner : "",
-                          schedule ? schedule : "",
-                          slave ? slave : "",
-                          alerts ? alerts->str : "",
-                          observers ? observers->str : "");
+  ret = gvm_server_sendf (
+    session, "%s%s%s%s%s%s%s%s</create_task>", start, prefs ? prefs : "",
+    hosts_ordering ? hosts_ordering : "", scanner ? scanner : "",
+    schedule ? schedule : "", slave ? slave : "", alerts ? alerts->str : "",
+    observers ? observers->str : "");
   g_free (start);
   g_free (prefs);
   g_free (hosts_ordering);
@@ -675,12 +659,9 @@ gmp_create_task_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_create_task (gnutls_session_t* session,
-                 const char* name,
-                 const char* config,
-                 const char* target,
-                 const char* comment,
-                 gchar** id)
+gmp_create_task (gnutls_session_t *session, const char *name,
+                 const char *config, const char *target, const char *comment,
+                 gchar **id)
 {
   int ret;
 
@@ -691,10 +672,7 @@ gmp_create_task (gnutls_session_t* session,
                               "<name>%s</name>"
                               "<comment>%s</comment>"
                               "</create_task>",
-                              config,
-                              target,
-                              name,
-                              comment);
+                              config, target, name, comment);
   if (ret)
     return -1;
 
@@ -716,15 +694,12 @@ gmp_create_task (gnutls_session_t* session,
  * @return 0 on success, 1 on failure, -1 on error.
  */
 int
-gmp_start_task_report (gnutls_session_t* session, const char* task_id,
-                       char** report_id)
+gmp_start_task_report (gnutls_session_t *session, const char *task_id,
+                       char **report_id)
 {
   int ret;
   entity_t entity;
-  if (gvm_server_sendf (session,
-                        "<start_task task_id=\"%s\"/>",
-                        task_id)
-      == -1)
+  if (gvm_server_sendf (session, "<start_task task_id=\"%s\"/>", task_id) == -1)
     return -1;
 
   /* Read the response. */
@@ -771,16 +746,15 @@ gmp_start_task_report_c (gvm_connection_t *connection, const char *task_id,
   const char *status;
   char first;
 
-  if (gvm_connection_sendf (connection,
-                            "<start_task task_id=\"%s\"/>",
-                            task_id)
+  if (gvm_connection_sendf (connection, "<start_task task_id=\"%s\"/>", task_id)
       == -1)
     return -1;
 
   /* Read the response. */
 
   entity = NULL;
-  if (read_entity_c (connection, &entity)) return -1;
+  if (read_entity_c (connection, &entity))
+    return -1;
 
   /* Check the response. */
 
@@ -827,13 +801,14 @@ int
 gmp_check_response_c (gvm_connection_t *connection)
 {
   int ret;
-  const char* status;
+  const char *status;
   entity_t entity;
 
   /* Read the response. */
 
   entity = NULL;
-  if (read_entity_c (connection, &entity)) return -1;
+  if (read_entity_c (connection, &entity))
+    return -1;
 
   /* Check the response. */
 
@@ -855,7 +830,8 @@ gmp_check_response_c (gvm_connection_t *connection)
     }
   ret = (int) strtol (status, NULL, 10);
   free_entity (entity);
-  if (errno == ERANGE) return -1;
+  if (errno == ERANGE)
+    return -1;
   return ret;
 }
 
@@ -869,7 +845,7 @@ gmp_check_response_c (gvm_connection_t *connection)
  * @return GMP response code on success, -1 on error.
  */
 int
-gmp_read_create_response (gnutls_session_t* session, gchar **uuid)
+gmp_read_create_response (gnutls_session_t *session, gchar **uuid)
 {
   int ret;
   const char *status;
@@ -878,7 +854,8 @@ gmp_read_create_response (gnutls_session_t* session, gchar **uuid)
   /* Read the response. */
 
   entity = NULL;
-  if (read_entity (session, &entity)) return -1;
+  if (read_entity (session, &entity))
+    return -1;
 
   /* Parse the response. */
 
@@ -926,15 +903,12 @@ gmp_read_create_response (gnutls_session_t* session, gchar **uuid)
  * @return 0 on success, GMP response code on failure, -1 on error.
  */
 int
-gmp_stop_task (gnutls_session_t* session, const char* id)
+gmp_stop_task (gnutls_session_t *session, const char *id)
 {
   entity_t entity;
   int ret;
 
-  if (gvm_server_sendf (session,
-                        "<stop_task task_id=\"%s\"/>",
-                        id)
-      == -1)
+  if (gvm_server_sendf (session, "<stop_task task_id=\"%s\"/>", id) == -1)
     return -1;
 
   entity = NULL;
@@ -953,11 +927,9 @@ gmp_stop_task (gnutls_session_t* session, const char* id)
  * @return 0 on success, GMP response code on failure, -1 on error.
  */
 int
-gmp_stop_task_c (gvm_connection_t *connection, const char* id)
+gmp_stop_task_c (gvm_connection_t *connection, const char *id)
 {
-  if (gvm_connection_sendf (connection,
-                            "<stop_task task_id=\"%s\"/>",
-                            id)
+  if (gvm_connection_sendf (connection, "<stop_task task_id=\"%s\"/>", id)
       == -1)
     return -1;
 
@@ -974,14 +946,12 @@ gmp_stop_task_c (gvm_connection_t *connection, const char* id)
  * @return 0 on success, 1 on GMP failure, -1 on error.
  */
 int
-gmp_resume_task_report (gnutls_session_t* session, const char* task_id,
-                        char** report_id)
+gmp_resume_task_report (gnutls_session_t *session, const char *task_id,
+                        char **report_id)
 {
   int ret;
   entity_t entity;
-  if (gvm_server_sendf (session,
-                        "<resume_task task_id=\"%s\"/>",
-                        task_id)
+  if (gvm_server_sendf (session, "<resume_task task_id=\"%s\"/>", task_id)
       == -1)
     return -1;
 
@@ -1021,11 +991,10 @@ gmp_resume_task_report (gnutls_session_t* session, const char* task_id,
  * @return 0 on success, 1 on GMP failure, -1 on error.
  */
 int
-gmp_resume_task_report_c (gvm_connection_t *connection, const char* task_id,
-                          char** report_id)
+gmp_resume_task_report_c (gvm_connection_t *connection, const char *task_id,
+                          char **report_id)
 {
-  if (gvm_connection_sendf (connection,
-                            "<resume_task task_id=\"%s\"/>",
+  if (gvm_connection_sendf (connection, "<resume_task task_id=\"%s\"/>",
                             task_id)
       == -1)
     return -1;
@@ -1033,11 +1002,12 @@ gmp_resume_task_report_c (gvm_connection_t *connection, const char* task_id,
   /* Read the response. */
 
   entity_t entity = NULL;
-  if (read_entity_c (connection, &entity)) return -1;
+  if (read_entity_c (connection, &entity))
+    return -1;
 
   /* Check the response. */
 
-  const char* status = entity_attribute (entity, "status");
+  const char *status = entity_attribute (entity, "status");
   if (status == NULL)
     {
       free_entity (entity);
@@ -1079,15 +1049,15 @@ gmp_resume_task_report_c (gvm_connection_t *connection, const char* task_id,
  * @return 0 on success, GMP response code on failure, -1 on error.
  */
 int
-gmp_delete_task_ext (gnutls_session_t* session, const char* id,
+gmp_delete_task_ext (gnutls_session_t *session, const char *id,
                      gmp_delete_opts_t opts)
 {
   entity_t entity;
   int ret;
 
   if (gvm_server_sendf (session,
-                        "<delete_task task_id=\"%s\" ultimate=\"%d\"/>",
-                        id, opts.ultimate)
+                        "<delete_task task_id=\"%s\" ultimate=\"%d\"/>", id,
+                        opts.ultimate)
       == -1)
     return -1;
 
@@ -1111,15 +1081,13 @@ gmp_delete_task_ext (gnutls_session_t* session, const char* id,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_get_tasks (gnutls_session_t* session, const char* id, int details,
-               int include_rcfile, entity_t* status)
+gmp_get_tasks (gnutls_session_t *session, const char *id, int details,
+               int include_rcfile, entity_t *status)
 {
   (void) include_rcfile;
   if (id == NULL)
     {
-      if (gvm_server_sendf (session,
-                            "<get_tasks details=\"%i\"/>",
-                            details)
+      if (gvm_server_sendf (session, "<get_tasks details=\"%i\"/>", details)
           == -1)
         return -1;
     }
@@ -1129,15 +1097,13 @@ gmp_get_tasks (gnutls_session_t* session, const char* id, int details,
                             "<get_tasks"
                             " task_id=\"%s\""
                             " details=\"%i\"/>",
-                            id,
-                            details)
+                            id, details)
           == -1)
         return -1;
     }
 
   /* Read the response. */
   return gmp_check_response (session, status);
-
 }
 
 /**
@@ -1150,9 +1116,8 @@ gmp_get_tasks (gnutls_session_t* session, const char* id, int details,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_get_task_ext (gnutls_session_t* session,
-                  gmp_get_task_opts_t opts,
-                  entity_t* response)
+gmp_get_task_ext (gnutls_session_t *session, gmp_get_task_opts_t opts,
+                  entity_t *response)
 {
   if ((response == NULL) || (opts.task_id == NULL))
     return -1;
@@ -1164,8 +1129,7 @@ gmp_get_task_ext (gnutls_session_t* session,
                             " task_id=\"%s\""
                             " actions=\"%s\""
                             "%s/>",
-                            opts.task_id,
-                            opts.actions,
+                            opts.task_id, opts.actions,
                             GMP_FMT_BOOL_ATTRIB (opts, details)))
         return -1;
     }
@@ -1173,8 +1137,7 @@ gmp_get_task_ext (gnutls_session_t* session,
                              "<get_tasks"
                              " task_id=\"%s\""
                              "%s/>",
-                             opts.task_id,
-                             GMP_FMT_BOOL_ATTRIB (opts, details)))
+                             opts.task_id, GMP_FMT_BOOL_ATTRIB (opts, details)))
     return -1;
 
   return gmp_check_response (session, response);
@@ -1190,9 +1153,8 @@ gmp_get_task_ext (gnutls_session_t* session,
  * @return 0 on success, 2 on timeout, -1 or GMP response code on error.
  */
 int
-gmp_get_tasks_ext (gnutls_session_t* session,
-                   gmp_get_tasks_opts_t opts,
-                   entity_t* response)
+gmp_get_tasks_ext (gnutls_session_t *session, gmp_get_tasks_opts_t opts,
+                   entity_t *response)
 {
   int ret;
   const char *status_code;
@@ -1205,9 +1167,7 @@ gmp_get_tasks_ext (gnutls_session_t* session,
                                  " filter=\"%s\"",
                                  opts.filter);
 
-  if (gvm_server_sendf (session,
-                        "%s%s/>",
-                        cmd,
+  if (gvm_server_sendf (session, "%s%s/>", cmd,
                         GMP_FMT_BOOL_ATTRIB (opts, details)))
     {
       g_free (cmd);
@@ -1218,12 +1178,12 @@ gmp_get_tasks_ext (gnutls_session_t* session,
   *response = NULL;
   switch (try_read_entity (session, opts.timeout, response))
     {
-      case 0:
-        break;
-      case -4:
-        return 2;
-      default:
-        return -1;
+    case 0:
+      break;
+    case -4:
+      return 2;
+    default:
+      return -1;
     }
 
   /* Check the response. */
@@ -1239,10 +1199,12 @@ gmp_get_tasks_ext (gnutls_session_t* session,
       free_entity (*response);
       return -1;
     }
-  if (status_code[0] == '2') return 0;
+  if (status_code[0] == '2')
+    return 0;
   ret = (int) strtol (status_code, NULL, 10);
   free_entity (*response);
-  if (errno == ERANGE) return -1;
+  if (errno == ERANGE)
+    return -1;
   return ret;
 }
 
@@ -1258,9 +1220,8 @@ gmp_get_tasks_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_modify_task_file (gnutls_session_t* session, const char* id,
-                      const char* name, const void* content,
-                      gsize content_len)
+gmp_modify_task_file (gnutls_session_t *session, const char *id,
+                      const char *name, const void *content, gsize content_len)
 {
   entity_t entity;
   int ret;
@@ -1279,13 +1240,12 @@ gmp_modify_task_file (gnutls_session_t* session, const char* id,
 
       if (content_len)
         {
-          gchar *base64_content = g_base64_encode ((guchar*) content,
-                                                   content_len);
-          int ret = gvm_server_sendf (session,
-                                      "%s",
-                                      base64_content);
+          gchar *base64_content =
+            g_base64_encode ((guchar *) content, content_len);
+          int ret = gvm_server_sendf (session, "%s", base64_content);
           g_free (base64_content);
-          if (ret) return -1;
+          if (ret)
+            return -1;
         }
 
       if (gvm_server_sendf (session, "</file>"))
@@ -1293,8 +1253,7 @@ gmp_modify_task_file (gnutls_session_t* session, const char* id,
     }
   else
     {
-      if (gvm_server_sendf (session,
-                            "<file name=\"%s\" action=\"remove\" />",
+      if (gvm_server_sendf (session, "<file name=\"%s\" action=\"remove\" />",
                             name))
         return -1;
     }
@@ -1318,7 +1277,7 @@ gmp_modify_task_file (gnutls_session_t* session, const char* id,
  * @return 0 on success, GMP response code on failure, -1 on error.
  */
 int
-gmp_delete_task (gnutls_session_t* session, const char* id)
+gmp_delete_task (gnutls_session_t *session, const char *id)
 {
   entity_t entity;
   int ret;
@@ -1346,15 +1305,13 @@ gmp_delete_task (gnutls_session_t* session, const char* id)
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_get_targets (gnutls_session_t* session, const char* id, int tasks,
-                 int include_rcfile, entity_t* target)
+gmp_get_targets (gnutls_session_t *session, const char *id, int tasks,
+                 int include_rcfile, entity_t *target)
 {
   (void) include_rcfile;
   if (id == NULL)
     {
-      if (gvm_server_sendf (session,
-                            "<get_targets tasks=\"%i\"/>",
-                            tasks)
+      if (gvm_server_sendf (session, "<get_targets tasks=\"%i\"/>", tasks)
           == -1)
         return -1;
     }
@@ -1364,8 +1321,7 @@ gmp_get_targets (gnutls_session_t* session, const char* id, int tasks,
                             "<get_targets"
                             " target_id=\"%s\""
                             " tasks=\"%i\"/>",
-                            id,
-                            tasks)
+                            id, tasks)
           == -1)
         return -1;
     }
@@ -1387,9 +1343,8 @@ gmp_get_targets (gnutls_session_t* session, const char* id, int tasks,
  * @return 0 on success, 2 on timeout, -1 or GMP response code on error.
  */
 int
-gmp_get_report_ext (gnutls_session_t* session,
-                    gmp_get_report_opts_t opts,
-                    entity_t* response)
+gmp_get_report_ext (gnutls_session_t *session, gmp_get_report_opts_t opts,
+                    entity_t *response)
 {
   int ret;
   const char *status_code;
@@ -1397,63 +1352,60 @@ gmp_get_report_ext (gnutls_session_t* session,
   if (response == NULL)
     return -1;
 
-  if (gvm_server_sendf (session,
-                        "<get_reports"
-                        " report_id=\"%s\""
-                        " format_id=\"%s\""
-                        " host_first_result=\"%i\""
-                        " host_max_results=\"%i\""
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s"
-                        "%s%s%s%s%s%s%s/>",
-                        opts.report_id,
-                        opts.format_id,
-                        opts.host_first_result,
-                        opts.host_max_results,
-                        GMP_FMT_STRING_ATTRIB (opts, type),
-                        GMP_FMT_STRING_ATTRIB (opts, filter),
-                        GMP_FMT_STRING_ATTRIB (opts, filt_id),
-                        GMP_FMT_STRING_ATTRIB (opts, host),
-                        GMP_FMT_STRING_ATTRIB (opts, pos),
-                        GMP_FMT_STRING_ATTRIB (opts, timezone),
-                        GMP_FMT_STRING_ATTRIB (opts, alert_id),
-                        GMP_FMT_STRING_ATTRIB (opts, delta_report_id),
-                        GMP_FMT_STRING_ATTRIB (opts, delta_states),
-                        GMP_FMT_STRING_ATTRIB (opts, host_levels),
-                        GMP_FMT_STRING_ATTRIB (opts, search_phrase),
-                        GMP_FMT_STRING_ATTRIB (opts, host_search_phrase),
-                        GMP_FMT_STRING_ATTRIB (opts, min_cvss_base),
-                        GMP_FMT_STRING_ATTRIB (opts, min_qod),
-                        GMP_FMT_BOOL_ATTRIB (opts, notes),
-                        GMP_FMT_BOOL_ATTRIB (opts, notes_details),
-                        GMP_FMT_BOOL_ATTRIB (opts, overrides),
-                        GMP_FMT_BOOL_ATTRIB (opts, override_details),
-                        GMP_FMT_BOOL_ATTRIB (opts, apply_overrides),
-                        GMP_FMT_BOOL_ATTRIB (opts, result_hosts_only),
-                        GMP_FMT_BOOL_ATTRIB (opts, ignore_pagination)))
+  if (gvm_server_sendf (
+        session,
+        "<get_reports"
+        " report_id=\"%s\""
+        " format_id=\"%s\""
+        " host_first_result=\"%i\""
+        " host_max_results=\"%i\""
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s"
+        "%s%s%s%s%s%s%s/>",
+        opts.report_id, opts.format_id, opts.host_first_result,
+        opts.host_max_results, GMP_FMT_STRING_ATTRIB (opts, type),
+        GMP_FMT_STRING_ATTRIB (opts, filter),
+        GMP_FMT_STRING_ATTRIB (opts, filt_id),
+        GMP_FMT_STRING_ATTRIB (opts, host), GMP_FMT_STRING_ATTRIB (opts, pos),
+        GMP_FMT_STRING_ATTRIB (opts, timezone),
+        GMP_FMT_STRING_ATTRIB (opts, alert_id),
+        GMP_FMT_STRING_ATTRIB (opts, delta_report_id),
+        GMP_FMT_STRING_ATTRIB (opts, delta_states),
+        GMP_FMT_STRING_ATTRIB (opts, host_levels),
+        GMP_FMT_STRING_ATTRIB (opts, search_phrase),
+        GMP_FMT_STRING_ATTRIB (opts, host_search_phrase),
+        GMP_FMT_STRING_ATTRIB (opts, min_cvss_base),
+        GMP_FMT_STRING_ATTRIB (opts, min_qod),
+        GMP_FMT_BOOL_ATTRIB (opts, notes),
+        GMP_FMT_BOOL_ATTRIB (opts, notes_details),
+        GMP_FMT_BOOL_ATTRIB (opts, overrides),
+        GMP_FMT_BOOL_ATTRIB (opts, override_details),
+        GMP_FMT_BOOL_ATTRIB (opts, apply_overrides),
+        GMP_FMT_BOOL_ATTRIB (opts, result_hosts_only),
+        GMP_FMT_BOOL_ATTRIB (opts, ignore_pagination)))
     return -1;
 
   *response = NULL;
   switch (try_read_entity (session, opts.timeout, response))
     {
-      case 0:
-        break;
-      case -4:
-        return 2;
-      default:
-        return -1;
+    case 0:
+      break;
+    case -4:
+      return 2;
+    default:
+      return -1;
     }
 
   /* Check the response. */
@@ -1469,10 +1421,12 @@ gmp_get_report_ext (gnutls_session_t* session,
       free_entity (*response);
       return -1;
     }
-  if (status_code[0] == '2') return 0;
+  if (status_code[0] == '2')
+    return 0;
   ret = (int) strtol (status_code, NULL, 10);
   free_entity (*response);
-  if (errno == ERANGE) return -1;
+  if (errno == ERANGE)
+    return -1;
   return ret;
 }
 
@@ -1486,16 +1440,15 @@ gmp_get_report_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_delete_port_list_ext (gnutls_session_t* session,
-                          const char* id,
+gmp_delete_port_list_ext (gnutls_session_t *session, const char *id,
                           gmp_delete_opts_t opts)
 {
   entity_t entity;
   int ret;
 
-  if (gvm_server_sendf (session,
-                        "<delete_port_list port_list_id=\"%s\" ultimate=\"%d\"/>",
-                        id, opts.ultimate)
+  if (gvm_server_sendf (
+        session, "<delete_port_list port_list_id=\"%s\" ultimate=\"%d\"/>", id,
+        opts.ultimate)
       == -1)
     return -1;
 
@@ -1545,9 +1498,8 @@ gmp_delete_report (gnutls_session_t *session, const char *id)
  *         GMP error, -1 other error.
  */
 int
-gmp_create_target_ext (gnutls_session_t* session,
-                       gmp_create_target_opts_t opts,
-                       gchar** id)
+gmp_create_target_ext (gnutls_session_t *session, gmp_create_target_opts_t opts,
+                       gchar **id)
 {
   gchar *comment, *ssh, *smb, *esxi, *snmp, *port_range, *start;
   gchar *exclude_hosts, *alive_tests;
@@ -1558,11 +1510,11 @@ gmp_create_target_ext (gnutls_session_t* session,
   if (opts.hosts == NULL)
     return -1;
 
-  start = g_markup_printf_escaped ("<create_target>"
-                                   "<name>%s</name>"
-                                   "<hosts>%s</hosts>",
-                                   opts.name ? opts.name : "unnamed",
-                                   opts.hosts);
+  start =
+    g_markup_printf_escaped ("<create_target>"
+                             "<name>%s</name>"
+                             "<hosts>%s</hosts>",
+                             opts.name ? opts.name : "unnamed", opts.hosts);
 
   if (opts.exclude_hosts)
     exclude_hosts = g_markup_printf_escaped ("<exclude_hosts>"
@@ -1584,7 +1536,7 @@ gmp_create_target_ext (gnutls_session_t* session,
     comment = g_markup_printf_escaped ("<comment>"
                                        "%s"
                                        "</comment>",
-                                      opts.comment);
+                                       opts.comment);
   else
     comment = NULL;
 
@@ -1622,8 +1574,8 @@ gmp_create_target_ext (gnutls_session_t* session,
     snmp = NULL;
 
   if (opts.port_range)
-    port_range = g_markup_printf_escaped ("<port_range>%s</port_range>",
-                                          opts.port_range);
+    port_range =
+      g_markup_printf_escaped ("<port_range>%s</port_range>", opts.port_range);
   else
     port_range = NULL;
 
@@ -1633,17 +1585,11 @@ gmp_create_target_ext (gnutls_session_t* session,
                           "<reverse_lookup_only>%d</reverse_lookup_only>"
                           "<reverse_lookup_unify>%d</reverse_lookup_unify>"
                           "</create_target>",
-                          start,
-                          exclude_hosts ? exclude_hosts : "",
-                          alive_tests ? alive_tests : "",
-                          ssh ? ssh : "",
-                          smb ? smb : "",
-                          esxi ? esxi : "",
-                          snmp ? snmp : "",
-                          port_range ? port_range : "",
-                          comment ? comment : "",
-                          opts.reverse_lookup_only,
-                          opts.reverse_lookup_unify);
+                          start, exclude_hosts ? exclude_hosts : "",
+                          alive_tests ? alive_tests : "", ssh ? ssh : "",
+                          smb ? smb : "", esxi ? esxi : "", snmp ? snmp : "",
+                          port_range ? port_range : "", comment ? comment : "",
+                          opts.reverse_lookup_only, opts.reverse_lookup_unify);
   g_free (start);
   g_free (exclude_hosts);
   g_free (alive_tests);
@@ -1673,16 +1619,15 @@ gmp_create_target_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_delete_target_ext (gnutls_session_t* session,
-                       const char* id,
+gmp_delete_target_ext (gnutls_session_t *session, const char *id,
                        gmp_delete_opts_t opts)
 {
   entity_t entity;
   int ret;
 
   if (gvm_server_sendf (session,
-                        "<delete_target target_id=\"%s\" ultimate=\"%d\"/>",
-                        id, opts.ultimate)
+                        "<delete_target target_id=\"%s\" ultimate=\"%d\"/>", id,
+                        opts.ultimate)
       == -1)
     return -1;
 
@@ -1703,16 +1648,15 @@ gmp_delete_target_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_delete_config_ext (gnutls_session_t* session,
-                       const char* id,
+gmp_delete_config_ext (gnutls_session_t *session, const char *id,
                        gmp_delete_opts_t opts)
 {
   entity_t entity;
   int ret;
 
   if (gvm_server_sendf (session,
-                        "<delete_config config_id=\"%s\" ultimate=\"%d\"/>",
-                        id, opts.ultimate)
+                        "<delete_config config_id=\"%s\" ultimate=\"%d\"/>", id,
+                        opts.ultimate)
       == -1)
     return -1;
 
@@ -1736,12 +1680,9 @@ gmp_delete_config_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_create_lsc_credential (gnutls_session_t* session,
-                           const char* name,
-                           const char* login,
-                           const char* password,
-                           const char* comment,
-                           gchar** uuid)
+gmp_create_lsc_credential (gnutls_session_t *session, const char *name,
+                           const char *login, const char *password,
+                           const char *comment, gchar **uuid)
 {
   int ret;
 
@@ -1755,10 +1696,7 @@ gmp_create_lsc_credential (gnutls_session_t* session,
                                           "<password>%s</password>"
                                           "<comment>%s</comment>"
                                           "</create_credential>",
-                                          name,
-                                          login,
-                                          password,
-                                          comment);
+                                          name, login, password, comment);
       else
         ret = gvm_server_sendf_xml_quiet (session,
                                           "<create_credential>"
@@ -1766,9 +1704,7 @@ gmp_create_lsc_credential (gnutls_session_t* session,
                                           "<login>%s</login>"
                                           "<password>%s</password>"
                                           "</create_credential>",
-                                          name,
-                                          login,
-                                          password);
+                                          name, login, password);
     }
   else
     {
@@ -1779,17 +1715,14 @@ gmp_create_lsc_credential (gnutls_session_t* session,
                                     "<login>%s</login>"
                                     "<comment>%s</comment>"
                                     "</create_credential>",
-                                    name,
-                                    login,
-                                    comment);
+                                    name, login, comment);
       else
         ret = gvm_server_sendf_xml (session,
                                     "<create_credential>"
                                     "<name>%s</name>"
                                     "<login>%s</login>"
                                     "</create_credential>",
-                                    name,
-                                    login);
+                                    name, login);
     }
   if (ret)
     return -1;
@@ -1815,12 +1748,9 @@ gmp_create_lsc_credential (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_create_lsc_credential_key (gnutls_session_t *session,
-                               const char *name,
-                               const char *login,
-                               const char *passphrase,
-                               const char *private_key,
-                               const char *comment,
+gmp_create_lsc_credential_key (gnutls_session_t *session, const char *name,
+                               const char *login, const char *passphrase,
+                               const char *private_key, const char *comment,
                                gchar **uuid)
 {
   int ret;
@@ -1836,11 +1766,8 @@ gmp_create_lsc_credential_key (gnutls_session_t *session,
                                 "</key>"
                                 "<comment>%s</comment>"
                                 "</create_credential>",
-                                name,
-                                login,
-                                passphrase ? passphrase : "",
-                                private_key,
-                                comment);
+                                name, login, passphrase ? passphrase : "",
+                                private_key, comment);
   else
     ret = gvm_server_sendf_xml (session,
                                 "<create_credential>"
@@ -1851,9 +1778,7 @@ gmp_create_lsc_credential_key (gnutls_session_t *session,
                                 "<private>%s</private>"
                                 "</key>"
                                 "</create_credential>",
-                                name,
-                                login,
-                                passphrase ? passphrase : "",
+                                name, login, passphrase ? passphrase : "",
                                 private_key);
 
   if (ret)
@@ -1876,9 +1801,9 @@ gmp_create_lsc_credential_key (gnutls_session_t *session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_create_lsc_credential_ext (gnutls_session_t* session,
+gmp_create_lsc_credential_ext (gnutls_session_t *session,
                                gmp_create_lsc_credential_opts_t opts,
-                               gchar** id)
+                               gchar **id)
 {
   gchar *comment, *pass, *start, *snmp_elems;
   int ret;
@@ -1888,17 +1813,17 @@ gmp_create_lsc_credential_ext (gnutls_session_t* session,
   if (opts.login == NULL)
     return -1;
 
-  start = g_markup_printf_escaped ("<create_credential>"
-                                   "<name>%s</name>"
-                                   "<login>%s</login>",
-                                   opts.name ? opts.name : "unnamed",
-                                   opts.login);
+  start =
+    g_markup_printf_escaped ("<create_credential>"
+                             "<name>%s</name>"
+                             "<login>%s</login>",
+                             opts.name ? opts.name : "unnamed", opts.login);
 
   if (opts.comment)
     comment = g_markup_printf_escaped ("<comment>"
                                        "%s"
                                        "</comment>",
-                                      opts.comment);
+                                       opts.comment);
   else
     comment = NULL;
 
@@ -1922,30 +1847,26 @@ gmp_create_lsc_credential_ext (gnutls_session_t* session,
 
   if (opts.community && opts.auth_algorithm && opts.privacy_password
       && opts.privacy_algorithm)
-    snmp_elems = g_markup_printf_escaped ("<community>"
-                                          "%s"
-                                          "</community>"
-                                          "<auth_algorithm>"
-                                          "%s"
-                                          "</auth_algorithm>"
-                                          "<privacy>"
-                                          "<password>%s</password>"
-                                          "<algorithm>%s</algorithm>"
-                                          "</privacy>",
-                                          opts.community,
-                                          opts.auth_algorithm,
-                                          opts.privacy_password,
-                                          opts.privacy_algorithm);
+    snmp_elems =
+      g_markup_printf_escaped ("<community>"
+                               "%s"
+                               "</community>"
+                               "<auth_algorithm>"
+                               "%s"
+                               "</auth_algorithm>"
+                               "<privacy>"
+                               "<password>%s</password>"
+                               "<algorithm>%s</algorithm>"
+                               "</privacy>",
+                               opts.community, opts.auth_algorithm,
+                               opts.privacy_password, opts.privacy_algorithm);
   else
     snmp_elems = NULL;
 
   /* Send the request. */
 
-  ret = gvm_server_sendf (session,
-                          "%s%s%s%s</create_credential>",
-                          start,
-                          comment ? comment : "",
-                          pass ? pass : "",
+  ret = gvm_server_sendf (session, "%s%s%s%s</create_credential>", start,
+                          comment ? comment : "", pass ? pass : "",
                           snmp_elems ? snmp_elems : "");
 
   g_free (start);
@@ -1972,8 +1893,7 @@ gmp_create_lsc_credential_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_delete_lsc_credential_ext (gnutls_session_t* session,
-                               const char* id,
+gmp_delete_lsc_credential_ext (gnutls_session_t *session, const char *id,
                                gmp_delete_opts_t opts)
 {
   entity_t entity;
@@ -2005,20 +1925,18 @@ gmp_delete_lsc_credential_ext (gnutls_session_t* session,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_get_system_reports (gnutls_session_t* session, const char* name, int brief,
+gmp_get_system_reports (gnutls_session_t *session, const char *name, int brief,
                         entity_t *reports)
 {
   if (name)
     {
       if (gvm_server_sendf (session,
                             "<get_system_reports name=\"%s\" brief=\"%i\"/>",
-                            name,
-                            brief)
+                            name, brief)
           == -1)
         return -1;
     }
-  else if (gvm_server_sendf (session,
-                             "<get_system_reports brief=\"%i\"/>",
+  else if (gvm_server_sendf (session, "<get_system_reports brief=\"%i\"/>",
                              brief)
            == -1)
     return -1;
@@ -2038,7 +1956,7 @@ gmp_get_system_reports (gnutls_session_t* session, const char* name, int brief,
  * @return 0 on success, -1 or GMP response code on error.
  */
 int
-gmp_get_system_reports_ext (gnutls_session_t* session,
+gmp_get_system_reports_ext (gnutls_session_t *session,
                             gmp_get_system_reports_opts_t opts,
                             entity_t *reports)
 {

--- a/gmp/gmp.h
+++ b/gmp/gmp.h
@@ -25,14 +25,14 @@
 #ifndef _GVM_GMP_H
 #define _GVM_GMP_H
 
-#include <glib.h>                /* for gchar */
-#include <glib/gtypes.h>         /* for gsize */
-#include <gnutls/gnutls.h>       /* for gnutls_session_t */
-#include <stddef.h>              /* for NULL */
-
 #include "../base/array.h"       /* for array_t */
 #include "../util/serverutils.h" /* for gvm_connection_t */
 #include "../util/xmlutils.h"    /* for entity_t */
+
+#include <glib.h>          /* for gchar */
+#include <glib/gtypes.h>   /* for gsize */
+#include <gnutls/gnutls.h> /* for gnutls_session_t */
+#include <stddef.h>        /* for NULL */
 
 /**
  * @brief Struct holding options for authentication.
@@ -52,197 +52,224 @@ typedef struct
  * @brief Sensible default values for gmp_authenticate_info_opts_t
  */
 static const gmp_authenticate_info_opts_t gmp_authenticate_info_opts_defaults =
-  { 0, NULL, NULL, NULL, NULL, NULL, NULL };
+  {0, NULL, NULL, NULL, NULL, NULL, NULL};
 
 /**
  * @brief Struct holding options for gmp get_report command.
  */
 typedef struct
 {
-  const char* sort_field;
-  const char* sort_order;
-  const char* format_id;   ///< ID of required report format.
-  const char* levels;      ///< Result levels to include.
-  const char* report_id;   ///< ID of single report to get.
-  int first_result;        ///< First result to get.
-  int max_results;         ///< Maximum number of results to return.
-  int timeout;             ///< Timeout for GMP response.
-  int host_first_result;   ///< Skip over results before this result number.
-  int host_max_results;    ///< Maximum number of results to return.
-  int autofp;              ///< Whether to trust vendor security updates. 0 No, 1 full match, 2 partial.
-  char *type;              ///< Type of report.
-  char *filter;            ///< Term to filter results.
-  char *filt_id;           ///< ID of filter, to filter results.
-  char *host;              ///< Host for asset report.
-  char *pos;               ///< Position of report from end.
-  char *timezone;          ///< Timezone.
-  char *alert_id;          ///< ID of alert.
-  char *delta_report_id;   ///< ID of report to compare single report to.
-  char *delta_states;      ///< Delta states (Changed Gone New Same) to include.
-  char *host_levels;       ///< Letter encoded threat level filter, for hosts.
-  char *search_phrase;     ///< Search phrase result filter.
-  char *host_search_phrase;///< Search phrase result filter.
-  char *min_cvss_base;     ///< Minimum CVSS base filter.
-  char *min_qod;           ///< Minimum QoD filter.
+  const char *sort_field;
+  const char *sort_order;
+  const char *format_id; ///< ID of required report format.
+  const char *levels;    ///< Result levels to include.
+  const char *report_id; ///< ID of single report to get.
+  int first_result;      ///< First result to get.
+  int max_results;       ///< Maximum number of results to return.
+  int timeout;           ///< Timeout for GMP response.
+  int host_first_result; ///< Skip over results before this result number.
+  int host_max_results;  ///< Maximum number of results to return.
+  int autofp; ///< Whether to trust vendor security updates. 0 No, 1 full match,
+              ///< 2 partial.
+  char *type; ///< Type of report.
+  char *filter;          ///< Term to filter results.
+  char *filt_id;         ///< ID of filter, to filter results.
+  char *host;            ///< Host for asset report.
+  char *pos;             ///< Position of report from end.
+  char *timezone;        ///< Timezone.
+  char *alert_id;        ///< ID of alert.
+  char *delta_report_id; ///< ID of report to compare single report to.
+  char *delta_states;    ///< Delta states (Changed Gone New Same) to include.
+  char *host_levels;     ///< Letter encoded threat level filter, for hosts.
+  char *search_phrase;   ///< Search phrase result filter.
+  char *host_search_phrase; ///< Search phrase result filter.
+  char *min_cvss_base;      ///< Minimum CVSS base filter.
+  char *min_qod;            ///< Minimum QoD filter.
   /* Boolean flags: */
-  int notes;               ///< Whether to include associated notes.
-  int notes_details;       ///< Whether to include details of above.
-  int overrides;           ///< Whether to include overrides in the report.
-  int override_details;    ///< If overrides, whether to include details.
-  int apply_overrides;     ///< Whether overrides are applied.
-  int result_hosts_only;   ///< Whether to include only hosts that have results.
-  int ignore_pagination;   ///< Whether to ignore pagination filters.
+  int notes;             ///< Whether to include associated notes.
+  int notes_details;     ///< Whether to include details of above.
+  int overrides;         ///< Whether to include overrides in the report.
+  int override_details;  ///< If overrides, whether to include details.
+  int apply_overrides;   ///< Whether overrides are applied.
+  int result_hosts_only; ///< Whether to include only hosts that have results.
+  int ignore_pagination; ///< Whether to ignore pagination filters.
 } gmp_get_report_opts_t;
 
 /**
  * @brief Sensible default values for gmp_get_report_opts_t.
  */
-static const gmp_get_report_opts_t gmp_get_report_opts_defaults =
-  {
-    "ROWID", "ascending", "a994b278-1f62-11e1-96ac-406186ea4fc5", "hmlgd",
-    NULL, 1, -1, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 0, 0, 0
-  };
+static const gmp_get_report_opts_t gmp_get_report_opts_defaults = {
+  "ROWID",
+  "ascending",
+  "a994b278-1f62-11e1-96ac-406186ea4fc5",
+  "hmlgd",
+  NULL,
+  1,
+  -1,
+  0,
+  0,
+  0,
+  0,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0};
 
 /**
  * @brief Struct holding options for gmp get_tasks command.
  */
 typedef struct
 {
-  const char* filter;    ///< Filter argument.
-  int timeout;           ///< Timeout for GMP response.
-  const char* actions;   ///< Actions argument.
+  const char *filter;  ///< Filter argument.
+  int timeout;         ///< Timeout for GMP response.
+  const char *actions; ///< Actions argument.
   /* Boolean flags: */
-  int details;           ///< Whether to include overrides in the tasks.
-  int rcfile;            ///< Ignored.  Removed since GMP 6.0.
+  int details; ///< Whether to include overrides in the tasks.
+  int rcfile;  ///< Ignored.  Removed since GMP 6.0.
 } gmp_get_tasks_opts_t;
 
 /**
  * @brief Sensible default values for gmp_get_tasks_opts_t.
  */
-static const gmp_get_tasks_opts_t gmp_get_tasks_opts_defaults =
-  { "", 0, NULL, 0, 0 };
+static const gmp_get_tasks_opts_t gmp_get_tasks_opts_defaults = {"", 0, NULL, 0,
+                                                                 0};
 
 /**
  * @brief Struct holding options for gmp get_tasks command.
  */
 typedef struct
 {
-  const char* actions;   ///< Actions argument.
-  const char* task_id;   ///< ID of single task to get.
+  const char *actions; ///< Actions argument.
+  const char *task_id; ///< ID of single task to get.
   /* Boolean flags: */
-  int details;           ///< Whether to include overrides in the tasks.
-  int rcfile;            ///< Ignored.  Removed since GMP 6.0.
+  int details; ///< Whether to include overrides in the tasks.
+  int rcfile;  ///< Ignored.  Removed since GMP 6.0.
 } gmp_get_task_opts_t;
 
 /**
  * @brief Sensible default values for gmp_get_tasks_opts_t.
  */
-static const gmp_get_task_opts_t gmp_get_task_opts_defaults =
-  { NULL, NULL, 0, 0 };
+static const gmp_get_task_opts_t gmp_get_task_opts_defaults = {NULL, NULL, 0,
+                                                               0};
 
 /**
  * @brief Struct holding options for gmp create_task command.
  */
 typedef struct
 {
-  array_t*    alert_ids;      ///< Array of alert IDs.
-  const char* config_id;      ///< ID of config.
-  const char* scanner_id;     ///< ID of task scanner.
-  const char* schedule_id;    ///< ID of task schedule.
-  const char* slave_id;       ///< ID of task schedule.
-  const char* target_id;      ///< ID of target.
-  const char* name;           ///< Name of task.
-  const char* comment;        ///< Comment on task.
-  const char* hosts_ordering; ///< Order for scanning target hosts.
-  const char* observers;      ///< Comma-separated string of observer users.
-  array_t*    observer_groups;///< IDs of observer groups.
+  array_t *alert_ids;         ///< Array of alert IDs.
+  const char *config_id;      ///< ID of config.
+  const char *scanner_id;     ///< ID of task scanner.
+  const char *schedule_id;    ///< ID of task schedule.
+  const char *slave_id;       ///< ID of task schedule.
+  const char *target_id;      ///< ID of target.
+  const char *name;           ///< Name of task.
+  const char *comment;        ///< Comment on task.
+  const char *hosts_ordering; ///< Order for scanning target hosts.
+  const char *observers;      ///< Comma-separated string of observer users.
+  array_t *observer_groups;   ///< IDs of observer groups.
   int schedule_periods;       ///< Number of periods the schedule must run for.
   /* Preferences */
-  const char* in_assets;      ///< In assets preference.
-  const char* max_hosts;      ///< Max hosts preference.
-  const char* max_checks;     ///< Max checks preference.
-  const char* source_iface;   ///< Source iface preference.
+  const char *in_assets;    ///< In assets preference.
+  const char *max_hosts;    ///< Max hosts preference.
+  const char *max_checks;   ///< Max checks preference.
+  const char *source_iface; ///< Source iface preference.
   /* Boolean flags: */
-  int alterable;              ///< Whether the task is alterable.
+  int alterable; ///< Whether the task is alterable.
 } gmp_create_task_opts_t;
 
 /**
  * @brief Sensible default values for gmp_get_report_opts_t.
  */
-static const gmp_create_task_opts_t gmp_create_task_opts_defaults =
-  {
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL,
-    NULL, NULL, NULL, 0
-  };
+static const gmp_create_task_opts_t gmp_create_task_opts_defaults = {
+  NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+  NULL, NULL, 0,    NULL, NULL, NULL, NULL, 0};
 
 /**
  * @brief Struct holding options for gmp create_target command.
  */
 typedef struct
 {
-  int ssh_credential_port;         ///< Port for SSH access.
-  const char* ssh_credential_id;   ///< ID of SSH credential.
-  const char* smb_credential_id;   ///< ID of SMB credential.
-  const char* esxi_credential_id;  ///< ID of ESXi credential.
-  const char* snmp_credential_id;  ///< ID of SNMP credential.
-  const char* port_range;          ///< Port range.
-  const char* name;                ///< Name of target.
-  const char* comment;             ///< Comment on target.
-  const char* hosts;               ///< Name of target.
-  const char* exclude_hosts;       ///< Hosts to exclude.
-  const char* alive_tests;         ///< Alive tests.
+  int ssh_credential_port;        ///< Port for SSH access.
+  const char *ssh_credential_id;  ///< ID of SSH credential.
+  const char *smb_credential_id;  ///< ID of SMB credential.
+  const char *esxi_credential_id; ///< ID of ESXi credential.
+  const char *snmp_credential_id; ///< ID of SNMP credential.
+  const char *port_range;         ///< Port range.
+  const char *name;               ///< Name of target.
+  const char *comment;            ///< Comment on target.
+  const char *hosts;              ///< Name of target.
+  const char *exclude_hosts;      ///< Hosts to exclude.
+  const char *alive_tests;        ///< Alive tests.
   /* Boolean flags: */
-  int reverse_lookup_only;         ///< Scanner pref reverse_lookup_only.
-  int reverse_lookup_unify;        ///< Scanner pref reverse_lookup_unify.
+  int reverse_lookup_only;  ///< Scanner pref reverse_lookup_only.
+  int reverse_lookup_unify; ///< Scanner pref reverse_lookup_unify.
 } gmp_create_target_opts_t;
 
 /**
  * @brief Sensible default values for gmp_get_report_opts_t.
  */
-static const gmp_create_target_opts_t gmp_create_target_opts_defaults =
-  { 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0 };
+static const gmp_create_target_opts_t gmp_create_target_opts_defaults = {
+  0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0};
 
 /**
  * @brief Struct holding options for gmp get_system_reports command.
  */
 typedef struct
 {
-  const char* name;                ///< Name of report.
-  const char* duration;            ///< Duration.
-  const char* start_time;          ///< Time of first data point.
-  const char* end_time;            ///< Time of last data point.
-  const char* slave_id;            ///< ID of the slave to get report from.
-  int brief;                       ///< Brief flag.
+  const char *name;       ///< Name of report.
+  const char *duration;   ///< Duration.
+  const char *start_time; ///< Time of first data point.
+  const char *end_time;   ///< Time of last data point.
+  const char *slave_id;   ///< ID of the slave to get report from.
+  int brief;              ///< Brief flag.
 } gmp_get_system_reports_opts_t;
 
 /**
  * @brief Sensible default values for gmp_get_report_opts_t.
  */
-static const gmp_get_system_reports_opts_t gmp_get_system_reports_opts_defaults =
-  { NULL, NULL, NULL, NULL, NULL, 0 };
+static const gmp_get_system_reports_opts_t
+  gmp_get_system_reports_opts_defaults = {NULL, NULL, NULL, NULL, NULL, 0};
 
 /**
  * @brief Struct holding options for gmp create_lsc_credential command.
  */
 typedef struct
 {
-  const char *name;        ///< Name of LSC credential.
-  const char *community;   ///< SNMP community.
-  const char *login;       ///< Login.
-  const char *passphrase;  ///< Passphrase.
-  const char *private_key; ///< Private key.
+  const char *name;              ///< Name of LSC credential.
+  const char *community;         ///< SNMP community.
+  const char *login;             ///< Login.
+  const char *passphrase;        ///< Passphrase.
+  const char *private_key;       ///< Private key.
   const char *auth_algorithm;    ///< SNMP authentication algorithm.
   const char *privacy_password;  ///< SNMP privacy password.
   const char *privacy_algorithm; ///< SNMP privacy algorithm.
-  const char *comment;     ///< Comment on LSC credential.
+  const char *comment;           ///< Comment on LSC credential.
 } gmp_create_lsc_credential_opts_t;
 
 /**
  * @brief Sensible default values for gmp_create_lsc_credential_opts_t.
  */
-static const gmp_create_lsc_credential_opts_t gmp_create_lsc_credential_opts_defaults =
-  { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
+static const gmp_create_lsc_credential_opts_t
+  gmp_create_lsc_credential_opts_defaults = {NULL, NULL, NULL, NULL, NULL,
+                                             NULL, NULL, NULL, NULL};
 
 /**
  * @brief Struct holding options for various gmp delete_[...] commands.
@@ -255,93 +282,122 @@ typedef struct
 /**
  * @brief Sensible default values for gmp_get_report_opts_t.
  */
-static const gmp_delete_opts_t gmp_delete_opts_defaults =
-  { 0 };
+static const gmp_delete_opts_t gmp_delete_opts_defaults = {0};
 
 /**
  * @brief Default values for gmp_get_report_opts_t for ultimate deletion.
  */
-static const gmp_delete_opts_t gmp_delete_opts_ultimate_defaults =
-  { 1 };
+static const gmp_delete_opts_t gmp_delete_opts_ultimate_defaults = {1};
 
-int gmp_read_create_response (gnutls_session_t*, gchar **);
+int
+gmp_read_create_response (gnutls_session_t *, gchar **);
 
-const char *gmp_task_status (entity_t status_response);
+const char *
+gmp_task_status (entity_t status_response);
 
-int gmp_ping (gnutls_session_t *, int);
+int
+gmp_ping (gnutls_session_t *, int);
 
-int gmp_ping_c (gvm_connection_t *, int, gchar **);
+int
+gmp_ping_c (gvm_connection_t *, int, gchar **);
 
-int gmp_authenticate (gnutls_session_t * session, const char *username,
-                      const char *password);
+int
+gmp_authenticate (gnutls_session_t *session, const char *username,
+                  const char *password);
 
-int gmp_authenticate_info_ext (gnutls_session_t*, gmp_authenticate_info_opts_t);
+int
+gmp_authenticate_info_ext (gnutls_session_t *, gmp_authenticate_info_opts_t);
 
-int gmp_authenticate_info_ext_c (gvm_connection_t *,
-                                 gmp_authenticate_info_opts_t);
+int
+gmp_authenticate_info_ext_c (gvm_connection_t *, gmp_authenticate_info_opts_t);
 
-int gmp_create_task (gnutls_session_t *, const char *, const char *,
-                     const char *, const char *, gchar **);
+int
+gmp_create_task (gnutls_session_t *, const char *, const char *, const char *,
+                 const char *, gchar **);
 
-int gmp_create_task_ext (gnutls_session_t *, gmp_create_task_opts_t, gchar **);
+int
+gmp_create_task_ext (gnutls_session_t *, gmp_create_task_opts_t, gchar **);
 
-int gmp_start_task_report (gnutls_session_t *, const char *, char **);
+int
+gmp_start_task_report (gnutls_session_t *, const char *, char **);
 
-int gmp_start_task_report_c (gvm_connection_t *, const char *, char **);
+int
+gmp_start_task_report_c (gvm_connection_t *, const char *, char **);
 
-int gmp_stop_task (gnutls_session_t *, const char *);
+int
+gmp_stop_task (gnutls_session_t *, const char *);
 
-int gmp_stop_task_c (gvm_connection_t *, const char *);
+int
+gmp_stop_task_c (gvm_connection_t *, const char *);
 
-int gmp_resume_task_report (gnutls_session_t*, const char*, char**);
+int
+gmp_resume_task_report (gnutls_session_t *, const char *, char **);
 
-int gmp_resume_task_report_c (gvm_connection_t *, const char *, char **);
+int
+gmp_resume_task_report_c (gvm_connection_t *, const char *, char **);
 
-int gmp_get_tasks (gnutls_session_t *, const char *, int, int, entity_t *);
+int
+gmp_get_tasks (gnutls_session_t *, const char *, int, int, entity_t *);
 
-int gmp_get_tasks_ext (gnutls_session_t *, gmp_get_tasks_opts_t, entity_t *);
+int
+gmp_get_tasks_ext (gnutls_session_t *, gmp_get_tasks_opts_t, entity_t *);
 
-int gmp_get_task_ext (gnutls_session_t *, gmp_get_task_opts_t, entity_t *);
+int
+gmp_get_task_ext (gnutls_session_t *, gmp_get_task_opts_t, entity_t *);
 
-int gmp_get_targets (gnutls_session_t *, const char *, int, int, entity_t *);
+int
+gmp_get_targets (gnutls_session_t *, const char *, int, int, entity_t *);
 
-int gmp_get_report_ext (gnutls_session_t *, gmp_get_report_opts_t, entity_t *);
+int
+gmp_get_report_ext (gnutls_session_t *, gmp_get_report_opts_t, entity_t *);
 
-int gmp_delete_port_list_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
+int
+gmp_delete_port_list_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
 
-int gmp_delete_task (gnutls_session_t *, const char *);
+int
+gmp_delete_task (gnutls_session_t *, const char *);
 
-int gmp_delete_task_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
+int
+gmp_delete_task_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
 
-int gmp_modify_task_file (gnutls_session_t *, const char *, const char *,
-                          const void *, gsize);
+int
+gmp_modify_task_file (gnutls_session_t *, const char *, const char *,
+                      const void *, gsize);
 
-int gmp_delete_report (gnutls_session_t*, const char*);
+int
+gmp_delete_report (gnutls_session_t *, const char *);
 
-int gmp_create_target_ext (gnutls_session_t *, gmp_create_target_opts_t,
-                           gchar**);
+int
+gmp_create_target_ext (gnutls_session_t *, gmp_create_target_opts_t, gchar **);
 
-int gmp_delete_target_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
+int
+gmp_delete_target_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
 
-int gmp_delete_config_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
+int
+gmp_delete_config_ext (gnutls_session_t *, const char *, gmp_delete_opts_t);
 
-int gmp_create_lsc_credential_ext (gnutls_session_t*, gmp_create_lsc_credential_opts_t,
-                                   gchar**);
+int
+gmp_create_lsc_credential_ext (gnutls_session_t *,
+                               gmp_create_lsc_credential_opts_t, gchar **);
 
-int gmp_create_lsc_credential (gnutls_session_t *, const char *, const char *,
-                               const char *, const char *, gchar **);
+int
+gmp_create_lsc_credential (gnutls_session_t *, const char *, const char *,
+                           const char *, const char *, gchar **);
 
-int gmp_create_lsc_credential_key (gnutls_session_t *, const char *,
-                                   const char *, const char *, const char *,
-                                   const char *, gchar **);
+int
+gmp_create_lsc_credential_key (gnutls_session_t *, const char *, const char *,
+                               const char *, const char *, const char *,
+                               gchar **);
 
-int gmp_delete_lsc_credential_ext (gnutls_session_t *, const char *,
-                                   gmp_delete_opts_t);
+int
+gmp_delete_lsc_credential_ext (gnutls_session_t *, const char *,
+                               gmp_delete_opts_t);
 
-int gmp_get_system_reports (gnutls_session_t *, const char *, int, entity_t *);
+int
+gmp_get_system_reports (gnutls_session_t *, const char *, int, entity_t *);
 
-int gmp_get_system_reports_ext (gnutls_session_t *,
-                                gmp_get_system_reports_opts_t,
-                                entity_t *);
+int
+gmp_get_system_reports_ext (gnutls_session_t *, gmp_get_system_reports_opts_t,
+                            entity_t *);
 
 #endif /* not _GVM_GMP_H */

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -24,20 +24,20 @@
 
 #include "osp.h"
 
-#include <assert.h>              /* for assert */
-#include <gnutls/gnutls.h>       /* for gnutls_session_int, gnutls_session_t */
-#include <stdarg.h>              /* for va_list */
-#include <stdlib.h>              /* for NULL, atoi */
-#include <string.h>              /* for strcmp, strlen, strncpy */
-#include <sys/socket.h>          /* for AF_UNIX, connect, socket, SOCK_STREAM */
-#include <sys/un.h>              /* for sockaddr_un, sa_family_t */
-#include <unistd.h>              /* for close */
-
 #include "../base/hosts.h"       /* for gvm_get_host_type */
 #include "../util/serverutils.h" /* for gvm_server_close, gvm_server_open_w... */
-#include "../util/xmlutils.h"    /* for entity_child, entity_text, free_entity */
+#include "../util/xmlutils.h" /* for entity_child, entity_text, free_entity */
 
-#undef  G_LOG_DOMAIN
+#include <assert.h>        /* for assert */
+#include <gnutls/gnutls.h> /* for gnutls_session_int, gnutls_session_t */
+#include <stdarg.h>        /* for va_list */
+#include <stdlib.h>        /* for NULL, atoi */
+#include <string.h>        /* for strcmp, strlen, strncpy */
+#include <sys/socket.h>    /* for AF_UNIX, connect, socket, SOCK_STREAM */
+#include <sys/un.h>        /* for sockaddr_un, sa_family_t */
+#include <unistd.h>        /* for close */
+
+#undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.
  */
@@ -46,7 +46,8 @@
 /**
  * @brief Struct holding options for OSP connection.
  */
-struct osp_connection {
+struct osp_connection
+{
   gnutls_session_t session; /**< Pointer to GNUTLS Session. */
   int socket;               /**< Socket. */
   char *host;               /**< Host. */
@@ -56,19 +57,19 @@ struct osp_connection {
 /**
  * @brief Struct holding options for OSP parameters.
  */
-struct osp_param {
-  char *id;                 /**< Parameter id. */
-  char *name;               /**< Parameter name. */
-  char *desc;               /**< Parameter description. */
-  char *def;                /**< Default value. */
-  osp_param_type_t type;    /**< Parameter type. */
-  int mandatory;            /**< If mandatory or not. */
+struct osp_param
+{
+  char *id;              /**< Parameter id. */
+  char *name;            /**< Parameter name. */
+  char *desc;            /**< Parameter description. */
+  char *def;             /**< Default value. */
+  osp_param_type_t type; /**< Parameter type. */
+  int mandatory;         /**< If mandatory or not. */
 };
 
 static int
 osp_send_command (osp_connection_t *, entity_t *, const char *, ...)
-    __attribute__((__format__(__printf__, 3, 4)));
-
+  __attribute__ ((__format__ (__printf__, 3, 4)));
 
 /**
  * @brief Open a new connection to an OSP server.
@@ -116,8 +117,8 @@ osp_connection_new (const char *host, int port, const char *cacert,
         return NULL;
 
       connection = g_malloc0 (sizeof (*connection));
-      connection->socket = gvm_server_open_with_cert
-                            (&connection->session, host, port, cacert, cert, key);
+      connection->socket = gvm_server_open_with_cert (
+        &connection->session, host, port, cacert, cert, key);
     }
   if (connection->socket == -1)
     {
@@ -166,11 +167,10 @@ osp_send_command (osp_connection_t *connection, entity_t *response,
         goto out;
     }
 
-
   rc = 0;
 
 out:
-  va_end(ap);
+  va_end (ap);
 
   return rc;
 }
@@ -337,9 +337,9 @@ osp_get_scan (osp_connection_t *connection, const char *scan_id,
 
   assert (connection);
   assert (scan_id);
-  rc = osp_send_command
-        (connection, &entity, "<get_scans scan_id='%s' details='%d'/>",
-         scan_id, details ? 1 : 0);
+  rc = osp_send_command (connection, &entity,
+                         "<get_scans scan_id='%s' details='%d'/>", scan_id,
+                         details ? 1 : 0);
   if (rc)
     {
       if (error)
@@ -388,8 +388,8 @@ osp_stop_scan (osp_connection_t *connection, const char *scan_id, char **error)
 
   assert (connection);
   assert (scan_id);
-  rc = osp_send_command
-        (connection, &entity, "<stop_scan scan_id='%s'/>", scan_id);
+  rc = osp_send_command (connection, &entity, "<stop_scan scan_id='%s'/>",
+                         scan_id);
   if (rc)
     {
       if (error)
@@ -601,15 +601,15 @@ osp_get_scanner_details (osp_connection_t *connection, char **desc,
           child = entities->data;
           param = osp_param_new ();
           param->id = g_strdup (entity_attribute (child, "id"));
-          param->type = osp_param_str_to_type (entity_attribute (child, "type"));
+          param->type =
+            osp_param_str_to_type (entity_attribute (child, "type"));
           param->name = g_strdup (entity_text (entity_child (child, "name")));
-          param->desc = g_strdup (entity_text (entity_child (child,
-                                                             "description")));
-          param->def = g_strdup (entity_text (entity_child (child,
-                                                            "default")));
+          param->desc =
+            g_strdup (entity_text (entity_child (child, "description")));
+          param->def = g_strdup (entity_text (entity_child (child, "default")));
           if (entity_child (child, "mandatory"))
-            param->mandatory = atoi (entity_text
-                                      (entity_child (child, "mandatory")));
+            param->mandatory =
+              atoi (entity_text (entity_child (child, "mandatory")));
           *params = g_slist_append (*params, param);
           entities = next_entities (entities);
         }

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -32,7 +32,8 @@ typedef struct osp_connection osp_connection_t;
 /**
  * @brief OSP parameter types.
  */
-typedef enum {
+typedef enum
+{
   OSP_PARAM_TYPE_INT = 0,      /**< Integer type. */
   OSP_PARAM_TYPE_STR,          /**< String type. */
   OSP_PARAM_TYPE_PASSWORD,     /**< Password type. */

--- a/tests/test-hosts.c
+++ b/tests/test-hosts.c
@@ -25,13 +25,13 @@
  * of the hosts object.
  */
 
-#include <arpa/inet.h>     /* for inet_ntop */
-#include <glib.h>          /* for g_free */
-#include <netinet/in.h>    /* for INET6_ADDRSTRLEN, INET_ADDRSTRLEN, in6_addr */
-#include <stdio.h>         /* for printf, fprintf, NULL, stderr */
-#include <sys/socket.h>    /* for AF_INET, AF_INET6 */
-
 #include "../base/hosts.h" /* for gvm_host_type_str, gvm_host_resolve, gvm_... */
+
+#include <arpa/inet.h>  /* for inet_ntop */
+#include <glib.h>       /* for g_free */
+#include <netinet/in.h> /* for INET6_ADDRSTRLEN, INET_ADDRSTRLEN, in6_addr */
+#include <stdio.h>      /* for printf, fprintf, NULL, stderr */
+#include <sys/socket.h> /* for AF_INET, AF_INET6 */
 
 static void
 print_vhosts (gvm_host_t *host)
@@ -92,24 +92,24 @@ main (int argc, char **argv)
             }
           if (inet_ntop (AF_INET, &addr, name, sizeof (name)) == NULL)
             {
-                printf ("inet_ntop() error.\n");
-                break;
+              printf ("inet_ntop() error.\n");
+              break;
             }
 
           if (gvm_host_resolve (host, &addr6, AF_INET6) == -1)
             {
               fprintf (stderr, "ERROR - %s: Couldn't resolve IPv6 address.\n",
                        host->name);
-              printf ("#%d %s %s (%s)\n", i, gvm_host_type_str (host),
-                      str, name);
+              printf ("#%d %s %s (%s)\n", i, gvm_host_type_str (host), str,
+                      name);
               i++;
               g_free (str);
               continue;
             }
           if (inet_ntop (AF_INET6, &addr6, name6, sizeof (name6)) == NULL)
             {
-                printf ("inet_ntop() error.\n");
-                break;
+              printf ("inet_ntop() error.\n");
+              break;
             }
 
           printf ("#%d %s %s (%s / %s)\n", i, gvm_host_type_str (host), str,

--- a/util/authutils.c
+++ b/util/authutils.c
@@ -38,10 +38,8 @@
  *        methods.
  */
 /** @warning  Beware to have it in sync with \ref authentication_method. */
-static const gchar *authentication_methods[] = { "file",
-                                                 "ldap_connect",
-                                                 "radius_connect",
-                                                 NULL };
+static const gchar *authentication_methods[] = {"file", "ldap_connect",
+                                                "radius_connect", NULL};
 
 /**
  * @brief Flag whether the config file was read.
@@ -167,7 +165,7 @@ gvm_auth_init ()
  * or NULL if an unavailable message digest algorithm was selected.
  */
 gchar *
-digest_hex (int gcrypt_algorithm, const guchar * digest)
+digest_hex (int gcrypt_algorithm, const guchar *digest)
 {
   unsigned int i;
   gchar *hex;
@@ -245,7 +243,7 @@ int
 gvm_authenticate_classic (const gchar *username, const gchar *password,
                           const gchar *hash_arg)
 {
-  int gcrypt_algorithm = GCRY_MD_MD5;   // FIX whatever configure used
+  int gcrypt_algorithm = GCRY_MD_MD5; // FIX whatever configure used
   int ret;
   gchar *actual, *expect, *seed_pass;
   guchar *hash;

--- a/util/authutils.h
+++ b/util/authutils.h
@@ -46,7 +46,8 @@ typedef enum authentication_method auth_method_t;
 
 const gchar *auth_method_name (auth_method_t);
 
-int gvm_auth_init ();
+int
+gvm_auth_init ();
 
 int
 gvm_authenticate_classic (const gchar *, const gchar *, const gchar *);
@@ -54,9 +55,11 @@ gvm_authenticate_classic (const gchar *, const gchar *, const gchar *);
 gchar *
 get_password_hashes (const gchar *);
 
-gchar *digest_hex (int, const guchar *);
+gchar *
+digest_hex (int, const guchar *);
 
-int gvm_auth_ldap_enabled ();
+int
+gvm_auth_ldap_enabled ();
 
 int
 gvm_auth_radius_enabled ();

--- a/util/compressutils.c
+++ b/util/compressutils.c
@@ -26,7 +26,7 @@
  * @brief For z_const to be defined as const.
  */
 #if !defined(ZLIB_CONST)
-#  define ZLIB_CONST
+#define ZLIB_CONST
 #endif
 
 #include "compressutils.h"
@@ -82,22 +82,22 @@ gvm_compress (const void *src, unsigned long srclen, unsigned long *dstlen)
       deflateEnd (&strm);
       switch (err)
         {
-          case Z_OK:
-          case Z_STREAM_END:
-            if (strm.avail_out != 0)
-              {
-                *dstlen = strm.total_out;
-                return buffer;
-              }
-            /* Fallthrough. */
-          case Z_BUF_ERROR:
-            g_free (buffer);
-            buflen *= 2;
-            break;
+        case Z_OK:
+        case Z_STREAM_END:
+          if (strm.avail_out != 0)
+            {
+              *dstlen = strm.total_out;
+              return buffer;
+            }
+          /* Fallthrough. */
+        case Z_BUF_ERROR:
+          g_free (buffer);
+          buflen *= 2;
+          break;
 
-          default:
-            g_free (buffer);
-            return NULL;
+        default:
+          g_free (buffer);
+          return NULL;
         }
     }
 }
@@ -112,8 +112,7 @@ gvm_compress (const void *src, unsigned long srclen, unsigned long *dstlen)
  * @return Pointer to uncompressed data if success, NULL otherwise.
  */
 void *
-gvm_uncompress (const void *src, unsigned long srclen,
-                unsigned long *dstlen)
+gvm_uncompress (const void *src, unsigned long srclen, unsigned long *dstlen)
 {
   unsigned long buflen = srclen * 2;
 
@@ -139,8 +138,8 @@ gvm_uncompress (const void *src, unsigned long srclen,
 #endif
       /*
        * From: http://www.zlib.net/manual.html
-       * Add 32 to windowBits to enable zlib and gzip decoding with automatic header
-       * detection.
+       * Add 32 to windowBits to enable zlib and gzip decoding with automatic
+       * header detection.
        */
       if (inflateInit2 (&strm, 15 + 32) != Z_OK)
         return NULL;
@@ -153,22 +152,22 @@ gvm_uncompress (const void *src, unsigned long srclen,
       inflateEnd (&strm);
       switch (err)
         {
-          case Z_OK:
-          case Z_STREAM_END:
-            if (strm.avail_out != 0)
-              {
-                *dstlen = strm.total_out;
-                return buffer;
-              }
-            /* Fallthrough. */
-          case Z_BUF_ERROR:
-            g_free (buffer);
-            buflen *= 2;
-            break;
+        case Z_OK:
+        case Z_STREAM_END:
+          if (strm.avail_out != 0)
+            {
+              *dstlen = strm.total_out;
+              return buffer;
+            }
+          /* Fallthrough. */
+        case Z_BUF_ERROR:
+          g_free (buffer);
+          buflen *= 2;
+          break;
 
-          default:
-            g_free (buffer);
-            return NULL;
+        default:
+          g_free (buffer);
+          return NULL;
         }
     }
 }
@@ -215,8 +214,8 @@ gvm_compress_gzipheader (const void *src, unsigned long srclen,
 #endif
 
       if (deflateInit2 (&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
-                        windowsBits | GZIP_ENCODING, 8,
-                        Z_DEFAULT_STRATEGY) != Z_OK)
+                        windowsBits | GZIP_ENCODING, 8, Z_DEFAULT_STRATEGY)
+          != Z_OK)
         return NULL;
 
       buffer = g_malloc0 (buflen);
@@ -227,22 +226,22 @@ gvm_compress_gzipheader (const void *src, unsigned long srclen,
       deflateEnd (&strm);
       switch (err)
         {
-          case Z_OK:
-          case Z_STREAM_END:
-            if (strm.avail_out != 0)
-              {
-                *dstlen = strm.total_out;
-                return buffer;
-              }
-            /* Fallthrough. */
-          case Z_BUF_ERROR:
-            g_free (buffer);
-            buflen *= 2;
-            break;
+        case Z_OK:
+        case Z_STREAM_END:
+          if (strm.avail_out != 0)
+            {
+              *dstlen = strm.total_out;
+              return buffer;
+            }
+          /* Fallthrough. */
+        case Z_BUF_ERROR:
+          g_free (buffer);
+          buflen *= 2;
+          break;
 
-          default:
-            g_free (buffer);
-            return NULL;
+        default:
+          g_free (buffer);
+          return NULL;
         }
     }
 }

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -74,7 +74,7 @@ gvm_file_check_is_dir (const char *name)
  * @return 0 if the name was successfully deleted, -1 if an error occurred.
  */
 int
-gvm_file_remove_recurse (const gchar * pathname)
+gvm_file_remove_recurse (const gchar *pathname)
 {
   if (gvm_file_check_is_dir (pathname) == 1)
     {
@@ -244,14 +244,11 @@ gvm_export_file_name (const char *fname_format, const char *username,
 
   now = time (NULL);
   now_broken = localtime (&now);
-  now_date_str = g_strdup_printf ("%04d%02d%02d",
-                                  (now_broken->tm_year + 1900),
-                                  (now_broken->tm_mon + 1),
-                                  now_broken->tm_mday);
-  now_time_str = g_strdup_printf ("%02d%02d%02d",
-                                  now_broken->tm_hour,
-                                  now_broken->tm_min,
-                                  now_broken->tm_sec);
+  now_date_str =
+    g_strdup_printf ("%04d%02d%02d", (now_broken->tm_year + 1900),
+                     (now_broken->tm_mon + 1), now_broken->tm_mday);
+  now_time_str = g_strdup_printf ("%02d%02d%02d", now_broken->tm_hour,
+                                  now_broken->tm_min, now_broken->tm_sec);
 
   memset (&creation_time, 0, sizeof (struct tm));
   memset (&modification_time, 0, sizeof (struct tm));
@@ -262,45 +259,35 @@ gvm_export_file_name (const char *fname_format, const char *username,
     creation_date_short = g_strndup (creation_iso_time, 19);
 
   if (creation_date_short
-      && (((ret = strptime (creation_date_short,
-                            "%Y-%m-%dT%H:%M:%S",
+      && (((ret = strptime (creation_date_short, "%Y-%m-%dT%H:%M:%S",
                             &creation_time))
            == NULL)
           || (strlen (ret) == 0)))
     {
-      creation_date_str
-        = g_strdup_printf ("%04d%02d%02d",
-                            (creation_time.tm_year + 1900),
-                            (creation_time.tm_mon + 1),
-                            creation_time.tm_mday);
-      creation_time_str
-        = g_strdup_printf ("%02d%02d%02d",
-                            creation_time.tm_hour,
-                            creation_time.tm_min,
-                            creation_time.tm_sec);
+      creation_date_str =
+        g_strdup_printf ("%04d%02d%02d", (creation_time.tm_year + 1900),
+                         (creation_time.tm_mon + 1), creation_time.tm_mday);
+      creation_time_str =
+        g_strdup_printf ("%02d%02d%02d", creation_time.tm_hour,
+                         creation_time.tm_min, creation_time.tm_sec);
     }
 
   if (modification_iso_time && (strlen (modification_iso_time) >= 19))
     modification_date_short = g_strndup (modification_iso_time, 19);
 
   if (modification_date_short
-      && (((ret = strptime (modification_date_short,
-                            "%Y-%m-%dT%H:%M:%S",
+      && (((ret = strptime (modification_date_short, "%Y-%m-%dT%H:%M:%S",
                             &modification_time))
            == NULL)
           || (strlen (ret) == 0)))
     {
-      modification_date_str
-        = g_strdup_printf ("%04d%02d%02d",
-                            (modification_time.tm_year + 1900),
-                            (modification_time.tm_mon + 1),
-                            modification_time.tm_mday);
+      modification_date_str = g_strdup_printf (
+        "%04d%02d%02d", (modification_time.tm_year + 1900),
+        (modification_time.tm_mon + 1), modification_time.tm_mday);
 
-      modification_time_str
-        = g_strdup_printf ("%02d%02d%02d",
-                            modification_time.tm_hour,
-                            modification_time.tm_min,
-                            modification_time.tm_sec);
+      modification_time_str =
+        g_strdup_printf ("%02d%02d%02d", modification_time.tm_hour,
+                         modification_time.tm_min, modification_time.tm_sec);
     }
 
   if (creation_date_str == NULL)
@@ -376,11 +363,11 @@ gvm_export_file_name (const char *fname_format, const char *username,
               break;
             case 'u':
               g_string_append (file_name_buf, username ? username : "");
-                break;
+              break;
             case 'Y':
               g_string_append_printf (file_name_buf, "%04d",
                                       modification_time.tm_year + 1900);
-            break;
+              break;
             case '%':
               g_string_append_c (file_name_buf, '%');
               break;
@@ -405,7 +392,7 @@ gvm_export_file_name (const char *fname_format, const char *username,
     {
       if (*fname_point <= ' ')
         *fname_point = '_';
-      fname_point ++;
+      fname_point++;
     }
 
   g_free (now_date_str);

--- a/util/fileutils.h
+++ b/util/fileutils.h
@@ -29,18 +29,23 @@
 
 #include <glib.h>
 
-int gvm_file_check_is_dir (const char *name);
+int
+gvm_file_check_is_dir (const char *name);
 
-int gvm_file_remove_recurse (const gchar * pathname);
+int
+gvm_file_remove_recurse (const gchar *pathname);
 
-gboolean gvm_file_copy (const gchar *, const gchar *);
+gboolean
+gvm_file_copy (const gchar *, const gchar *);
 
-gboolean gvm_file_move (const gchar *, const gchar *);
+gboolean
+gvm_file_move (const gchar *, const gchar *);
 
-char *gvm_file_as_base64 (const char *);
+char *
+gvm_file_as_base64 (const char *);
 
-gchar *gvm_export_file_name (const char *, const char *, const char *,
-                             const char *, const char *, const char *,
-                             const char *, const char *);
+gchar *
+gvm_export_file_name (const char *, const char *, const char *, const char *,
+                      const char *, const char *, const char *, const char *);
 
 #endif /* not _GVM_FILEUTILS_H */

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -23,15 +23,16 @@
  */
 
 #include "gpgmeutils.h"
-#include <errno.h>     /* for ENOENT, errno */
-#include <locale.h>    /* for setlocale, LC_MESSAGES, LC_CTYPE */
-#include <sys/stat.h>  /* for mkdir */
-#include <unistd.h>    /* for access, F_OK */
-#include <gpg-error.h> /* for gpg_err_source, gpg_strerror, gpg_error_from... */
-#include <string.h>    /* for strlen */
-#include <stdlib.h>    /* for mkdtemp */
 
 #include "fileutils.h"
+
+#include <errno.h>     /* for ENOENT, errno */
+#include <gpg-error.h> /* for gpg_err_source, gpg_strerror, gpg_error_from... */
+#include <locale.h>    /* for setlocale, LC_MESSAGES, LC_CTYPE */
+#include <stdlib.h>    /* for mkdtemp */
+#include <string.h>    /* for strlen */
+#include <sys/stat.h>  /* for mkdir */
+#include <unistd.h>    /* for access, F_OK */
 
 #undef G_LOG_DOMAIN
 /**
@@ -61,16 +62,13 @@ log_gpgme (GLogLevelFlags level, gpg_error_t err, const char *fmt, ...)
   va_start (arg_ptr, fmt);
   msg = g_strdup_vprintf (fmt, arg_ptr);
   va_end (arg_ptr);
-  if (err && gpg_err_source (err) != GPG_ERR_SOURCE_ANY
-          && gpg_err_source (err))
-    g_log (G_LOG_DOMAIN, level, "%s: %s <%s>",
-           msg, gpg_strerror (err), gpg_strsource (err));
+  if (err && gpg_err_source (err) != GPG_ERR_SOURCE_ANY && gpg_err_source (err))
+    g_log (G_LOG_DOMAIN, level, "%s: %s <%s>", msg, gpg_strerror (err),
+           gpg_strsource (err));
   else if (err)
-    g_log (G_LOG_DOMAIN, level, "%s: %s",
-           msg, gpg_strerror (err));
+    g_log (G_LOG_DOMAIN, level, "%s: %s", msg, gpg_strerror (err));
   else
-    g_log (G_LOG_DOMAIN, level, "%s",
-           msg);
+    g_log (G_LOG_DOMAIN, level, "%s", msg);
   g_free (msg);
 }
 
@@ -109,9 +107,9 @@ gvm_init_gpgme_ctx_from_dir (const gchar *dir)
           return NULL;
         }
       gpgme_set_locale (NULL, LC_CTYPE, setlocale (LC_CTYPE, NULL));
-#   ifdef LC_MESSAGES
+#ifdef LC_MESSAGES
       gpgme_set_locale (NULL, LC_MESSAGES, setlocale (LC_MESSAGES, NULL));
-#   endif
+#endif
 
 #ifndef NDEBUG
       g_message ("Setting GnuPG dir to '%s'", dir);
@@ -151,7 +149,7 @@ gvm_init_gpgme_ctx_from_dir (const gchar *dir)
         info = NULL;
 #ifndef NDEBUG
       g_message ("Using OpenPGP engine version '%s'",
-                 info && info->version? info->version: "[?]");
+                 info && info->version ? info->version : "[?]");
 #endif
 
       /* Everything is fine.  */
@@ -179,19 +177,17 @@ gvm_init_gpgme_ctx_from_dir (const gchar *dir)
  *  3 error importing key/certificate, -1 error.
  */
 int
-gvm_gpg_import_from_string (gpgme_ctx_t ctx,
-                            const char *key_str, ssize_t key_len,
-                            gpgme_data_type_t key_type)
+gvm_gpg_import_from_string (gpgme_ctx_t ctx, const char *key_str,
+                            ssize_t key_len, gpgme_data_type_t key_type)
 {
   gpgme_data_t key_data;
   gpgme_error_t err;
   gpgme_data_type_t given_key_type;
   gpgme_import_result_t import_result;
 
-  gpgme_data_new_from_mem (&key_data, key_str,
-                           (key_len >= 0 ? key_len
-                                         : (ssize_t) strlen(key_str)),
-                           0);
+  gpgme_data_new_from_mem (
+    &key_data, key_str, (key_len >= 0 ? key_len : (ssize_t) strlen (key_str)),
+    0);
 
   given_key_type = gpgme_data_identify (key_data, 0);
   if (given_key_type != key_type)
@@ -206,8 +202,8 @@ gvm_gpg_import_from_string (gpgme_ctx_t ctx,
         {
           ret = 2;
           g_warning ("%s: key_str is not the expected type: "
-                     " expected: %d, got %d", __FUNCTION__,
-                     key_type, given_key_type);
+                     " expected: %d, got %d",
+                     __FUNCTION__, key_type, given_key_type);
         }
       gpgme_data_release (key_data);
       return ret;
@@ -217,14 +213,12 @@ gvm_gpg_import_from_string (gpgme_ctx_t ctx,
   gpgme_data_release (key_data);
   if (err)
     {
-      g_warning ("%s: Import failed: %s",
-                 __FUNCTION__, gpgme_strerror (err));
+      g_warning ("%s: Import failed: %s", __FUNCTION__, gpgme_strerror (err));
       return 3;
     }
 
   import_result = gpgme_op_import_result (ctx);
-  g_debug ("%s: %d imported, %d not imported",
-           __FUNCTION__,
+  g_debug ("%s: %d imported, %d not imported", __FUNCTION__,
            import_result->imported, import_result->not_imported);
 
   gpgme_import_status_t status;
@@ -232,12 +226,10 @@ gvm_gpg_import_from_string (gpgme_ctx_t ctx,
   while (status)
     {
       if (status->result != GPG_ERR_NO_ERROR)
-        g_warning ("%s: '%s' could not be imported: %s",
-                   __FUNCTION__, status->fpr,
-                   gpgme_strerror (status->result));
+        g_warning ("%s: '%s' could not be imported: %s", __FUNCTION__,
+                   status->fpr, gpgme_strerror (status->result));
       else
-        g_debug ("%s: Imported '%s'",
-                 __FUNCTION__, status->fpr);
+        g_debug ("%s: Imported '%s'", __FUNCTION__, status->fpr);
 
       status = status->next;
     };
@@ -257,8 +249,7 @@ gvm_gpg_import_from_string (gpgme_ctx_t ctx,
  * @return  The key as a gpgme_key_t.
  */
 static gpgme_key_t
-find_email_encryption_key (gpgme_ctx_t ctx,
-                           const char *uid_email)
+find_email_encryption_key (gpgme_ctx_t ctx, const char *uid_email)
 {
   gchar *bracket_email;
   gpgme_key_t key;
@@ -275,21 +266,20 @@ find_email_encryption_key (gpgme_ctx_t ctx,
     {
       if (key->can_encrypt)
         {
-          g_debug ("%s: key '%s' OK for encryption",
-                   __FUNCTION__, key->subkeys->fpr);
+          g_debug ("%s: key '%s' OK for encryption", __FUNCTION__,
+                   key->subkeys->fpr);
 
           gpgme_user_id_t uid;
           uid = key->uids;
           while (uid && recipient_found == FALSE)
             {
-              g_debug ("%s: UID email: %s",
-                         __FUNCTION__, uid->email);
+              g_debug ("%s: UID email: %s", __FUNCTION__, uid->email);
 
               if (strcmp (uid->email, uid_email) == 0
                   || strstr (uid->email, bracket_email))
                 {
-                  g_message ("%s: Found matching UID for %s",
-                             __FUNCTION__, uid_email);
+                  g_message ("%s: Found matching UID for %s", __FUNCTION__,
+                             uid_email);
                   recipient_found = TRUE;
                 }
               uid = uid->next;
@@ -297,8 +287,8 @@ find_email_encryption_key (gpgme_ctx_t ctx,
         }
       else
         {
-          g_debug ("%s: key '%s' cannot be used for encryption",
-                   __FUNCTION__, key->subkeys->fpr);
+          g_debug ("%s: key '%s' cannot be used for encryption", __FUNCTION__,
+                   key->subkeys->fpr);
         }
 
       if (recipient_found == FALSE)
@@ -309,8 +299,7 @@ find_email_encryption_key (gpgme_ctx_t ctx,
     return key;
   else
     {
-      g_warning ("%s: No suitable key found for %s",
-                 __FUNCTION__, uid_email);
+      g_warning ("%s: No suitable key found for %s", __FUNCTION__, uid_email);
       return NULL;
     }
 }
@@ -333,15 +322,14 @@ find_email_encryption_key (gpgme_ctx_t ctx,
 static int
 encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
                          const char *key_str, ssize_t key_len,
-                         const char *uid_email,
-                         gpgme_protocol_t protocol,
+                         const char *uid_email, gpgme_protocol_t protocol,
                          gpgme_data_type_t data_type)
 {
   char gpg_temp_dir[] = "/tmp/gvmd-gpg-XXXXXX";
   gpgme_ctx_t ctx;
   gpgme_data_t plain_data, encrypted_data;
   gpgme_key_t key;
-  gpgme_key_t keys[2] = { NULL, NULL };
+  gpgme_key_t keys[2] = {NULL, NULL};
   gpgme_error_t err;
   gpgme_encrypt_flags_t encrypt_flags;
   const char *key_type_str;
@@ -379,8 +367,7 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
   // Import public key into context
   if (gvm_gpg_import_from_string (ctx, key_str, key_len, data_type))
     {
-      g_warning ("%s: Import of %s failed",
-                 __FUNCTION__, key_type_str);
+      g_warning ("%s: Import of %s failed", __FUNCTION__, key_type_str);
       gpgme_release (ctx);
       gvm_file_remove_recurse (gpg_temp_dir);
       return -1;
@@ -390,8 +377,8 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
   key = find_email_encryption_key (ctx, uid_email);
   if (key == NULL)
     {
-      g_warning ("%s: Could not find %s for encryption",
-                 __FUNCTION__, key_type_str);
+      g_warning ("%s: Could not find %s for encryption", __FUNCTION__,
+                 key_type_str);
       gpgme_release (ctx);
       gvm_file_remove_recurse (gpg_temp_dir);
       return -1;
@@ -406,13 +393,12 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
     gpgme_data_set_encoding (encrypted_data, GPGME_DATA_ENCODING_BASE64);
 
   // Encrypt data
-  err = gpgme_op_encrypt (ctx, keys, encrypt_flags,
-                          plain_data, encrypted_data);
+  err = gpgme_op_encrypt (ctx, keys, encrypt_flags, plain_data, encrypted_data);
 
   if (err)
     {
-      g_warning ("%s: Encryption failed: %s",
-                 __FUNCTION__, gpgme_strerror (err));
+      g_warning ("%s: Encryption failed: %s", __FUNCTION__,
+                 gpgme_strerror (err));
       gpgme_data_release (plain_data);
       gpgme_data_release (encrypted_data);
       gpgme_release (ctx);
@@ -447,11 +433,9 @@ gvm_pgp_pubkey_encrypt_stream (FILE *plain_file, FILE *encrypted_file,
                                const char *public_key_str,
                                ssize_t public_key_len)
 {
-  return encrypt_stream_internal (plain_file, encrypted_file,
-                                  public_key_str, public_key_len,
-                                  uid_email,
-                                  GPGME_PROTOCOL_OpenPGP,
-                                  GPGME_DATA_TYPE_PGP_KEY);
+  return encrypt_stream_internal (
+    plain_file, encrypted_file, public_key_str, public_key_len, uid_email,
+    GPGME_PROTOCOL_OpenPGP, GPGME_DATA_TYPE_PGP_KEY);
 }
 
 /**
@@ -469,12 +453,10 @@ gvm_pgp_pubkey_encrypt_stream (FILE *plain_file, FILE *encrypted_file,
  */
 int
 gvm_smime_encrypt_stream (FILE *plain_file, FILE *encrypted_file,
-                          const char *uid_email,
-                          const char *certificate_str, ssize_t certificate_len)
+                          const char *uid_email, const char *certificate_str,
+                          ssize_t certificate_len)
 {
-  return encrypt_stream_internal (plain_file, encrypted_file,
-                                  certificate_str, certificate_len,
-                                  uid_email,
-                                  GPGME_PROTOCOL_CMS,
-                                  GPGME_DATA_TYPE_CMS_OTHER);
+  return encrypt_stream_internal (
+    plain_file, encrypted_file, certificate_str, certificate_len, uid_email,
+    GPGME_PROTOCOL_CMS, GPGME_DATA_TYPE_CMS_OTHER);
 }

--- a/util/gpgmeutils.h
+++ b/util/gpgmeutils.h
@@ -30,20 +30,21 @@
 #include <glib.h>  /* for gchar */
 #include <gpgme.h> /* for gpgme_ctx_t */
 
-void log_gpgme (GLogLevelFlags, gpg_error_t, const char *, ...);
+void
+log_gpgme (GLogLevelFlags, gpg_error_t, const char *, ...);
 
-gpgme_ctx_t gvm_init_gpgme_ctx_from_dir (const gchar *);
+gpgme_ctx_t
+gvm_init_gpgme_ctx_from_dir (const gchar *);
 
 int
 gvm_gpg_import_from_string (gpgme_ctx_t, const char *, ssize_t,
                             gpgme_data_type_t);
 
 int
-gvm_pgp_pubkey_encrypt_stream (FILE *, FILE *, const char *,
-                               const char *, ssize_t);
+gvm_pgp_pubkey_encrypt_stream (FILE *, FILE *, const char *, const char *,
+                               ssize_t);
 
 int
-gvm_smime_encrypt_stream (FILE *, FILE *, const char *,
-                          const char *, ssize_t);
+gvm_smime_encrypt_stream (FILE *, FILE *, const char *, const char *, ssize_t);
 
 #endif /*_GVM_GPGMEUTILS_H*/

--- a/util/kb.h
+++ b/util/kb.h
@@ -25,25 +25,25 @@
 #ifndef _GVM_KB_H
 #define _GVM_KB_H
 
+#include "../base/nvti.h" /* for nvti_t */
+
 #include <assert.h>
 #include <stddef.h>    /* for NULL */
 #include <sys/types.h> /* for size_t */
-
-#include "../base/nvti.h" /* for nvti_t */
 
 /**
  * @brief Default KB location.
  */
 #define KB_PATH_DEFAULT "/tmp/redis.sock"
 
-
 /**
  * @brief Possible type of a kb_item.
  */
-enum kb_item_type {
-  KB_TYPE_UNSPEC,   /**< Ignore the value (name/presence test).              */
-  KB_TYPE_INT,      /**< The kb_items v should then be interpreted as int.   */
-  KB_TYPE_STR,      /**< The kb_items v should then be interpreted as char*. */
+enum kb_item_type
+{
+  KB_TYPE_UNSPEC, /**< Ignore the value (name/presence test).              */
+  KB_TYPE_INT,    /**< The kb_items v should then be interpreted as int.   */
+  KB_TYPE_STR,    /**< The kb_items v should then be interpreted as char*. */
   /* -- */
   KB_TYPE_CNT,
 };
@@ -51,24 +51,25 @@ enum kb_item_type {
 /**
  * @brief Possible positions of nvt values in cache list.
  */
-enum kb_nvt_pos {
-    NVT_FILENAME_POS,
-    NVT_REQUIRED_KEYS_POS,
-    NVT_MANDATORY_KEYS_POS,
-    NVT_EXCLUDED_KEYS_POS,
-    NVT_REQUIRED_UDP_PORTS_POS,
-    NVT_REQUIRED_PORTS_POS,
-    NVT_DEPENDENCIES_POS,
-    NVT_TAGS_POS,
-    NVT_CVES_POS,
-    NVT_BIDS_POS,
-    NVT_XREFS_POS,
-    NVT_CATEGORY_POS,
-    NVT_TIMEOUT_POS,
-    NVT_FAMILY_POS,
-    NVT_NAME_POS,
-    NVT_TIMESTAMP_POS,
-    NVT_OID_POS,
+enum kb_nvt_pos
+{
+  NVT_FILENAME_POS,
+  NVT_REQUIRED_KEYS_POS,
+  NVT_MANDATORY_KEYS_POS,
+  NVT_EXCLUDED_KEYS_POS,
+  NVT_REQUIRED_UDP_PORTS_POS,
+  NVT_REQUIRED_PORTS_POS,
+  NVT_DEPENDENCIES_POS,
+  NVT_TAGS_POS,
+  NVT_CVES_POS,
+  NVT_BIDS_POS,
+  NVT_XREFS_POS,
+  NVT_CATEGORY_POS,
+  NVT_TIMEOUT_POS,
+  NVT_FAMILY_POS,
+  NVT_NAME_POS,
+  NVT_TIMESTAMP_POS,
+  NVT_OID_POS,
 };
 
 /**
@@ -77,19 +78,19 @@ enum kb_nvt_pos {
  */
 struct kb_item
 {
-  enum kb_item_type type;   /**< One of KB_TYPE_INT or KB_TYPE_STR. */
+  enum kb_item_type type; /**< One of KB_TYPE_INT or KB_TYPE_STR. */
 
-  union                 /**< Store a char or an int. */
+  union /**< Store a char or an int. */
   {
-    char *v_str;        /**< Hold an str value for this kb item. */
-    int v_int;          /**< Hold an int value for this kb item. */
-  };                    /**< Value of this knowledge base item. */
+    char *v_str; /**< Hold an str value for this kb item. */
+    int v_int;   /**< Hold an int value for this kb item. */
+  };             /**< Value of this knowledge base item. */
 
   size_t len;           /**< Length of string. */
   struct kb_item *next; /**< Next item in list. */
 
-  size_t namelen;       /**< Name length (including final NULL byte). */
-  char name[0];         /**< Name of this knowledge base item.  */
+  size_t namelen; /**< Name length (including final NULL byte). */
+  char name[0];   /**< Name of this knowledge base item.  */
 };
 
 struct kb_operations;
@@ -99,7 +100,7 @@ struct kb_operations;
  */
 struct kb
 {
-  const struct kb_operations *kb_ops;   /**< KB vtable. */
+  const struct kb_operations *kb_ops; /**< KB vtable. */
 };
 
 /**
@@ -158,12 +159,12 @@ struct kb_operations
    * Function provided by an implementation to get all items stored
    * under a given name.
    */
-  struct kb_item * (*kb_get_all) (kb_t, const char *);
+  struct kb_item *(*kb_get_all) (kb_t, const char *);
   /**
    * Function provided by an implementation to get all items stored
    * under a given pattern.
    */
-  struct kb_item * (*kb_get_pattern) (kb_t, const char *);
+  struct kb_item *(*kb_get_pattern) (kb_t, const char *);
   /**
    * Function provided by an implementation to count all items stored
    * under a given pattern.
@@ -227,8 +228,8 @@ extern const struct kb_operations *KBDefaultOperations;
 /**
  * @brief Release a KB item (or a list).
  */
-void kb_item_free (struct kb_item *);
-
+void
+kb_item_free (struct kb_item *);
 
 /**
  * @brief Initialize a new Knowledge Base object.
@@ -236,7 +237,8 @@ void kb_item_free (struct kb_item *);
  * @param[in] kb_path   Path to KB.
  * @return 0 on success, non-null on error.
  */
-static inline int kb_new (kb_t *kb, const char *kb_path)
+static inline int
+kb_new (kb_t *kb, const char *kb_path)
 {
   assert (kb);
   assert (KBDefaultOperations);
@@ -253,7 +255,8 @@ static inline int kb_new (kb_t *kb, const char *kb_path)
  * @param[in] kb_index       DB index
  * @return Knowledge Base object, NULL otherwise.
  */
-static inline kb_t kb_direct_conn (const char *kb_path, const int kb_index)
+static inline kb_t
+kb_direct_conn (const char *kb_path, const int kb_index)
 {
   assert (KBDefaultOperations);
   assert (KBDefaultOperations->kb_direct_conn);
@@ -267,7 +270,8 @@ static inline kb_t kb_direct_conn (const char *kb_path, const int kb_index)
  * @param[in] key       Marker key to search for in KB objects.
  * @return Knowledge Base object, NULL otherwise.
  */
-static inline kb_t kb_find (const char *kb_path, const char *key)
+static inline kb_t
+kb_find (const char *kb_path, const char *key)
 {
   assert (KBDefaultOperations);
   assert (KBDefaultOperations->kb_find);
@@ -280,7 +284,8 @@ static inline kb_t kb_find (const char *kb_path, const char *key)
  * @param[in] kb  KB handle to release.
  * @return 0 on success, non-null on error.
  */
-static inline int kb_delete (kb_t kb)
+static inline int
+kb_delete (kb_t kb)
 {
   assert (kb);
   assert (kb->kb_ops);
@@ -597,7 +602,6 @@ kb_nvt_get_oids (kb_t kb)
   return kb->kb_ops->kb_get_nvt_oids (kb);
 }
 
-
 /**
  * @brief Delete all entries under a given name.
  * @param[in] kb  KB handle where to store the item.
@@ -619,7 +623,8 @@ kb_del_items (kb_t kb, const char *name)
  * @param[in] kb        KB handle.
  * @return 0 on success, non-null on error.
  */
-static inline int kb_save (kb_t kb)
+static inline int
+kb_save (kb_t kb)
 {
   int rc = 0;
 
@@ -638,7 +643,8 @@ static inline int kb_save (kb_t kb)
  * @param[in] kb  KB handle.
  * @return 0 on success, non-null on error.
  */
-static inline int kb_lnk_reset (kb_t kb)
+static inline int
+kb_lnk_reset (kb_t kb)
 {
   int rc = 0;
 
@@ -657,7 +663,8 @@ static inline int kb_lnk_reset (kb_t kb)
  * @param[in] except    Don't flush DB with except key.
  * @return 0 on success, non-null on error.
  */
-static inline int kb_flush (kb_t kb, const char *except)
+static inline int
+kb_flush (kb_t kb, const char *except)
 {
   int rc = 0;
 
@@ -675,7 +682,8 @@ static inline int kb_flush (kb_t kb, const char *except)
  * @param[in] kb KB handle.
  * @return kb_index on success, null on error.
  */
-static inline int kb_get_kb_index (kb_t kb)
+static inline int
+kb_get_kb_index (kb_t kb)
 {
   assert (kb);
   assert (kb->kb_ops);

--- a/util/ldaputils.c
+++ b/util/ldaputils.c
@@ -26,13 +26,13 @@
 
 #ifdef ENABLE_LDAP_AUTH
 
-#include <glib.h>         /* for g_free, gchar, g_warning, g_strdup */
-#include <glib/gstdio.h>  /* for g_unlink, g_chmod */
-#include <lber.h>         /* for berval */
-#include <ldap.h>         /* for ldap_err2string, LDAP_SUCCESS, ldap_initialize */
+#include <glib.h>        /* for g_free, gchar, g_warning, g_strdup */
+#include <glib/gstdio.h> /* for g_unlink, g_chmod */
+#include <lber.h>        /* for berval */
+#include <ldap.h> /* for ldap_err2string, LDAP_SUCCESS, ldap_initialize */
 #include <stdio.h>
-#include <string.h>       /* for strlen, strchr, strstr */
-#include <unistd.h>       /* for close */
+#include <string.h> /* for strlen, strchr, strstr */
+#include <unistd.h> /* for close */
 
 #undef G_LOG_DOMAIN
 /**
@@ -45,10 +45,10 @@
 
 /**
  * @file ldap_connect_auth.c
- * Contains structs and functions to use for basic authentication (unmanaged, meaning that
- * authorization like role management is file-based) against an LDAP directory server.
+ * Contains structs and functions to use for basic authentication (unmanaged,
+ * meaning that authorization like role management is file-based) against an
+ * LDAP directory server.
  */
-
 
 /**
  * @brief Authenticate against an ldap directory server.
@@ -61,9 +61,9 @@
  * @return 0 authentication success, 1 authentication failure, -1 error.
  */
 int
-ldap_connect_authenticate (const gchar * username, const gchar * password,
-                           /*const *//*ldap_auth_info_t */ void *ldap_auth_info,
-                           const gchar *cacert)
+ldap_connect_authenticate (
+  const gchar *username, const gchar *password,
+  /*const */ /*ldap_auth_info_t */ void *ldap_auth_info, const gchar *cacert)
 {
   ldap_auth_info_t info = (ldap_auth_info_t) ldap_auth_info;
   LDAP *ldap = NULL;
@@ -106,7 +106,7 @@ ldap_connect_authenticate (const gchar * username, const gchar * password,
  *         ldap_auth_info_free.
  */
 ldap_auth_info_t
-ldap_auth_info_new (const gchar * ldap_host, const gchar * auth_dn,
+ldap_auth_info_new (const gchar *ldap_host, const gchar *auth_dn,
                     gboolean allow_plaintext)
 {
   // Certain parameters might not be NULL.
@@ -151,7 +151,7 @@ ldap_auth_info_free (ldap_auth_info_t info)
  *         with g_free.
  */
 gchar *
-ldap_auth_info_auth_dn (const ldap_auth_info_t info, const gchar * username)
+ldap_auth_info_auth_dn (const ldap_auth_info_t info, const gchar *username)
 {
   if (info == NULL || username == NULL)
     return NULL;
@@ -175,9 +175,8 @@ ldap_auth_info_auth_dn (const ldap_auth_info_t info, const gchar * username)
  * @return LDAP Handle or NULL if an error occurred, authentication failed etc.
  */
 LDAP *
-ldap_auth_bind (const gchar *host, const gchar *userdn,
-                const gchar *password, gboolean force_encryption,
-                const gchar *cacert)
+ldap_auth_bind (const gchar *host, const gchar *userdn, const gchar *password,
+                gboolean force_encryption, const gchar *cacert)
 {
   LDAP *ldap = NULL;
   int ldap_return = 0;
@@ -192,7 +191,7 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
 
   // Prevent empty password, bind against ADS will succeed with
   // empty password by default.
-  if (strlen(password) == 0)
+  if (strlen (password) == 0)
     return NULL;
 
   if (force_encryption == FALSE)
@@ -218,8 +217,7 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
           g_file_set_contents (name, cacert, strlen (cacert), &error);
           if (error)
             {
-              g_warning ("Could not write LDAP CACERTFILE: %s",
-                         error->message);
+              g_warning ("Could not write LDAP CACERTFILE: %s", error->message);
               g_error_free (error);
             }
           else
@@ -267,9 +265,9 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
         {
           if (force_encryption == TRUE)
             {
-              g_warning
-                ("Aborting ldap authentication: Could not init LDAP StartTLS nor ldaps: %s.",
-                 ldap_err2string (ldap_return));
+              g_warning ("Aborting ldap authentication: Could not init LDAP "
+                         "StartTLS nor ldaps: %s.",
+                         ldap_err2string (ldap_return));
               g_free (ldapuri);
               goto fail;
             }
@@ -277,7 +275,8 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
             {
               g_warning ("Could not init LDAP StartTLS, nor ldaps: %s.",
                          ldap_err2string (ldap_return));
-              g_warning ("Reinit LDAP connection to do plaintext authentication");
+              g_warning (
+                "Reinit LDAP connection to do plaintext authentication");
               ldap_unbind_ext_s (ldap, NULL, NULL);
 
               // Note that for connections to default ADS, a failed
@@ -285,7 +284,8 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
               ldap_return = ldap_initialize (&ldap, ldapuri);
               if (ldap == NULL || ldap_return != LDAP_SUCCESS)
                 {
-                  g_warning ("Could not reopen LDAP connection for authentication.");
+                  g_warning (
+                    "Could not reopen LDAP connection for authentication.");
                   g_free (ldapuri);
                   goto fail;
                 }
@@ -308,8 +308,8 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
       gchar **use_uid = NULL;
       ldap_memfree (dn);
       dn = NULL;
-      uid = g_strsplit (userdn,",",2);
-      use_uid = g_strsplit (uid[0],"=", 2);
+      uid = g_strsplit (userdn, ",", 2);
+      use_uid = g_strsplit (uid[0], "=", 2);
 
       if (!g_strcmp0 (use_uid[0], "uid"))
         do_search = 1;
@@ -328,8 +328,8 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
       /* Perform anonymous bind to search. */
       credential.bv_val = NULL;
       credential.bv_len = 0U;
-      ldap_return = ldap_sasl_bind_s (ldap, NULL, LDAP_SASL_SIMPLE,
-                                      &credential, NULL, NULL, NULL);
+      ldap_return = ldap_sasl_bind_s (ldap, NULL, LDAP_SASL_SIMPLE, &credential,
+                                      NULL, NULL, NULL);
       if (ldap_return != LDAP_SUCCESS)
         {
           g_warning ("LDAP anonymous authentication failure: %s",
@@ -338,7 +338,7 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
         }
       else
         {
-          char *attrs[2] = { "dn", NULL };
+          char *attrs[2] = {"dn", NULL};
           LDAPMessage *result = NULL;
           gchar **base = g_strsplit (userdn, ",", 2);
 
@@ -392,7 +392,7 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
       return ldap;
     }
 
- fail:
+fail:
   if (fd > -1)
     {
       g_unlink (name);
@@ -410,7 +410,7 @@ ldap_auth_bind (const gchar *host, const gchar *userdn,
  * @return TRUE if authdn is considered safe enough to be sprintf'ed into.
  */
 gboolean
-ldap_auth_dn_is_good (const gchar * authdn)
+ldap_auth_dn_is_good (const gchar *authdn)
 {
   gchar *eg;
   LDAPDN dn;
@@ -432,7 +432,7 @@ ldap_auth_dn_is_good (const gchar * authdn)
   ln = strlen (authdn);
 
   // As a special exception allow ADS-style domain\user - pairs.
-  if (strchr (authdn, '\\') && authdn[ln-2] == '%' && authdn[ln-1] == 's')
+  if (strchr (authdn, '\\') && authdn[ln - 2] == '%' && authdn[ln - 1] == 's')
     return TRUE;
 
   // Also allow user@domain - pairs.
@@ -469,7 +469,7 @@ ldap_auth_dn_is_good (const gchar * authdn)
  * @return NULL.
  */
 ldap_auth_info_t
-ldap_auth_info_new (const gchar * ldap_host, const gchar * auth_dn,
+ldap_auth_info_new (const gchar *ldap_host, const gchar *auth_dn,
                     gboolean allow_plaintext)
 {
   (void) ldap_host;
@@ -489,9 +489,9 @@ ldap_auth_info_new (const gchar * ldap_host, const gchar * auth_dn,
  * @return -1.
  */
 int
-ldap_connect_authenticate (const gchar * username, const gchar * password,
-                   /*const *//*ldap_auth_info_t */ void *ldap_auth_info,
-                           const gchar *cacert)
+ldap_connect_authenticate (
+  const gchar *username, const gchar *password,
+  /*const */ /*ldap_auth_info_t */ void *ldap_auth_info, const gchar *cacert)
 {
   (void) username;
   (void) password;

--- a/util/ldaputils.h
+++ b/util/ldaputils.h
@@ -38,13 +38,14 @@ typedef struct ldap_auth_info *ldap_auth_info_t;
  */
 struct ldap_auth_info
 {
-  gchar *ldap_host;             ///< Address of the ldap server, might include port.
-  gchar *auth_dn;               ///< DN to authenticate with.
-  gboolean allow_plaintext;     ///< !Whether or not StartTLS is required.
+  gchar *ldap_host;         ///< Address of the ldap server, might include port.
+  gchar *auth_dn;           ///< DN to authenticate with.
+  gboolean allow_plaintext; ///< !Whether or not StartTLS is required.
 };
 
-int ldap_connect_authenticate (const gchar *, const gchar *,
-                               /* ldap_auth_info_t */ void *, const gchar *);
+int
+ldap_connect_authenticate (const gchar *, const gchar *,
+                           /* ldap_auth_info_t */ void *, const gchar *);
 
 void ldap_auth_info_free (ldap_auth_info_t);
 
@@ -55,14 +56,15 @@ ldap_auth_info_new (const gchar *, const gchar *, gboolean);
 
 #include <ldap.h>
 
-gchar*
-ldap_auth_info_auth_dn (const ldap_auth_info_t, const gchar*);
+gchar *
+ldap_auth_info_auth_dn (const ldap_auth_info_t, const gchar *);
 
 LDAP *
 ldap_auth_bind (const gchar *, const gchar *, const gchar *, gboolean,
                 const gchar *);
 
-gboolean ldap_auth_dn_is_good (const gchar *);
+gboolean
+ldap_auth_dn_is_good (const gchar *);
 
 #endif /* ENABLE_LDAP_AUTH */
 

--- a/util/nvticache.c
+++ b/util/nvticache.c
@@ -30,25 +30,25 @@
 
 #include "nvticache.h"
 
-#include <assert.h>   /* for assert */
+#include "kb.h" /* for kb_del_items, kb_item_get_str, kb_item_add_int */
+
+#include <assert.h> /* for assert */
+#include <errno.h>
+#include <stdio.h>    /* for fopen */
+#include <stdlib.h>   /* for atoi */
 #include <string.h>   /* for strcmp */
 #include <sys/stat.h> /* for stat, st_mtime */
 #include <time.h>     /* for time, time_t */
-#include <stdlib.h>     /* for atoi */
-#include <stdio.h>     /* for fopen */
-#include <errno.h>
 
-#include "kb.h" /* for kb_del_items, kb_item_get_str, kb_item_add_int */
-
-#undef  G_LOG_DOMAIN
+#undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.
  */
 #define G_LOG_DOMAIN "lib  nvticache"
 
-char *src_path = NULL;      /**< The directory of the source files. */
-kb_t cache_kb = NULL;       /**< Cache KB handler. */
-int cache_saved = 1;        /**< If cache was saved. */
+char *src_path = NULL; /**< The directory of the source files. */
+kb_t cache_kb = NULL;  /**< Cache KB handler. */
+int cache_saved = 1;   /**< If cache was saved. */
 
 /**
  * @brief Return whether the nvt cache is initialized.
@@ -58,7 +58,7 @@ int cache_saved = 1;        /**< If cache was saved. */
 int
 nvticache_initialized (void)
 {
- return !!cache_kb;
+  return !!cache_kb;
 }
 
 /**
@@ -525,19 +525,19 @@ nvticache_get_prefs (const char *oid)
   g_snprintf (pattern, sizeof (pattern), "oid:%s:prefs", oid);
   prefs = element = kb_item_get_all (cache_kb, pattern);
   while (element)
-  {
-    nvtpref_t *np;
-    char **array = g_strsplit (element->v_str, "|||", -1);
+    {
+      nvtpref_t *np;
+      char **array = g_strsplit (element->v_str, "|||", -1);
 
-    assert (array[2]);
-    assert (!array[3]);
-    np = g_malloc0 (sizeof (nvtpref_t));
-    np->name = array[0];
-    np->type = array[1];
-    np->dflt = array[2];
-    list = g_slist_append (list, np);
-    element = element->next;
-  }
+      assert (array[2]);
+      assert (!array[3]);
+      np = g_malloc0 (sizeof (nvtpref_t));
+      np->name = array[0];
+      np->type = array[1];
+      np->dflt = array[2];
+      list = g_slist_append (list, np);
+      element = element->next;
+    }
   kb_item_free (prefs);
 
   return list;

--- a/util/nvticache.h
+++ b/util/nvticache.h
@@ -27,10 +27,10 @@
 #ifndef _GVM_NVTICACHE_H
 #define _GVM_NVTICACHE_H
 
-#include <glib.h>          /* for gchar */
+#include "../base/nvti.h" /* for nvti_t */
+#include "kb.h"           /* for kb_t */
 
-#include "../base/nvti.h"  /* for nvti_t */
-#include "kb.h"            /* for kb_t */
+#include <glib.h> /* for gchar */
 
 #ifndef NVTICACHE_STR
 #define NVTICACHE_STR "nvticache10"

--- a/util/radiusutils.c
+++ b/util/radiusutils.c
@@ -24,7 +24,7 @@
 
 #ifdef ENABLE_RADIUS_AUTH
 
-#include <arpa/inet.h>          /* for inet_pton */
+#include <arpa/inet.h> /* for inet_pton */
 
 #if defined(RADIUS_AUTH_FREERADIUS)
 #include <freeradius-client.h>
@@ -33,22 +33,22 @@
 #endif
 #elif defined(RADIUS_AUTH_RADCLI)
 #include <errno.h>
-#include <unistd.h>
-#include <stdlib.h>             /* for mkstemp */
-#include <string.h>             /* for strerror */
 #include <radcli/radcli.h>
+#include <stdlib.h> /* for mkstemp */
+#include <string.h> /* for strerror */
+#include <unistd.h>
 #ifndef RC_CONFIG_FILE
 #define RC_DICTIONARY_FILE "/etc/radcli/dictionary"
 #endif
 #endif
 
-#include <glib.h>               /* for g_warning */
 #include "../base/networking.h" /* for gvm_resolve */
+
+#include <glib.h> /* for g_warning */
 
 #ifndef PW_MAX_MSG_SIZE
 #define PW_MAX_MSG_SIZE 4096
 #endif
-
 
 /**
  * Initialize the Radius client configuration.
@@ -104,9 +104,8 @@ radius_init (const char *hostname, const char *secret)
                "radius_deadtime  0\n"
                "authserver  %s\n"
                "acctserver  %s\n",
-               RC_DICTIONARY_FILE,
-               authserver,
-               authserver) < 0)
+               RC_DICTIONARY_FILE, authserver, authserver)
+      < 0)
     {
       fclose (config_file);
       g_warning ("%s: Couldn't write to temp radius config file %s:%s\n",
@@ -119,13 +118,13 @@ radius_init (const char *hostname, const char *secret)
   rh = rc_read_config (config_filename);
   if (rh == NULL)
     {
-      g_warning ("%s: Couldn't read temp radius config file %s\n",
-                 __FUNCTION__, config_filename);
+      g_warning ("%s: Couldn't read temp radius config file %s\n", __FUNCTION__,
+                 config_filename);
       unlink (config_filename);
       goto radius_init_fail;
     }
   unlink (config_filename);
-#else // defined(RADIUS_AUTH_RADCLI)
+#else  // defined(RADIUS_AUTH_RADCLI)
   if ((rh = rc_new ()) == NULL)
     {
       g_warning ("radius_init: Couldn't allocate memory");
@@ -133,44 +132,44 @@ radius_init (const char *hostname, const char *secret)
     }
   if (!rc_config_init (rh))
     {
-      g_warning("radius_init: Couldn't initialize the config");
+      g_warning ("radius_init: Couldn't initialize the config");
       return NULL;
     }
 
   /* Set the basic configuration options. */
   if (rc_add_config (rh, "auth_order", "radius", "config", 0))
     {
-      g_warning("radius_init: Couldn't set auth_order");
+      g_warning ("radius_init: Couldn't set auth_order");
       goto radius_init_fail;
     }
   if (rc_add_config (rh, "login_tries", "4", "config", 0))
     {
-      g_warning("radius_init: Couldn't set login_tries");
+      g_warning ("radius_init: Couldn't set login_tries");
       goto radius_init_fail;
     }
   if (rc_add_config (rh, "dictionary", RC_DICTIONARY_FILE, "config", 0))
     {
-      g_warning("radius_init: Couldn't set dictionary");
+      g_warning ("radius_init: Couldn't set dictionary");
       goto radius_init_fail;
     }
   if (rc_add_config (rh, "seqfile", "/var/run/radius.seq", "config", 0))
     {
-      g_warning("radius_init: Couldn't set seqfile");
+      g_warning ("radius_init: Couldn't set seqfile");
       goto radius_init_fail;
     }
   if (rc_add_config (rh, "radius_retries", "3", "config", 0))
     {
-      g_warning("radius_init: Couldn't set radius_retries");
+      g_warning ("radius_init: Couldn't set radius_retries");
       goto radius_init_fail;
     }
   if (rc_add_config (rh, "radius_timeout", "5", "config", 0))
     {
-      g_warning("radius_init: Couldn't set radius_timeout");
+      g_warning ("radius_init: Couldn't set radius_timeout");
       goto radius_init_fail;
     }
   if (rc_add_config (rh, "radius_deadtime", "0", "config", 0))
     {
-      g_warning("radius_init: Couldn't set radius_deadtime");
+      g_warning ("radius_init: Couldn't set radius_deadtime");
       goto radius_init_fail;
     }
   if (rc_add_config (rh, "authserver", authserver, "config", 0) != 0)
@@ -254,7 +253,7 @@ authenticate_leave:
   return rc;
 }
 
-#else  /* ENABLE_RADIUS_AUTH */
+#else /* ENABLE_RADIUS_AUTH */
 
 /**
  * @brief Dummy function for manager.

--- a/util/serverutils.h
+++ b/util/serverutils.h
@@ -42,62 +42,78 @@
  */
 typedef struct
 {
-  int tls;                      ///< Whether uses TCP-TLS (vs UNIX socket).
-  int socket;                   ///< Socket.
-  gnutls_session_t session;     ///< Session.
-  gnutls_certificate_credentials_t credentials;  ///< Credentials.
-  gchar *username;              ///< Username with which to connect.
-  gchar *password;              ///< Password for user with which to connect.
-  gchar *host_string;           ///< Server host string.
-  gchar *port_string;           ///< Server port string.
-  gint port;                    ///< Port of server.
-  gboolean use_certs;           ///< Whether to use certs.
-  gchar *ca_cert;               ///< CA certificate.
-  gchar *pub_key;               ///< The public key.
-  gchar *priv_key;              ///< The private key.
+  int tls;                  ///< Whether uses TCP-TLS (vs UNIX socket).
+  int socket;               ///< Socket.
+  gnutls_session_t session; ///< Session.
+  gnutls_certificate_credentials_t credentials; ///< Credentials.
+  gchar *username;    ///< Username with which to connect.
+  gchar *password;    ///< Password for user with which to connect.
+  gchar *host_string; ///< Server host string.
+  gchar *port_string; ///< Server port string.
+  gint port;          ///< Port of server.
+  gboolean use_certs; ///< Whether to use certs.
+  gchar *ca_cert;     ///< CA certificate.
+  gchar *pub_key;     ///< The public key.
+  gchar *priv_key;    ///< The private key.
 } gvm_connection_t;
 
-void gvm_connection_free (gvm_connection_t *);
+void
+gvm_connection_free (gvm_connection_t *);
 
-void gvm_connection_close (gvm_connection_t *);
+void
+gvm_connection_close (gvm_connection_t *);
 
 int gvm_server_verify (gnutls_session_t);
 
-int gvm_server_open (gnutls_session_t *, const char *, int);
+int
+gvm_server_open (gnutls_session_t *, const char *, int);
 
-int gvm_server_open_verify (gnutls_session_t *, const char *, int,
-                            const char *, const char *, const char *, int);
+int
+gvm_server_open_verify (gnutls_session_t *, const char *, int, const char *,
+                        const char *, const char *, int);
 
-int gvm_server_open_with_cert (gnutls_session_t *, const char *, int,
-                               const char *, const char *, const char *);
+int
+gvm_server_open_with_cert (gnutls_session_t *, const char *, int, const char *,
+                           const char *, const char *);
 
-int gvm_server_close (int, gnutls_session_t);
+int
+gvm_server_close (int, gnutls_session_t);
 
-int gvm_server_attach (int, gnutls_session_t *);
+int
+gvm_server_attach (int, gnutls_session_t *);
 
-int gvm_server_sendf (gnutls_session_t *, const char *, ...)
-    __attribute__ ((format (printf, 2, 3)));
+int
+gvm_server_sendf (gnutls_session_t *, const char *, ...)
+  __attribute__ ((format (printf, 2, 3)));
 
-int gvm_server_vsendf (gnutls_session_t *, const char *, va_list);
-int gvm_socket_vsendf (int, const char *, va_list);
+int
+gvm_server_vsendf (gnutls_session_t *, const char *, va_list);
+int
+gvm_socket_vsendf (int, const char *, va_list);
 
-int gvm_server_sendf_xml (gnutls_session_t *, const char *, ...);
-int gvm_server_sendf_xml_quiet (gnutls_session_t *, const char *, ...);
+int
+gvm_server_sendf_xml (gnutls_session_t *, const char *, ...);
+int
+gvm_server_sendf_xml_quiet (gnutls_session_t *, const char *, ...);
 
-int gvm_connection_sendf_xml (gvm_connection_t *, const char *, ...);
-int gvm_connection_sendf_xml_quiet (gvm_connection_t *, const char *, ...);
+int
+gvm_connection_sendf_xml (gvm_connection_t *, const char *, ...);
+int
+gvm_connection_sendf_xml_quiet (gvm_connection_t *, const char *, ...);
 
-int gvm_connection_sendf (gvm_connection_t *, const char *, ...);
+int
+gvm_connection_sendf (gvm_connection_t *, const char *, ...);
 
-int gvm_server_new (unsigned int, gchar *, gchar *, gchar *,
+int
+gvm_server_new (unsigned int, gchar *, gchar *, gchar *, gnutls_session_t *,
+                gnutls_certificate_credentials_t *);
+
+int
+gvm_server_new_mem (unsigned int, const char *, const char *, const char *,
                     gnutls_session_t *, gnutls_certificate_credentials_t *);
 
-int gvm_server_new_mem (unsigned int, const char *, const char *,
-                        const char *, gnutls_session_t *,
-                        gnutls_certificate_credentials_t *);
-
-int gvm_server_free (int, gnutls_session_t,
-                     gnutls_certificate_credentials_t);
+int
+gvm_server_free (int, gnutls_session_t, gnutls_certificate_credentials_t);
 
 int gvm_server_session_free (gnutls_session_t,
                              gnutls_certificate_credentials_t);
@@ -106,7 +122,7 @@ int
 load_gnutls_file (const char *, gnutls_datum_t *);
 
 void
-unload_gnutls_file(gnutls_datum_t *);
+unload_gnutls_file (gnutls_datum_t *);
 
 int
 set_gnutls_dhparams (gnutls_certificate_credentials_t, const char *);

--- a/util/sshutils.c
+++ b/util/sshutils.c
@@ -26,7 +26,7 @@
 
 #include <glib.h>          /* for g_free, g_strdup, g_strdup_printf */
 #include <gnutls/gnutls.h> /* for gnutls_datum_t */
-#include <gnutls/x509.h>   /* for gnutls_x509_privkey_deinit, gnutls_x509_p... */
+#include <gnutls/x509.h> /* for gnutls_x509_privkey_deinit, gnutls_x509_p... */
 #include <libssh/libssh.h> /* for ssh_key_free, ssh_key_type, ssh_key_type_... */
 #include <string.h>        /* for strcmp, strlen */
 
@@ -85,15 +85,15 @@ gvm_ssh_public_from_private (const char *private_key, const char *passphrase)
   int ret;
 
   decrypted_priv = gvm_ssh_pkcs8_decrypt (private_key, passphrase);
-  ret = ssh_pki_import_privkey_base64
-         (decrypted_priv ? decrypted_priv : private_key, passphrase,
-          NULL, NULL, &priv);
+  ret = ssh_pki_import_privkey_base64 (decrypted_priv ? decrypted_priv
+                                                      : private_key,
+                                       passphrase, NULL, NULL, &priv);
   g_free (decrypted_priv);
   if (ret)
     return NULL;
   ret = ssh_pki_export_pubkey_base64 (priv, &pub_key);
   type = ssh_key_type_to_char (ssh_key_type (priv));
-#if LIBSSH_VERSION_INT >= SSH_VERSION_INT (0, 6, 4)
+#if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0, 6, 4)
   if (!strcmp (type, "ssh-ecdsa"))
     type = ssh_pki_key_ecdsa_name (priv);
 #endif

--- a/util/uuidutils.c
+++ b/util/uuidutils.c
@@ -22,12 +22,11 @@
  * @brief UUID creation.
  */
 
+#include "uuidutils.h"
+
 #include <glib.h>
 #include <stdlib.h>
 #include <uuid/uuid.h>
-
-#include "uuidutils.h"
-
 
 /**
  * @brief Make a new universal identifier.

--- a/util/uuidutils.h
+++ b/util/uuidutils.h
@@ -25,6 +25,7 @@
 #ifndef _GVM_UUIDUTILS_H
 #define _GVM_UUIDUTILS_H
 
-char *gvm_uuid_make (void);
+char *
+gvm_uuid_make (void);
 
 #endif /* not _GVM_UUIDUTILS_H */

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -110,7 +110,7 @@ first_entity (entities_t entities)
  * @return The new entity.
  */
 entity_t
-add_entity (entities_t * entities, const char *name, const char *text)
+add_entity (entities_t *entities, const char *name, const char *text)
 {
   entity_t entity = make_entity (name, text);
   if (entities)
@@ -209,9 +209,8 @@ entity_child (entity_t entity, const char *name)
 
   if (entity->entities)
     {
-      entities_t match = g_slist_find_custom (entity->entities,
-                                              name,
-                                              compare_entity_with_name);
+      entities_t match =
+        g_slist_find_custom (entity->entities, name, compare_entity_with_name);
       return match ? (entity_t) match->data : NULL;
     }
   return NULL;
@@ -244,7 +243,7 @@ entity_attribute (entity_t entity, const char *name)
  * @param[in]  values  List of attribute values.
  */
 void
-add_attributes (entity_t entity, const gchar ** names, const gchar ** values)
+add_attributes (entity_t entity, const gchar **names, const gchar **values)
 {
   if (*names && *values)
     {
@@ -273,10 +272,10 @@ add_attributes (entity_t entity, const gchar ** names, const gchar ** values)
  * @param[in]  error             Error parameter.
  */
 static void
-handle_start_element (GMarkupParseContext * context, const gchar * element_name,
-                      const gchar ** attribute_names,
-                      const gchar ** attribute_values, gpointer user_data,
-                      GError ** error)
+handle_start_element (GMarkupParseContext *context, const gchar *element_name,
+                      const gchar **attribute_names,
+                      const gchar **attribute_values, gpointer user_data,
+                      GError **error)
 {
   entity_t entity;
   context_data_t *data = (context_data_t *) user_data;
@@ -326,8 +325,8 @@ xml_handle_start_element (context_data_t *context, const gchar *element_name,
  * @param[in]  error             Error parameter.
  */
 static void
-handle_end_element (GMarkupParseContext * context, const gchar * element_name,
-                    gpointer user_data, GError ** error)
+handle_end_element (GMarkupParseContext *context, const gchar *element_name,
+                    gpointer user_data, GError **error)
 {
   context_data_t *data = (context_data_t *) user_data;
 
@@ -339,7 +338,8 @@ handle_end_element (GMarkupParseContext * context, const gchar * element_name,
     {
       assert (strcmp (element_name,
                       /* The name of the very first entity. */
-                      ((entity_t) (data->first->data))->name) == 0);
+                      ((entity_t) (data->first->data))->name)
+              == 0);
       data->done = TRUE;
       /* "Pop" the element. */
       data->current = g_slist_next (data->current);
@@ -376,8 +376,8 @@ xml_handle_end_element (context_data_t *context, const gchar *element_name)
  * @param[in]  error             Error parameter.
  */
 static void
-handle_text (GMarkupParseContext * context, const gchar * text, gsize text_len,
-             gpointer user_data, GError ** error)
+handle_text (GMarkupParseContext *context, const gchar *text, gsize text_len,
+             gpointer user_data, GError **error)
 {
   context_data_t *data = (context_data_t *) user_data;
 
@@ -416,7 +416,7 @@ xml_handle_text (context_data_t *context, const gchar *text, gsize text_len)
  * @param[in]  user_data         Dummy parameter.
  */
 void
-handle_error (GMarkupParseContext * context, GError * error, gpointer user_data)
+handle_error (GMarkupParseContext *context, GError *error, gpointer user_data)
 {
   (void) context;
   (void) user_data;
@@ -427,21 +427,20 @@ handle_error (GMarkupParseContext * context, GError * error, gpointer user_data)
  * @brief Try read an XML entity tree from the manager.
  *
  * @param[in]   session        Pointer to GNUTLS session.
- * @param[in]   timeout        Server idle time before giving up, in seconds.  0 to
- *                             wait forever.
+ * @param[in]   timeout        Server idle time before giving up, in seconds.  0
+ * to wait forever.
  * @param[out]  entity         Pointer to an entity tree.
  * @param[out]  string_return  An optional return location for the text read
  *                             from the session.  If NULL then it simply
- *                             remains NULL.  If a pointer to NULL then it points
- *                             to a freshly allocated GString on successful return.
- *                             Otherwise it points to an existing GString onto
- *                             which the text is appended.
+ *                             remains NULL.  If a pointer to NULL then it
+ * points to a freshly allocated GString on successful return. Otherwise it
+ * points to an existing GString onto which the text is appended.
  *
  * @return 0 success, -1 read error, -2 parse error, -3 end of file, -4 timeout.
  */
 int
-try_read_entity_and_string (gnutls_session_t * session, int timeout,
-                            entity_t * entity, GString ** string_return)
+try_read_entity_and_string (gnutls_session_t *session, int timeout,
+                            entity_t *entity, GString **string_return)
 {
   GMarkupParser xml_parser;
   GError *error = NULL;
@@ -457,8 +456,7 @@ try_read_entity_and_string (gnutls_session_t * session, int timeout,
 
   if (time (&last_time) == -1)
     {
-      g_warning ("   failed to get current time: %s\n",
-                 strerror (errno));
+      g_warning ("   failed to get current time: %s\n", strerror (errno));
       return -1;
     }
 
@@ -511,8 +509,7 @@ try_read_entity_and_string (gnutls_session_t * session, int timeout,
       while (1)
         {
           g_debug ("   asking for %i\n", BUFFER_SIZE);
-          count =
-            gnutls_record_recv (*session, buffer, BUFFER_SIZE);
+          count = gnutls_record_recv (*session, buffer, BUFFER_SIZE);
           if (count < 0)
             {
               if (count == GNUTLS_E_INTERRUPTED)
@@ -521,8 +518,7 @@ try_read_entity_and_string (gnutls_session_t * session, int timeout,
               if ((timeout > 0) && (count == GNUTLS_E_AGAIN))
                 {
                   /* Server still busy, either timeout or try read again. */
-                  if ((timeout - (time (NULL) - last_time))
-                      <= 0)
+                  if ((timeout - (time (NULL) - last_time)) <= 0)
                     {
                       g_warning ("   timeout\n");
                       if (fcntl (socket, F_SETFL, 0L) < 0)
@@ -602,8 +598,8 @@ try_read_entity_and_string (gnutls_session_t * session, int timeout,
           if (timeout > 0)
             {
               if (fcntl (socket, F_SETFL, 0L) < 0)
-                g_warning ("%s :failed to set socket flag: %s",
-                           __FUNCTION__, strerror (errno));
+                g_warning ("%s :failed to set socket flag: %s", __FUNCTION__,
+                           strerror (errno));
             }
           g_markup_parse_context_free (xml_context);
           g_free (buffer);
@@ -655,15 +651,14 @@ try_read_entity_and_string (gnutls_session_t * session, int timeout,
  * @brief Try read an XML entity tree from the socket.
  *
  * @param[in]   socket         Socket to read from.
- * @param[in]   timeout        Server idle time before giving up, in seconds.  0 to
- *                             wait forever.
+ * @param[in]   timeout        Server idle time before giving up, in seconds.  0
+ * to wait forever.
  * @param[out]  entity         Pointer to an entity tree.
  * @param[out]  string_return  An optional return location for the text read
  *                             from the session.  If NULL then it simply
- *                             remains NULL.  If a pointer to NULL then it points
- *                             to a freshly allocated GString on successful return.
- *                             Otherwise it points to an existing GString onto
- *                             which the text is appended.
+ *                             remains NULL.  If a pointer to NULL then it
+ * points to a freshly allocated GString on successful return. Otherwise it
+ * points to an existing GString onto which the text is appended.
  *
  * @return 0 success, -1 read error, -2 parse error, -3 end of file, -4 timeout.
  */
@@ -683,8 +678,7 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
 
   if (time (&last_time) == -1)
     {
-      g_warning ("   failed to get current time: %s\n",
-                 strerror (errno));
+      g_warning ("   failed to get current time: %s\n", strerror (errno));
       return -1;
     }
 
@@ -744,8 +738,7 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
                   if (errno == EAGAIN)
                     {
                       /* Server still busy, either timeout or try read again. */
-                      if ((timeout - (time (NULL) - last_time))
-                          <= 0)
+                      if ((timeout - (time (NULL) - last_time)) <= 0)
                         {
                           g_warning ("   timeout\n");
                           if (fcntl (socket, F_SETFL, 0L) < 0)
@@ -820,8 +813,8 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
           if (timeout > 0)
             {
               if (fcntl (socket, F_SETFL, 0L) < 0)
-                g_warning ("%s :failed to set socket flag: %s",
-                           __FUNCTION__, strerror (errno));
+                g_warning ("%s :failed to set socket flag: %s", __FUNCTION__,
+                           strerror (errno));
             }
           g_markup_parse_context_free (xml_context);
           g_free (buffer);
@@ -861,8 +854,8 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
           g_warning ("   failed to get current time (1): %s\n",
                      strerror (errno));
           if (fcntl (socket, F_SETFL, 0L) < 0)
-            g_warning ("%s :failed to set server socket flag: %s",
-                       __FUNCTION__, strerror (errno));
+            g_warning ("%s :failed to set server socket flag: %s", __FUNCTION__,
+                       strerror (errno));
           g_markup_parse_context_free (xml_context);
           g_free (buffer);
           return -1;
@@ -877,16 +870,15 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
  * @param[out]  entity           Pointer to an entity tree.
  * @param[out]  string_return    An optional return location for the text read
  *                               from the session.  If NULL then it simply
- *                               remains NULL.  If a pointer to NULL then it points
- *                               to a freshly allocated GString on successful return.
- *                               Otherwise it points to an existing GString onto
- *                               which the text is appended.
+ *                               remains NULL.  If a pointer to NULL then it
+ * points to a freshly allocated GString on successful return. Otherwise it
+ * points to an existing GString onto which the text is appended.
  *
  * @return 0 success, -1 read error, -2 parse error, -3 end of file.
  */
 int
-read_entity_and_string (gnutls_session_t * session, entity_t * entity,
-                        GString ** string_return)
+read_entity_and_string (gnutls_session_t *session, entity_t *entity,
+                        GString **string_return)
 {
   return try_read_entity_and_string (session, 0, entity, string_return);
 }
@@ -898,16 +890,15 @@ read_entity_and_string (gnutls_session_t * session, entity_t * entity,
  * @param[out]  entity           Pointer to an entity tree.
  * @param[out]  string_return    An optional return location for the text read
  *                               from the session.  If NULL then it simply
- *                               remains NULL.  If a pointer to NULL then it points
- *                               to a freshly allocated GString on successful return.
- *                               Otherwise it points to an existing GString onto
- *                               which the text is appended.
+ *                               remains NULL.  If a pointer to NULL then it
+ * points to a freshly allocated GString on successful return. Otherwise it
+ * points to an existing GString onto which the text is appended.
  *
  * @return 0 success, -1 read error, -2 parse error, -3 end of file.
  */
 int
-read_entity_and_string_c (gvm_connection_t *connection, entity_t * entity,
-                          GString ** string_return)
+read_entity_and_string_c (gvm_connection_t *connection, entity_t *entity,
+                          GString **string_return)
 {
   if (connection->tls)
     return try_read_entity_and_string (&connection->session, 0, entity,
@@ -929,8 +920,7 @@ read_entity_and_string_c (gvm_connection_t *connection, entity_t * entity,
  * @return 0 success, -1 read error, -2 parse error, -3 end of file.
  */
 int
-read_entity_and_text (gnutls_session_t * session, entity_t * entity,
-                      char **text)
+read_entity_and_text (gnutls_session_t *session, entity_t *entity, char **text)
 {
   if (text)
     {
@@ -989,7 +979,7 @@ read_entity_and_text_c (gvm_connection_t *connection, entity_t *entity,
  * @return 0 success, -1 read error, -2 parse error, -3 end of file.
  */
 int
-read_string (gnutls_session_t * session, GString ** string)
+read_string (gnutls_session_t *session, GString **string)
 {
   int ret = 0;
   entity_t entity;
@@ -1031,7 +1021,7 @@ read_string_c (gvm_connection_t *connection, GString **string)
  * @return 0 success, -1 read error, -2 parse error, -3 end of file, -4 timeout.
  */
 int
-try_read_entity (gnutls_session_t * session, int timeout, entity_t * entity)
+try_read_entity (gnutls_session_t *session, int timeout, entity_t *entity)
 {
   return try_read_entity_and_string (session, timeout, entity, NULL);
 }
@@ -1047,12 +1037,12 @@ try_read_entity (gnutls_session_t * session, int timeout, entity_t * entity)
  * @return 0 success, -1 read error, -2 parse error, -3 end of file, -4 timeout.
  */
 int
-try_read_entity_c (gvm_connection_t *connection, int timeout,
-                   entity_t * entity)
+try_read_entity_c (gvm_connection_t *connection, int timeout, entity_t *entity)
 {
   if (connection->tls)
     return try_read_entity_and_string (&connection->session, 0, entity, NULL);
-  return try_read_entity_and_string_s (connection->socket, timeout, entity, NULL);
+  return try_read_entity_and_string_s (connection->socket, timeout, entity,
+                                       NULL);
 }
 
 /**
@@ -1064,7 +1054,7 @@ try_read_entity_c (gvm_connection_t *connection, int timeout,
  * @return 0 success, -1 read error, -2 parse error, -3 end of file.
  */
 int
-read_entity (gnutls_session_t * session, entity_t * entity)
+read_entity (gnutls_session_t *session, entity_t *entity)
 {
   return try_read_entity (session, 0, entity);
 }
@@ -1078,7 +1068,7 @@ read_entity (gnutls_session_t * session, entity_t * entity)
  * @return 0 success, -1 read error, -2 parse error, -3 end of file.
  */
 int
-read_entity_s (int socket, entity_t * entity)
+read_entity_s (int socket, entity_t *entity)
 {
   return try_read_entity_and_string_s (socket, 0, entity, NULL);
 }
@@ -1106,7 +1096,7 @@ read_entity_c (gvm_connection_t *connection, entity_t *entity)
  * @return 0 success, -1 read error, -2 parse error, -3 XML ended prematurely.
  */
 int
-parse_entity (const char *string, entity_t * entity)
+parse_entity (const char *string, entity_t *entity)
 {
   GMarkupParser xml_parser;
   GError *error = NULL;
@@ -1204,7 +1194,7 @@ foreach_print_attribute_to_string (gpointer name, gpointer value,
  * @param[in,out]  string  String to write to (will be created if NULL).
  */
 void
-print_entity_to_string (entity_t entity, GString * string)
+print_entity_to_string (entity_t entity, GString *string)
 {
   gchar *text_escaped = NULL;
   g_string_append_printf (string, "<%s", entity->name);
@@ -1251,7 +1241,7 @@ foreach_print_attribute (gpointer name, gpointer value, gpointer stream)
  * @param[in]  stream  The stream to which to print.
  */
 void
-print_entity (FILE * stream, entity_t entity)
+print_entity (FILE *stream, entity_t entity)
 {
   gchar *text_escaped = NULL;
   fprintf (stream, "<%s", entity->name);
@@ -1363,13 +1353,13 @@ compare_entities (entity_t entity1, entity_t entity2)
   if (strcmp (entity1->name, entity2->name))
     {
       g_debug ("  compare failed name: %s vs %s\n", entity1->name,
-                 entity2->name);
+               entity2->name);
       return 1;
     }
   if (strcmp (entity1->text, entity2->text))
     {
       g_debug ("  compare failed text %s vs %s (%s)\n", entity1->text,
-                 entity2->text, entity1->name);
+               entity2->text, entity1->name);
       return 1;
     }
 
@@ -1382,9 +1372,8 @@ compare_entities (entity_t entity1, entity_t entity2)
     {
       if (entity2->attributes == NULL)
         return 1;
-      if (g_hash_table_find
-          (entity1->attributes, compare_find_attribute,
-           (gpointer) entity2->attributes))
+      if (g_hash_table_find (entity1->attributes, compare_find_attribute,
+                             (gpointer) entity2->attributes))
         {
           g_debug ("  compare failed attributes\n");
           return 1;
@@ -1468,14 +1457,13 @@ static void
 xml_search_handle_start_element (GMarkupParseContext *ctx,
                                  const gchar *element_name,
                                  const gchar **attribute_names,
-                                 const gchar **attribute_values,
-                                 gpointer data,
+                                 const gchar **attribute_values, gpointer data,
                                  GError **error)
 {
   (void) ctx;
   (void) error;
 
-  xml_search_data_t *search_data = ((xml_search_data_t*) data);
+  xml_search_data_t *search_data = ((xml_search_data_t *) data);
 
   if (strcmp (element_name, search_data->find_element) == 0
       && search_data->found == 0)
@@ -1487,27 +1475,24 @@ xml_search_handle_start_element (GMarkupParseContext *ctx,
         {
           int index;
           GHashTable *found_attributes;
-          found_attributes = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                    NULL, NULL);
+          found_attributes =
+            g_hash_table_new_full (g_str_hash, g_str_equal, NULL, NULL);
           index = 0;
           while (attribute_names[index])
             {
               gchar *searched_value;
-              searched_value
-                = g_hash_table_lookup (search_data->find_attributes,
-                                       attribute_names[index]);
+              searched_value = g_hash_table_lookup (
+                search_data->find_attributes, attribute_names[index]);
               if (searched_value
                   && strcmp (searched_value, attribute_values[index]) == 0)
                 {
-                  g_debug ("%s: Found attribute %s=\"%s\"",
-                           __FUNCTION__,
+                  g_debug ("%s: Found attribute %s=\"%s\"", __FUNCTION__,
                            attribute_names[index], searched_value);
                   g_hash_table_add (found_attributes, searched_value);
                 }
-              index ++;
+              index++;
             }
-          g_debug ("%s: Found %d of %d attributes",
-                   __FUNCTION__,
+          g_debug ("%s: Found %d of %d attributes", __FUNCTION__,
                    g_hash_table_size (found_attributes),
                    g_hash_table_size (search_data->find_attributes));
 
@@ -1538,7 +1523,7 @@ int
  * @return  1 if element was found, 0 if not.
  */
 find_element_in_xml_file (gchar *file_path, gchar *find_element,
-                          GHashTable* find_attributes)
+                          GHashTable *find_attributes)
 {
   gchar buffer[XML_FILE_BUFFER_SIZE];
   FILE *file;
@@ -1558,11 +1543,7 @@ find_element_in_xml_file (gchar *file_path, gchar *find_element,
   xml_parser.text = NULL;
   xml_parser.passthrough = NULL;
   xml_parser.error = NULL;
-  xml_context = g_markup_parse_context_new
-                 (&xml_parser,
-                  0,
-                  &search_data,
-                  NULL);
+  xml_context = g_markup_parse_context_new (&xml_parser, 0, &search_data, NULL);
 
   file = fopen (file_path, "r");
   if (file == NULL)
@@ -1572,9 +1553,8 @@ find_element_in_xml_file (gchar *file_path, gchar *find_element,
       return 0;
     }
 
-  while ((read_len = fread (&buffer, sizeof(char), XML_FILE_BUFFER_SIZE, file))
-         && g_markup_parse_context_parse
-              (xml_context, buffer, read_len, &error)
+  while ((read_len = fread (&buffer, sizeof (char), XML_FILE_BUFFER_SIZE, file))
+         && g_markup_parse_context_parse (xml_context, buffer, read_len, &error)
          && error == NULL)
     {
     }

--- a/util/xmlutils.h
+++ b/util/xmlutils.h
@@ -25,11 +25,11 @@
 #ifndef _GVM_XMLUTILS_H
 #define _GVM_XMLUTILS_H
 
+#include "serverutils.h"
+
 #include <glib.h>
 #include <gnutls/gnutls.h>
 #include <stdio.h>
-
-#include "serverutils.h"
 
 /**
  * @brief XML context.
@@ -39,9 +39,9 @@
  */
 typedef struct
 {
-  GSList *first;                ///< The very first entity.
-  GSList *current;              ///< The element currently being parsed.
-  gboolean done;                ///< Flag which is true when the first element is closed.
+  GSList *first;   ///< The very first entity.
+  GSList *current; ///< The element currently being parsed.
+  gboolean done;   ///< Flag which is true when the first element is closed.
 } context_data_t;
 
 void
@@ -64,80 +64,103 @@ typedef GSList *entities_t;
  */
 struct entity_s
 {
-  char *name;                   ///< Name.
-  char *text;                   ///< Text.
-  GHashTable *attributes;       ///< Attributes.
-  entities_t entities;          ///< Children.
+  char *name;             ///< Name.
+  char *text;             ///< Text.
+  GHashTable *attributes; ///< Attributes.
+  entities_t entities;    ///< Children.
 };
 typedef struct entity_s *entity_t;
 
 /**
  * @brief Data for xml search functions.
  */
-typedef struct {
-  int found;                    /**< Founded.*/
-  int done;                     /**< Done. */
-  gchar *find_element;          /**< Element to be find. */
-  GHashTable *find_attributes;  /**< Attributes to find. */
+typedef struct
+{
+  int found;                   /**< Founded.*/
+  int done;                    /**< Done. */
+  gchar *find_element;         /**< Element to be find. */
+  GHashTable *find_attributes; /**< Attributes to find. */
 } xml_search_data_t;
 
 entities_t next_entities (entities_t);
 
 entity_t first_entity (entities_t);
 
-entity_t add_entity (entities_t *, const char *, const char *);
+entity_t
+add_entity (entities_t *, const char *, const char *);
 
 int compare_entities (entity_t, entity_t);
 
-entity_t entity_child (entity_t, const char *);
+entity_t
+entity_child (entity_t, const char *);
 
-const char *entity_attribute (entity_t, const char *);
+const char *
+entity_attribute (entity_t, const char *);
 
-char *entity_name (entity_t entity);
+char *
+entity_name (entity_t entity);
 
-char *entity_text (entity_t entity);
+char *
+entity_text (entity_t entity);
 
 void free_entity (entity_t);
 
-void print_entity (FILE *, entity_t);
+void
+print_entity (FILE *, entity_t);
 
-void print_entity_format (entity_t, gpointer indentation);
+void
+print_entity_format (entity_t, gpointer indentation);
 
-int try_read_entity_and_string (gnutls_session_t *, int, entity_t *,
-                                GString **);
+int
+try_read_entity_and_string (gnutls_session_t *, int, entity_t *, GString **);
 
-int read_entity_and_string (gnutls_session_t *, entity_t *, GString **);
+int
+read_entity_and_string (gnutls_session_t *, entity_t *, GString **);
 
-int read_entity_and_string_c (gvm_connection_t *, entity_t *, GString **);
+int
+read_entity_and_string_c (gvm_connection_t *, entity_t *, GString **);
 
-int read_entity_and_text (gnutls_session_t *, entity_t *, char **);
+int
+read_entity_and_text (gnutls_session_t *, entity_t *, char **);
 
-int read_entity_and_text_c (gvm_connection_t *, entity_t *, char **);
+int
+read_entity_and_text_c (gvm_connection_t *, entity_t *, char **);
 
-int try_read_entity (gnutls_session_t *, int, entity_t *);
+int
+try_read_entity (gnutls_session_t *, int, entity_t *);
 
-int try_read_entity_c (gvm_connection_t *, int, entity_t *);
+int
+try_read_entity_c (gvm_connection_t *, int, entity_t *);
 
-int read_entity (gnutls_session_t *, entity_t *);
+int
+read_entity (gnutls_session_t *, entity_t *);
 
-int read_entity_s (int, entity_t *);
+int
+read_entity_s (int, entity_t *);
 
-int read_entity_c (gvm_connection_t *, entity_t *);
+int
+read_entity_c (gvm_connection_t *, entity_t *);
 
-int read_string (gnutls_session_t *, GString **);
+int
+read_string (gnutls_session_t *, GString **);
 
-int read_string_c (gvm_connection_t *, GString **);
+int
+read_string_c (gvm_connection_t *, GString **);
 
-int parse_entity (const char *, entity_t *);
+int
+parse_entity (const char *, entity_t *);
 
-void print_entity_to_string (entity_t entity, GString * string);
+void
+print_entity_to_string (entity_t entity, GString *string);
 
 int xml_count_entities (entities_t);
 
-void xml_string_append (GString *, const char *, ...);
+void
+xml_string_append (GString *, const char *, ...);
 
 /* XML file utilities */
 
-int find_element_in_xml_file (gchar *, gchar *, GHashTable*);
+int
+find_element_in_xml_file (gchar *, gchar *, GHashTable *);
 
 #endif /* not _GVM_XMLUTILS_H */


### PR DESCRIPTION
Apply clang-format to the base/ directory. Note that there is no option in clang-format to align successive #define's values (see 1st commit message) so the "//clang-format off/on" comments are needed for those cases only.

To replicate, copy config below to .clang-format, and use the command:
clang-format -style=file -i base/*.{c,h}



---
AlignAfterOpenBracket: Align
AlignConsecutiveAssignments: 'false'
AlignConsecutiveDeclarations: 'false'
AlignEscapedNewlines: Left
AlignOperands: 'true'
AlignTrailingComments: 'true'
AllowAllParametersOfDeclarationOnNextLine: 'false'
AllowShortBlocksOnASingleLine: 'false'
AllowShortCaseLabelsOnASingleLine: 'false'
AllowShortFunctionsOnASingleLine: None
AllowShortIfStatementsOnASingleLine: 'false'
AllowShortLoopsOnASingleLine: 'false'
AlwaysBreakAfterReturnType: All
AlwaysBreakBeforeMultilineStrings: 'false'
BinPackArguments: 'true'
BinPackParameters: 'true'
BreakBeforeBinaryOperators: NonAssignment
BreakBeforeBraces: GNU
BreakBeforeTernaryOperators: 'true'
BreakStringLiterals: 'true'
ColumnLimit: '80'
ContinuationIndentWidth: '2'
DerivePointerAlignment: 'false'
IncludeBlocks: Regroup
IndentCaseLabels: 'false'
IndentWidth: '2'
IndentWrappedFunctionNames: 'false'
KeepEmptyLinesAtTheStartOfBlocks: 'false'
Language: Cpp
MaxEmptyLinesToKeep: '1'
PointerAlignment: Right
ReflowComments: 'true'
SortIncludes: 'true'
SpaceAfterCStyleCast: 'true'
SpaceBeforeAssignmentOperators: 'true'
SpaceBeforeParens: Always
SpaceInEmptyParentheses: 'false'
SpacesInCStyleCastParentheses: 'false'
SpacesInContainerLiterals: 'false'
SpacesInParentheses: 'false'
SpacesInSquareBrackets: 'false'
UseTab: Never

...
