### PR TITLE
Add functions, types for extended OSP start_scan

### DIFF
--- a/osp/osp.c
+++ b/osp/osp.c
@@ -1242,7 +1242,7 @@ osp_target_free (osp_target_t *target)
  * @param[in]  credential   The credential to add. Will be freed with target.
  */
 void
-osp_target_add_credential(osp_target_t *target, osp_credential_t *credential)
+osp_target_add_credential (osp_target_t *target, osp_credential_t *credential)
 {
   if (!target || !credential)
     return;
@@ -1329,8 +1329,8 @@ osp_vt_single_free (osp_vt_single_t *vt_single)
  * @param[in]  value      The value of the preference.
  */
 void
-osp_vt_single_add_value(osp_vt_single_t *vt_single,
-                        const char *name, const char *value)
+osp_vt_single_add_value (osp_vt_single_t *vt_single,
+                         const char *name, const char *value)
 {
   g_hash_table_replace (vt_single->vt_values,
                         g_strdup (name),

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -83,9 +83,10 @@ struct osp_credential
  */
 struct osp_target
 {
+  GSList *credentials;  /** Credentials to use in the scan */
+  gchar *exclude_hosts; /** String defining one or many hosts to exclude */
   gchar *hosts;         /** String defining one or many hosts to scan */
   gchar *ports;         /** String defining the ports to scan */
-  GSList *credentials;  /** Credentials to use in the scan */
 };
 
 /**
@@ -1194,17 +1195,21 @@ osp_credential_set_auth_data (osp_credential_t *credential,
 /**
  * @brief Create a new OSP target.
  *
- * @param[in]  hosts  The hostnames of the target.
- * @param[in]  ports  The ports of the target.
+ * @param[in]  hosts          The hostnames of the target.
+ * @param[in]  ports          The ports of the target.
+ * @param[in]  exclude_hosts  The excluded hosts of the target.
  *
  * @return The newly allocated osp_target_t.
  */
 osp_target_t *
-osp_target_new (const char *hosts, const char *ports)
+osp_target_new (const char *hosts,
+                const char *ports,
+                const char *exclude_hosts)
 {
   osp_target_t *new_target;
   new_target = g_malloc0 (sizeof (osp_target_t));
 
+  new_target->exclude_hosts = exclude_hosts ? g_strdup (exclude_hosts) : NULL;
   new_target->hosts = hosts ? g_strdup (hosts) : NULL;
   new_target->ports = ports ? g_strdup (ports) : NULL;
 
@@ -1224,6 +1229,7 @@ osp_target_free (osp_target_t *target)
 
   g_slist_free_full (target->credentials,
                      (GDestroyNotify) osp_credential_free);
+  g_free (target->exclude_hosts);
   g_free (target->hosts);
   g_free (target->ports);
   g_free (target);

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -677,8 +677,10 @@ target_append_as_xml (osp_target_t *target, GString *xml_string)
   xml_string_append (xml_string,
                      "<target>"
                      "<hosts>%s</hosts>"
+                     "<exclude_hosts>%s</exclude_hosts>"
                      "<ports>%s</ports>",
                      target->hosts ? target->hosts : "",
+                     target->exclude_hosts ? target->exclude_hosts : "",
                      target->ports ? target->ports : "");
 
   if (target->credentials)

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -421,19 +421,21 @@ osp_delete_scan (osp_connection_t *connection, const char *scan_id)
 }
 
 /**
- * @brief Get a scan from an OSP server.
+ * @brief Get a scan from an OSP server, optionally removing the results.
  *
  * @param[in]   connection  Connection to an OSP server.
  * @param[in]   scan_id     ID of scan to get.
  * @param[out]  report_xml  Scans report.
  * @param[in]   details     0 for no scan details, 1 otherwise.
+ * @param[in]   pop_results 0 to leave results, 1 to pop results from scanner.
  * @param[out]  error       Pointer to error, if any.
  *
  * @return Scan progress if success, -1 if error.
  */
 int
-osp_get_scan (osp_connection_t *connection, const char *scan_id,
-              char **report_xml, int details, char **error)
+osp_get_scan_pop (osp_connection_t *connection, const char *scan_id,
+                  char **report_xml, int details, int pop_results,
+                  char **error)
 {
   entity_t entity, child;
   int progress;
@@ -442,7 +444,11 @@ osp_get_scan (osp_connection_t *connection, const char *scan_id,
   assert (connection);
   assert (scan_id);
   rc = osp_send_command (connection, &entity,
-                         "<get_scans scan_id='%s' details='%d'/>", scan_id,
+                         "<get_scans scan_id='%s'"
+                         " details='%d'"
+                         " pop_results='%d'/>",
+                         scan_id,
+                         pop_results ? 1 : 0,
                          details ? 1 : 0);
   if (rc)
     {
@@ -473,6 +479,24 @@ osp_get_scan (osp_connection_t *connection, const char *scan_id,
     }
   free_entity (entity);
   return progress;
+}
+
+/**
+ * @brief Get a scan from an OSP server.
+ *
+ * @param[in]   connection  Connection to an OSP server.
+ * @param[in]   scan_id     ID of scan to get.
+ * @param[out]  report_xml  Scans report.
+ * @param[in]   details     0 for no scan details, 1 otherwise.
+ * @param[out]  error       Pointer to error, if any.
+ *
+ * @return Scan progress if success, -1 if error.
+ */
+int
+osp_get_scan (osp_connection_t *connection, const char *scan_id,
+              char **report_xml, int details, char **error)
+{
+  return osp_get_scan_pop (connection, scan_id, report_xml, details, 0, error);
 }
 
 /**

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -1119,7 +1119,14 @@ osp_credential_free (osp_credential_t *credential)
   g_free (credential);
 }
 
-
+/**
+ * @brief Create a new OSP target.
+ *
+ * @param[in]  hosts  The hostnames of the target.
+ * @param[in]  ports  The ports of the target.
+ *
+ * @return The newly allocated osp_target_t.
+ */
 osp_target_t *
 osp_target_new (const char *hosts, const char *ports)
 {
@@ -1132,6 +1139,11 @@ osp_target_new (const char *hosts, const char *ports)
   return new_target;
 }
 
+/**
+ * @brief Free an OSP target, including all added credentials.
+ *
+ * @param[in]  target  The OSP target to free.
+ */
 void
 osp_target_free (osp_target_t *target)
 {
@@ -1145,6 +1157,12 @@ osp_target_free (osp_target_t *target)
   g_free (target);
 }
 
+/**
+ * @brief Add a credential to an OSP target.
+ *
+ * @param[in]  target       The OSP target to add the credential to.
+ * @param[in]  credential   The credential to add. Will be freed with target.
+ */
 void
 osp_target_add_credential(osp_target_t *target, osp_credential_t *credential)
 {
@@ -1154,6 +1172,13 @@ osp_target_add_credential(osp_target_t *target, osp_credential_t *credential)
   target->credentials = g_slist_prepend (target->credentials, credential);
 }
 
+/**
+ * @brief Create a new OSP VT group.
+ *
+ * @param[in]  filter  The filter string for the VT group.
+ *
+ * @return  The newly allocated VT group.
+ */
 osp_vt_group_t *
 osp_vt_group_new (const char *filter)
 {
@@ -1165,6 +1190,11 @@ osp_vt_group_new (const char *filter)
   return new_vt_group;
 }
 
+/**
+ * @brief Free a OSP VT group.
+ *
+ * @param[in]  vt_group  The VT group to free.
+ */
 void
 osp_vt_group_free (osp_vt_group_t *vt_group)
 {
@@ -1175,6 +1205,13 @@ osp_vt_group_free (osp_vt_group_t *vt_group)
   g_free (vt_group);
 }
 
+/**
+ * @brief Create a new single OSP VT.
+ *
+ * @param[in]  vt_id  The id of the VT.
+ *
+ * @return  The newly allocated single VT.
+ */
 osp_vt_single_t *
 osp_vt_single_new (const char *vt_id)
 {
@@ -1188,6 +1225,11 @@ osp_vt_single_new (const char *vt_id)
   return new_vt_single;
 }
 
+/**
+ * @brief Free a single OSP VT, including all preference values.
+ *
+ * @param[in]  vt_single  The OSP VT to free.
+ */
 void
 osp_vt_single_free (osp_vt_single_t *vt_single)
 {
@@ -1200,6 +1242,14 @@ osp_vt_single_free (osp_vt_single_t *vt_single)
   g_free (vt_single);
 }
 
+/**
+ * @brief Add a preference value to an OSP VT.
+ * This creates a copy of the name and value.
+ *
+ * @param[in]  vt_single  The VT to add the preference to.
+ * @param[in]  name       The name / identifier of the preference.
+ * @param[in]  value      The value of the preference.
+ */
 void
 osp_vt_single_add_value(osp_vt_single_t *vt_single,
                         const char *name, const char *value)

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -149,7 +149,7 @@ osp_credential_set_auth_data (osp_credential_t *, const char*, const char*);
 /* OSP targets handling */
 
 osp_target_t *
-osp_target_new (const char *, const char *);
+osp_target_new (const char *, const char *, const char *);
 
 void
 osp_target_free (osp_target_t *);

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -134,11 +134,17 @@ osp_param_free (osp_param_t *);
 /* OSP credential handling */
 
 osp_credential_t *
-osp_credential_new (const char *, const char *, const char *, const char *,
-                    const char *);
+osp_credential_new (const char *, const char *, const char *);
 
 void
 osp_credential_free (osp_credential_t *);
+
+const gchar*
+osp_credential_get_auth_data (osp_credential_t *, const char*);
+
+void
+osp_credential_set_auth_data (osp_credential_t *, const char*, const char*);
+
 
 /* OSP targets handling */
 

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -81,9 +81,17 @@ int
 osp_start_scan (osp_connection_t *, const char *, const char *, GHashTable *,
                 const char *, char **);
 
+typedef struct {
+  GSList *targets;              ///< Target hosts to scan.
+  GSList *vt_groups;            ///< VT groups to use for the scan.
+  GSList *vts;                  ///< Single VTs to use for the scan.
+  GHashTable *scanner_params;   ///< Table of scanner parameters.
+  int parallel;                 ///< Number of parallel scans.
+  const char *scan_id;          ///< UUID to set for scan, null otherwise.
+} osp_start_scan_opts_t;
+
 int
-osp_start_scan_ext (osp_connection_t *, GSList *, GSList *, GSList *,
-                    GHashTable *, int, const char *, char **);
+osp_start_scan_ext (osp_connection_t *, osp_start_scan_opts_t, char **);
 
 int
 osp_get_scan (osp_connection_t *, const char *, char **, int, char **);

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -28,7 +28,17 @@
 #include <glib.h> /* for GHashTable, GSList */
 #include "../util/xmlutils.h"
 
+/* Type definitions */
+
 typedef struct osp_connection osp_connection_t;
+
+typedef struct osp_credential osp_credential_t;
+
+typedef struct osp_target osp_target_t;
+
+typedef struct osp_vt_group osp_vt_group_t;
+
+typedef struct osp_vt_single osp_vt_single_t;
 
 /**
  * @brief OSP parameter types.
@@ -47,10 +57,16 @@ typedef enum
 
 typedef struct osp_param osp_param_t;
 
+/* OSP Connection handling */
+
 osp_connection_t *
 osp_connection_new (const char *, int, const char *, const char *,
                     const char *);
 
+void
+osp_connection_close (osp_connection_t *);
+
+/* OSP commands */
 int
 osp_get_version (osp_connection_t *, char **, char **, char **, char **,
                  char **, char **);
@@ -66,6 +82,10 @@ osp_start_scan (osp_connection_t *, const char *, const char *, GHashTable *,
                 const char *, char **);
 
 int
+osp_start_scan_ext (osp_connection_t *, GSList *, GSList *, GSList *,
+                    GHashTable *, int, const char *, char **);
+
+int
 osp_get_scan (osp_connection_t *, const char *, char **, int, char **);
 
 int
@@ -76,6 +96,8 @@ osp_stop_scan (osp_connection_t *, const char *, char **);
 
 int
 osp_get_scanner_details (osp_connection_t *, char **, GSList **);
+
+/* OSP scanner parameters handling */
 
 osp_param_t *
 osp_param_new (void);
@@ -101,7 +123,43 @@ osp_param_mandatory (const osp_param_t *);
 void
 osp_param_free (osp_param_t *);
 
+/* OSP credential handling */
+
+osp_credential_t *
+osp_credential_new (const char *, const char *, const char *, const char *,
+                    const char *);
+
 void
-osp_connection_close (osp_connection_t *);
+osp_credential_free (osp_credential_t *);
+
+/* OSP targets handling */
+
+osp_target_t *
+osp_target_new (const char *, const char *);
+
+void
+osp_target_free (osp_target_t *);
+
+void
+osp_target_add_credential (osp_target_t *, osp_credential_t *);
+
+/* OSP VT group handling */
+
+osp_vt_group_t *
+osp_vt_group_new (const char *);
+
+void
+osp_vt_group_free (osp_vt_group_t *);
+
+/* OSP single VT handling */
+
+osp_vt_single_t *
+osp_vt_single_new (const char *);
+
+void
+osp_vt_single_free (osp_vt_single_t *);
+
+void
+osp_vt_single_add_value (osp_vt_single_t *, const char*, const char*);
 
 #endif

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -89,6 +89,14 @@ int
 osp_get_scan (osp_connection_t *, const char *, char **, int, char **);
 
 int
+osp_get_scan_pop (osp_connection_t *,
+                  const char *,
+                  char **,
+                  int,
+                  int,
+                  char **);
+
+int
 osp_delete_scan (osp_connection_t *, const char *);
 
 int


### PR DESCRIPTION
This adds various functions and types for starting a scan with extended
options like a list of VTs and targets with credentials.