### PR TITLE
Backport #202

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1146,8 +1146,10 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
   /* Reverse list, as we were prepending (for performance) to the list. */
   hosts->hosts = g_list_reverse (hosts->hosts);
 
-  /* Remove duplicated values. */
-  gvm_hosts_deduplicate (hosts);
+  /* No need to check for duplicates when a hosts string contains a
+   * single (IP/Hostname/Range/Subnetwork) entry. */
+  if (g_strv_length (split) > 1)
+    gvm_hosts_deduplicate (hosts);
 
   /* Set current to start of hosts list. */
   hosts->current = hosts->hosts;

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -34,6 +34,7 @@
 #include <arpa/inet.h>  /* for inet_pton, inet_ntop */
 #include <assert.h>     /* for assert */
 #include <ctype.h>      /* for isdigit */
+#include <malloc.h>
 #include <netdb.h>      /* for getnameinfo, NI_NAMEREQD */
 #include <stdint.h>     /* for uint8_t, uint32_t */
 #include <stdio.h>      /* for sscanf, perror */
@@ -949,6 +950,7 @@ gvm_hosts_deduplicate (gvm_hosts_t *hosts)
   hosts->count -= duplicates;
   hosts->removed += duplicates;
   hosts->current = hosts->hosts;
+  malloc_trim (0);
 }
 
 /**
@@ -1155,6 +1157,7 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
   hosts->current = hosts->hosts;
 
   g_strfreev (split);
+  malloc_trim (0);
   return hosts;
 }
 

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1314,6 +1314,7 @@ void
 gvm_hosts_resolve (gvm_hosts_t *hosts)
 {
   gvm_host_t *host;
+  int new_entries = 0;
 
   hosts->current = hosts->hosts;
 
@@ -1350,6 +1351,7 @@ gvm_hosts_resolve (gvm_hosts_t *hosts)
           hosts->hosts = g_list_prepend (hosts->hosts, new);
           hosts->count++;
           tmp = tmp->next;
+          new_entries = 1;
         }
       if (!list)
         g_warning ("Couldn't resolve hostname %s", host->name);
@@ -1362,7 +1364,8 @@ gvm_hosts_resolve (gvm_hosts_t *hosts)
       hosts->removed++;
       g_slist_free_full (list, g_free);
     }
-  gvm_hosts_deduplicate (hosts);
+  if (new_entries)
+    gvm_hosts_deduplicate (hosts);
 }
 
 /**


### PR DESCRIPTION
Performance fixes related to handling large sets of hosts.

Backport of https://github.com/greenbone/gvm-libs/pull/202