### PR TITLE
Fix redis_find(). 

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -569,6 +569,8 @@ redis_find (const char *kb_path, const char *key)
           if (rep != NULL)
             freeReplyObject (rep);
           i++;
+          redisFree (kbr->rctx);
+          kbr->rctx = NULL;
           continue;
         }
       freeReplyObject (rep);


### PR DESCRIPTION
Close connection if the key was not found, before continuing search in the next kb.
This avoid the "Too many open files" issue.