### PR TITLE
Fix missing and erroneous doc parameters.

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1357,6 +1357,7 @@ gvm_hosts_resolve (gvm_hosts_t *hosts)
  * @brief Exclude a list of vhosts from a host's vhosts list.
  *
  * @param[in] host  The host whose vhosts are to be excluded from.
+ * @param[in] excluded_str  String of hosts to exclude.
  *
  * @return Number of excluded vhosts.
  */

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -76,6 +76,7 @@ gmp_task_status (entity_t response)
  * @brief Read response and convert status of response to a return value.
  *
  * @param[in]  session  Pointer to GNUTLS session.
+ * @param[in]  entity   Entity containing response.
  *
  * @return 0 on success, -1 or GMP response code on error.
  */
@@ -172,7 +173,7 @@ gmp_ping (gnutls_session_t *session, int timeout)
 /**
  * @brief "Ping" the manager.
  *
- * @param[in]  session  Pointer to GNUTLS session.
+ * @param[in]  connection  Pointer to GNUTLS session.
  * @param[in]  timeout  Server idle time before giving up, in milliseconds.  0
  *                      to wait forever.
  * @param[out] version  Return location for freshly allocated version if

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -134,8 +134,8 @@ osp_connection_new (const char *host, int port, const char *cacert,
  * @brief Send a command to an OSP server.
  *
  * @param[in]   connection  Connection to OSP server.
- * @param[in]   command     OSP Command to send.
  * @param[out]  response    Response from OSP server.
+ * @param[in]   fmt         OSP Command to send.
  *
  * @return 0 and response, 1 if error.
  */
@@ -323,6 +323,7 @@ osp_delete_scan (osp_connection_t *connection, const char *scan_id)
  * @param[in]   scan_id     ID of scan to get.
  * @param[out]  report_xml  Scans report.
  * @param[in]   details     0 for no scan details, 1 otherwise.
+ * @param[out]  error       Pointer to error, if any.
  *
  * @return Scan progress if success, -1 if error.
  */
@@ -375,6 +376,7 @@ osp_get_scan (osp_connection_t *connection, const char *scan_id,
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[in]   scan_id     ID of scan to delete.
+ * @param[out]  error       Pointer to error, if any.
  *
  * @return Scan progress if success, -1 if error.
  */
@@ -444,8 +446,10 @@ option_concat_as_xml (gpointer key, gpointer value, gpointer pstr)
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[in]   target      Target host to scan.
+ * @param[in]   ports       List of ports to scan.
  * @param[in]   options     Table of scan options.
  * @param[in]   scan_id     uuid to set for scan, null otherwise.
+ * @param[out]  error       Pointer to error, if any.
  *
  * @return 0 on success, -1 otherwise.
  */

--- a/util/kb.c
+++ b/util/kb.c
@@ -1240,7 +1240,7 @@ redis_add_str (kb_t kb, const char *name, const char *str, size_t len)
  * @brief Set (replace) a new entry under a given name.
  * @param[in] kb  KB handle where to store the item.
  * @param[in] name  Item name.
- * @param[in] str  Item value.
+ * @param[in] val  Item value.
  * @param[in] len  Value length. Used for blobs.
  * @return 0 on success, non-null on error.
  */

--- a/util/serverutils.c
+++ b/util/serverutils.c
@@ -1044,7 +1044,7 @@ server_new_gnutls_init (gnutls_certificate_credentials_t *server_credentials)
  * @param[in]  end_type Connection end type.
  * @param[in]  priority TLS priority to be set. If no one is given, NORMAL is
  *             default.
- * @param[in]  server_credentials GNUTLS session.
+ * @param[in]  server_session GNUTLS session.
  * @param[in]  server_credentials Credentials to be set.
  * @return 0 on success, -1 on error.
  */


### PR DESCRIPTION
These caused warnings during documentation builds.