### PR TITLE
Backport PR #223

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -366,8 +366,9 @@ get_redis_ctx (struct kb_redis *kbr)
       rc = select_database (kbr);
       if (rc)
         {
-          g_debug ("%s: No redis DB available, retrying in %ds...", __func__,
-                   KB_RETRY_DELAY);
+          g_log (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+                 "%s: No redis DB available, retrying in %ds...", __func__,
+                 KB_RETRY_DELAY);
           sleep (KB_RETRY_DELAY);
           redisFree (kbr->rctx);
           kbr->rctx = NULL;


### PR DESCRIPTION
Use g_log instead of g_debug for No redis DB available message.
Backport PR #223