### PR TITLE
Backport PR #205

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1371,6 +1371,7 @@ gvm_hosts_resolve (gvm_hosts_t *hosts)
     }
   if (new_entries)
     gvm_hosts_deduplicate (hosts);
+  hosts->current = hosts->hosts;
 }
 
 /**


### PR DESCRIPTION
Reset hosts iterator at the end of gvm_hosts_resolve(). 

As gvm_hosts_deduplicate() is now only called when there are new entries
added to the hosts list.

Backport of https://github.com/greenbone/gvm-libs/pull/205