### PR TITLE
Solve TODO. Remove gvm_auth_tear_down().

### DIFF
--- a/util/authutils.c
+++ b/util/authutils.c
@@ -156,17 +156,6 @@ gvm_auth_init ()
 }
 
 /**
- * @brief Free memory associated to authentication configuration.
- *
- * This will have no effect if gvm_auth_init was not called.
- */
-void
-gvm_auth_tear_down (void)
-{
-  /** @todo Close memleak, destroy list and content. */
-}
-
-/**
  * @brief Generate a hexadecimal representation of a message digest.
  *
  * @param gcrypt_algorithm The libgcrypt message digest algorithm used to

--- a/util/authutils.h
+++ b/util/authutils.h
@@ -48,8 +48,6 @@ const gchar *auth_method_name (auth_method_t);
 
 int gvm_auth_init ();
 
-void gvm_auth_tear_down (void);
-
 int
 gvm_authenticate_classic (const gchar *, const gchar *, const gchar *);
 


### PR DESCRIPTION
It was an empty function with a reference to a list to be freed, which was removed
in 2015. So, nothing to be freed. There is no plan to extend it. Therefore remove it.