### PR TITLE
Reduce memory footprint when handling large hosts sets

### DIFF
--- a/base/hosts.h
+++ b/base/hosts.h
@@ -89,11 +89,12 @@ struct gvm_vhost
  */
 struct gvm_hosts
 {
-  gchar *orig_str;      /**< Original hosts definition string. */
-  GList *hosts;         /**< Hosts objects list. */
-  GList *current;       /**< Current host object in iteration. */
-  unsigned int count;   /**< Number of single host objects in hosts list. */
-  unsigned int removed; /**< Number of duplicate/excluded values. */
+  gchar *orig_str;    /**< Original hosts definition string. */
+  gvm_host_t **hosts; /**< Hosts objects list. */
+  size_t max_size;    /**< Current max size of hosts array entries. */
+  size_t current;     /**< Current host index in iteration. */
+  size_t count;       /**< Number of single host objects in hosts list. */
+  size_t removed;     /**< Number of duplicate/excluded values. */
 };
 
 /* Function prototypes. */


### PR DESCRIPTION
Use a dynamic array for gvm_hosts instead of doubly-linked lists.

This substantially improves handling of large sets of hosts.
ie. With a "10.0.0.0/8" hosts string, memory footprint is reduced from
1.33GB to 0.9GB. Other operations times such as creation and shuffling
are also slightly faster.