### PR TITLE
New xrefs data model

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -401,7 +401,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
   for (i = 0; i < g_slist_length (n->refs); i ++)
     {
       ref = g_slist_nth_data (n->refs, i);
-      if (type && type[0] && strcasecmp (ref->type, type) != 0)
+      if (type && strcasecmp (ref->type, type) != 0)
         continue;
 
       if (exclude_types && exclude_types[0])

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -395,7 +395,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
   for (i = 0; i < g_slist_length (n->refs); i ++)
     {
       ref = g_slist_nth_data (n->refs, i);
-      if (type && type[0] && strcmp (ref->type, type) != 0)
+      if (type && type[0] && strcasecmp (ref->type, type) != 0)
         continue;
 
       if (exclude_types && exclude_types[0])
@@ -404,7 +404,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
           exclude = 0;
           for (exclude_item = exclude_split; *exclude_item; exclude_item ++)
             {
-              if (strcmp (g_strstrip (*exclude_item), ref->type) == 0)
+              if (strcasecmp (g_strstrip (*exclude_item), ref->type) == 0)
                 {
                   exclude = 1;
                   break; 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -626,38 +626,6 @@ nvti_set_name (nvti_t *n, const gchar *name)
 }
 
 /**
- * @brief Set the CVE references of a NVT.
- *
- * @param n The NVT Info structure.
- *
- * @param cve The cve list to set. A copy will be created from this.
- *
- * @return 0 for success. Anything else indicates an error.
- */
-int
-nvti_set_cve (nvti_t *n, const gchar *cve)
-{
-  // @todo: Is this method expected to delete previous cve entries?
-  return (nvti_add_cve (n, cve));
-}
-
-/**
- * @brief Set the bid references of a NVT.
- *
- * @param n The NVT Info structure.
- *
- * @param bid The bid to set. A copy will be created from this.
- *
- * @return 0 for success. Anything else indicates an error.
- */
-int
-nvti_set_bid (nvti_t *n, const gchar *bid)
-{
-  // @todo: Is this method expected to delete previous bid entries?
-  return (nvti_add_bid (n, bid));
-}
-
-/**
  * @brief Set the xrefs of a NVT.
  *
  * @param n The NVT Info structure.
@@ -1003,36 +971,6 @@ nvti_add_refs_from_csv (nvti_t *n, const gchar *type, const gchar *ref_ids,
   g_strfreev (split);
 
   return (0);
-}
-
-/**
- * @brief Add a single CVE ID of a NVT.
- *
- * @param n The NVT Info structure.
- *
- * @param cve The CVE ID to add. A copy will be created from this.
- *
- * @return 0 for success. 1 if n was NULL, 2 if cve_id was NULL.
- */
-int
-nvti_add_cve (nvti_t *n, const gchar *cve)
-{
-  return (nvti_add_refs_from_csv (n, "cve", cve, ""));
-}
-
-/**
- * @brief Add a single BID ID of a NVT.
- *
- * @param n The NVT Info structure.
- *
- * @param bid The BID ID to add. A copy will be created from this.
- *
- * @return 0 for success. 1 if n was NULL. 2 if bid_id was NULL.
- */
-int
-nvti_add_bid (nvti_t *n, const gchar *bid)
-{
-  return (nvti_add_refs_from_csv (n, "bid", bid, ""));
 }
 
 /**

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -953,7 +953,7 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
     return (1);
 
   split = g_strsplit (ref_ids, ",", 0);
-  item = split;
+
   for (item = split; *item; item++)
     {
       gchar *id;

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -121,7 +121,7 @@ vtref_free (vtref_t *ref)
  *
  * @return The type string. Don't free this.
  */
-gchar *
+const gchar *
 vtref_type (const vtref_t *r)
 {
   return (r ? r->type : NULL);
@@ -135,7 +135,7 @@ vtref_type (const vtref_t *r)
  *
  * @return The id string. Don't free this.
  */
-gchar *
+const gchar *
 vtref_id (const vtref_t *r)
 {
   return (r ? r->ref_id : NULL);
@@ -151,7 +151,7 @@ vtref_id (const vtref_t *r)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_add_ref (nvti_t *vt, vtref_t *ref)
+nvti_add_vtref (nvti_t *vt, vtref_t *ref)
 {
   if (!vt)
     return (-1);
@@ -966,7 +966,7 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
 
       if (type)
         {
-          nvti_add_ref (n, vtref_new (type, id, ref_text));
+          nvti_add_vtref (n, vtref_new (type, id, ref_text));
         }
       else
         {
@@ -974,7 +974,7 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
 
           split2 = g_strsplit (id, ":", 2);
           if (split2[0] && split2[1])
-            nvti_add_ref (n, vtref_new (split2[0], split2[1], ""));
+            nvti_add_vtref (n, vtref_new (split2[0], split2[1], ""));
           g_strfreev (split2);
         }
     }
@@ -1153,7 +1153,7 @@ nvti_add_required_udp_ports (nvti_t *n, const gchar *port)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_add_vtpref (nvti_t *n, nvtpref_t *np)
+nvti_add_pref (nvti_t *n, nvtpref_t *np)
 {
   if (!n)
     return (-1);

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -684,7 +684,7 @@ nvti_set_xref (nvti_t *n, const gchar *xref)
       type_and_id = *item;
       g_strstrip (type_and_id);
 
-      if ((strcmp (type_and_id, "") == 0) || (strcmp (type_and_id, "NOXREF")) == 0)
+      if (strcmp (type_and_id, "") == 0)
         {
           item++;
           continue;
@@ -1032,7 +1032,7 @@ nvti_add_cve (nvti_t *n, const gchar *cve)
       id = *item;
       g_strstrip (id);
 
-      if ((strcmp (id, "") == 0) || (strcmp (id, "NOCVE")) == 0)
+      if (strcmp (id, "") == 0)
         {
           item++;
           continue;
@@ -1075,7 +1075,7 @@ nvti_add_bid (nvti_t *n, const gchar *bid)
       id = *item;
       g_strstrip (id);
 
-      if ((strcmp (id, "") == 0) || (strcmp (id, "NOBID")) == 0)
+      if (strcmp (id, "") == 0)
         {
           item++;
           continue;

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -315,8 +315,8 @@ nvti_name (const nvti_t *n)
  *
  * @return The references as string. This needs to be free'd.
  *         The format of the string depends on the "use_types" parameter.
- *         Either it is a comma-separated list "id,id,id" or additionally
- *         using the type like "type:id,type:id,type:id".
+ *         Either it is a comma-separated list "id, id, id" or additionally
+ *         using the type like "type:id, type:id, type:id".
  *         NULL is returned in case n is NULL.
  */
 gchar *
@@ -332,7 +332,6 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
   for (i = 0; i < g_slist_length (n->refs); i ++)
     {
       ref = g_slist_nth_data (n->refs, i);
-
       if (type && type[0] && strcmp (ref->type, type) != 0)
         continue;
 
@@ -357,14 +356,14 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
           if (use_types)
             {
               if (refs)
-                refs2 = g_strdup_printf ("%s,%s:%s", refs, ref->type, ref->ref_id);
+                refs2 = g_strdup_printf ("%s, %s:%s", refs, ref->type, ref->ref_id);
               else
                 refs2 = g_strdup_printf ("%s:%s", ref->type, ref->ref_id);
             }
           else
             {
               if (refs)
-                refs2 = g_strdup_printf ("%s,%s", refs, ref->ref_id);
+                refs2 = g_strdup_printf ("%s, %s", refs, ref->ref_id);
               else
                 refs2 = g_strdup_printf ("%s", ref->ref_id);
             }

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -868,8 +868,8 @@ nvti_set_category (nvti_t *n, const gint category)
  * @return 0 for success. 1 if n was NULL.
  */
 int
-nvti_add_refs_from_csv (nvti_t *n, const gchar *type, const gchar *ref_ids,
-                        const gchar *ref_text)
+nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
+               const gchar *ref_text)
 {
   gchar **split, **item;
 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -299,18 +299,25 @@ nvti_name (const nvti_t *n)
 }
 
 /**
- * @brief Get the CVE references.
+ * @brief Get references as string.
  *
- * @param n The NVT Info structure of which the name should
+ * @param n The NVT Info structure of which the references should
  *          be returned.
  *
- * @return The CVE list as string. Don't free this.
+ * @param type Optional type to collect. If NULL, all types are collected.
+ *
+ * @return The references as string. This needs to be free'd.
+ *         The format of the string is a comma-separated list
+ *         of the references. If type is given, then it is a simple list
+ *         of references of the same type.
+ *         If no type is given each reference is a colon separated
+ *         type:id tupel.
+ *         NULL in case n is NULL.
  */
 gchar *
-nvti_cve (const nvti_t *n)
+nvti_refs (const nvti_t *n, const gchar *type)
 {
-  // @todo: actually, the returned string now needs to be free'd
-  gchar *cves, *cves2;
+  gchar *refs, *refs2;
   vtref_t * ref;
   guint i;
 
@@ -319,52 +326,18 @@ nvti_cve (const nvti_t *n)
   for (i = 0; i < g_slist_length (n->refs); i ++)
     {
       ref = g_slist_nth_data (n->refs, i);
-      if (strcmp (ref->type, "cve") == 0)
-        {
-          if (cves)
-            cves2 = g_strdup_printf ("%s,%s", cves, ref->ref_id);
-	  else
-            cves2 = g_strdup_printf ("%s", ref->ref_id);
-	  g_free (cves);
-	  cves = cves2;
-        }
+      if (type && strcmp (ref->type, type) != 0)
+        continue;
+
+      if (refs)
+        refs2 = g_strdup_printf ("%s,%s:%s", refs, ref->type, ref->ref_id);
+      else
+        refs2 = g_strdup_printf ("%s:%s", ref->type, ref->ref_id);
+      g_free (refs);
+      refs = refs2;
     }
 
-  return (cves);
-}
-
-/**
- * @brief Get the bid references.
- *
- * @param n The NVT Info structure of which the name should
- *          be returned.
- *
- * @return The bid list as string. Don't free this.
- */
-gchar *
-nvti_bid (const nvti_t *n)
-{
-  gchar *bids, *bids2;
-  vtref_t * ref;
-  guint i;
-
-  if (! n) return (NULL);
-
-  for (i = 0; i < g_slist_length (n->refs); i ++)
-    {
-      ref = g_slist_nth_data (n->refs, i);
-      if (strcmp (ref->type, "bid") == 0)
-        {
-          if (bids)
-            bids2 = g_strdup_printf ("%s,%s", bids, ref->ref_id);
-	  else
-            bids2 = g_strdup_printf ("%s", ref->ref_id);
-	  g_free (bids);
-	  bids = bids2;
-        }
-    }
-
-  return (bids);
+  return (refs);
 }
 
 /**

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -394,17 +394,16 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
       if (exclude_types && exclude_types[0])
         {
           exclude_split = g_strsplit (exclude_types, ",", 0);
-          exclude_item = exclude_split;
           exclude = 0;
-          while (*exclude_item)
+          for (exclude_item = exclude_split; *exclude_item; exclude_item ++)
             {
               if (strcmp (g_strstrip (*exclude_item), ref->type) == 0)
                 {
                   exclude = 1;
                   break; 
                 }
-              exclude_item ++;
             }
+          g_strfreev (exclude_split);
         }
 
       if (! exclude)
@@ -937,7 +936,7 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
 
   split = g_strsplit (ref_ids, ",", 0);
   item = split;
-  while (*item)
+  for (item = split; *item; item++)
     {
       gchar *id;
       gchar **split2;
@@ -946,10 +945,7 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
       g_strstrip (id);
 
       if (strcmp (id, "") == 0)
-        {
-          item++;
-          continue;
-        }
+        continue;
 
       if (type)
         {
@@ -960,9 +956,8 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
           split2 = g_strsplit (id, ":", 2);
           if (split2[0] && split2[1])
             nvti_add_ref (n, vtref_new (split2[0], split2[1], ""));
+          g_strfreev (split2);
         }
-
-      item++;
     }
   g_strfreev (split);
 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -387,12 +387,16 @@ nvti_ref (const nvti_t *n, guint p)
 gchar *
 nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint use_types)
 {
-  gchar *refs = NULL, *refs2 = NULL, **exclude_item;
+  gchar *refs, *refs2, **exclude_item;
   vtref_t * ref;
-  guint i, exclude = 0;
+  guint i, exclude;
   gchar **exclude_split;
 
   if (! n) return (NULL);
+
+  refs = NULL;
+  refs2 = NULL;
+  exclude = 0;
 
   for (i = 0; i < g_slist_length (n->refs); i ++)
     {

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -68,7 +68,7 @@
  *         released using @ref vtref_free .
  */
 vtref_t *
-vtref_new (gchar *type, gchar *ref_id, gchar *ref_text)
+vtref_new (const gchar *type, const gchar *ref_id, const gchar *ref_text)
 {
   vtref_t *ref = g_malloc0 (sizeof (vtref_t));
 
@@ -971,7 +971,8 @@ nvti_set_category (nvti_t *n, const gint category)
  * @return 0 for success. 1 if n was NULL. 2 if type was NULL.
  */
 int
-nvti_add_refs_from_csv (nvti_t *n, gchar *type, gchar *ref_ids, gchar *ref_text)
+nvti_add_refs_from_csv (nvti_t *n, const gchar *type, const gchar *ref_ids,
+                        const gchar *ref_text)
 {
   gchar **split, **item;
 
@@ -1016,35 +1017,7 @@ nvti_add_refs_from_csv (nvti_t *n, gchar *type, gchar *ref_ids, gchar *ref_text)
 int
 nvti_add_cve (nvti_t *n, const gchar *cve)
 {
-  gchar **split, **item;
-
-  if (!n)
-    return (1);
-  if (!cve)
-    return (2);
-
-  split = g_strsplit (cve, ",", 0);
-  item = split;
-  while (*item)
-    {
-      gchar *id;
-
-      id = *item;
-      g_strstrip (id);
-
-      if (strcmp (id, "") == 0)
-        {
-          item++;
-          continue;
-        }
-
-      nvti_add_ref (n, vtref_new ("cve", id, ""));
-
-      item++;
-    }
-  g_strfreev (split);
-
-  return (0);
+  return (nvti_add_refs_from_csv (n, "cve", cve, ""));
 }
 
 /**
@@ -1059,35 +1032,7 @@ nvti_add_cve (nvti_t *n, const gchar *cve)
 int
 nvti_add_bid (nvti_t *n, const gchar *bid)
 {
-  gchar **split, **item;
-
-  if (!n)
-    return (1);
-  if (!bid)
-    return (2);
-
-  split = g_strsplit (bid, ",", 0);
-  item = split;
-  while (*item)
-    {
-      gchar *id;
-
-      id = *item;
-      g_strstrip (id);
-
-      if (strcmp (id, "") == 0)
-        {
-          item++;
-          continue;
-        }
-
-      nvti_add_ref (n, vtref_new ("bid", id, ""));
-
-      item++;
-    }
-  g_strfreev (split);
-
-  return (0);
+  return (nvti_add_refs_from_csv (n, "bid", bid, ""));
 }
 
 /**

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -55,6 +55,19 @@
 /* VT references */
 
 /**
+ * @brief The structure for a cross reference of a VT.
+ *
+ * The elements of this structure should only be accessed by the
+ * respective functions.
+ */
+typedef struct vtref
+{
+  gchar *type;     ///< Reference type ("cve", "bid", ...)
+  gchar *ref_id;   ///< The actual reference ID ("CVE-2018-1234", "https://example.org")
+  gchar *ref_text; ///< Optional additional text
+} vtref_t;
+
+/**
  * @brief Create a new vtref structure filled with the given values.
  *
  * @param type The type to be set. A copy is created of this.

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -392,7 +392,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
   guint i, exclude;
   gchar **exclude_split;
 
-  if (! n) return (NULL);
+  if (!n) return (NULL);
 
   refs = NULL;
   refs2 = NULL;
@@ -403,7 +403,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
   else
       exclude_split = NULL;
 
-  for (i = 0; i < g_slist_length (n->refs); i ++)
+  for (i = 0; i < g_slist_length (n->refs); i++)
     {
       ref = g_slist_nth_data (n->refs, i);
       if (type && strcasecmp (ref->type, type) != 0)
@@ -412,7 +412,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
       if (exclude_split)
         {
           exclude = 0;
-          for (exclude_item = exclude_split; *exclude_item; exclude_item ++)
+          for (exclude_item = exclude_split; *exclude_item; exclude_item++)
             {
               if (strcasecmp (g_strstrip (*exclude_item), ref->type) == 0)
                 {
@@ -422,7 +422,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
             }
         }
 
-      if (! exclude)
+      if (!exclude)
         {
           if (use_types)
             {

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -57,11 +57,11 @@
 /**
  * @brief Create a new vtref structure filled with the given values.
  *
- * @param type The type to be set. A copy will created of this.
+ * @param type The type to be set. A copy is created of this.
  *
- * @param ref_id The actual reference to be set. A copy will created of this.
+ * @param ref_id The actual reference to be set. A copy is created of this.
  *
- * @param ref_text The optional text accompanying a reference. A copy will created of this.
+ * @param ref_text The optional text accompanying a reference. A copy is created of this.
  *
  * @return NULL in case the memory could not be allocated.
  *         Else a vtref structure which needs to be
@@ -84,6 +84,7 @@ vtref_new (gchar *type, gchar *ref_id, gchar *ref_text)
 
   return (ref);
 }
+
 
 /**
  * @brief Free memory of a vtref structure.
@@ -953,6 +954,53 @@ nvti_set_category (nvti_t *n, const gint category)
     return (-1);
 
   n->category = category;
+  return (0);
+}
+
+/**
+ * @brief Add many new vtref from a comma-separated list.
+ *
+ * @param n The NVTI where to add the references.
+ *
+ * @param type The type for all references. A copy is created of this.
+ *
+ * @param ref_ids A CSV of reference to be added. A copy is of this.
+ *
+ * @param ref_text The optional text accompanying all references. A copy is created of this.
+ *
+ * @return 0 for success. 1 if n was NULL. 2 if type was NULL.
+ */
+int
+nvti_add_refs_from_csv (nvti_t *n, gchar *type, gchar *ref_ids, gchar *ref_text)
+{
+  gchar **split, **item;
+
+  if (!n)
+    return (1);
+  if (!type)
+    return (2);
+
+  split = g_strsplit (ref_ids, ",", 0);
+  item = split;
+  while (*item)
+    {
+      gchar *id;
+
+      id = *item;
+      g_strstrip (id);
+
+      if (strcmp (id, "") == 0)
+        {
+          item++;
+          continue;
+        }
+
+      nvti_add_ref (n, vtref_new (type, id, ref_text));
+
+      item++;
+    }
+  g_strfreev (split);
+
   return (0);
 }
 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -407,7 +407,7 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
               if (strcasecmp (g_strstrip (*exclude_item), ref->type) == 0)
                 {
                   exclude = 1;
-                  break; 
+                  break;
                 }
             }
           g_strfreev (exclude_split);

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -948,7 +948,6 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
   for (item = split; *item; item++)
     {
       gchar *id;
-      gchar **split2;
 
       id = *item;
       g_strstrip (id);
@@ -962,6 +961,8 @@ nvti_add_refs (nvti_t *n, const gchar *type, const gchar *ref_ids,
         }
       else
         {
+          gchar **split2;
+
           split2 = g_strsplit (id, ":", 2);
           if (split2[0] && split2[1])
             nvti_add_ref (n, vtref_new (split2[0], split2[1], ""));

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -104,6 +104,34 @@ vtref_free (vtref_t *ref)
 }
 
 /**
+ * @brief Get the type of a reference.
+ *
+ * @param r The VT Reference structure of which the type should
+ *          be returned.
+ *
+ * @return The type string. Don't free this.
+ */
+gchar *
+vtref_type (const vtref_t *r)
+{
+  return (r ? r->type : NULL);
+}
+
+/**
+ * @brief Get the id of a reference.
+ *
+ * @param r The VT Reference structure of which the id should
+ *          be returned.
+ *
+ * @return The id string. Don't free this.
+ */
+gchar *
+vtref_id (const vtref_t *r)
+{
+  return (r ? r->ref_id : NULL);
+}
+
+/**
  * @brief Add a reference to the VT Info.
  *
  * @param vt  The VT Info structure.
@@ -296,6 +324,34 @@ gchar *
 nvti_name (const nvti_t *n)
 {
   return (n ? n->name : NULL);
+}
+
+/**
+ * @brief Get the number of references of the NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @return The number of references.
+ */
+guint
+nvti_ref_len (const nvti_t *n)
+{
+  return (n ? g_slist_length (n->refs) : 0);
+}
+
+/**
+ * @brief Get the n'th reference of the NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param p The position of the reference to return.
+ *
+ * @return The reference. NULL on error.
+ */
+vtref_t *
+nvti_ref (const nvti_t *n, guint p)
+{
+  return (n ? g_slist_nth_data (n->refs, p) : NULL);
 }
 
 /**
@@ -521,7 +577,7 @@ nvti_pref_len (const nvti_t *n)
  *
  * @param p The position of the preference to return.
  *
- * @return The number of preferences. NULL if
+ * @return The preference. NULL on error.
  */
 const nvtpref_t *
 nvti_pref (const nvti_t *n, guint p)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -85,9 +85,6 @@ vtref_new (const gchar *type, const gchar *ref_id, const gchar *ref_text)
 {
   vtref_t *ref = g_malloc0 (sizeof (vtref_t));
 
-  if (!ref)
-    return NULL;
-
   if (type)
     ref->type = g_strdup (type);
   if (ref_id)
@@ -182,9 +179,6 @@ nvtpref_t *
 nvtpref_new (int id, gchar *name, gchar *type, gchar *dflt)
 {
   nvtpref_t *np = g_malloc0 (sizeof (nvtpref_t));
-
-  if (!np)
-    return NULL;
 
   np->id = id;
   if (name)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -322,29 +322,34 @@ nvti_name (const nvti_t *n)
 gchar *
 nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint use_types)
 {
-  gchar *refs, *refs2, **exclude_item;
+  gchar *refs = NULL, *refs2 = NULL, **exclude_item;
   vtref_t * ref;
-  guint i, exclude;
-  gchar **exclude_split = g_strsplit (exclude_types, ",", 0);
+  guint i, exclude = 0;
+  gchar **exclude_split;
 
   if (! n) return (NULL);
 
   for (i = 0; i < g_slist_length (n->refs); i ++)
     {
       ref = g_slist_nth_data (n->refs, i);
-      if (type && strcmp (ref->type, type) != 0)
+
+      if (type && type[0] && strcmp (ref->type, type) != 0)
         continue;
 
-      exclude_item = exclude_split;
-      exclude = 0;
-      while (*exclude_item)
+      if (exclude_types && exclude_types[0])
         {
-          if (strcmp (g_strstrip (*exclude_item), ref->type) == 0)
+          exclude_split = g_strsplit (exclude_types, ",", 0);
+          exclude_item = exclude_split;
+          exclude = 0;
+          while (*exclude_item)
             {
-              exclude = 1;
-              break; 
+              if (strcmp (g_strstrip (*exclude_item), ref->type) == 0)
+                {
+                  exclude = 1;
+                  break; 
+                }
+              exclude_item ++;
             }
-          exclude_item ++;
         }
 
       if (! exclude)
@@ -363,10 +368,9 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
               else
                 refs2 = g_strdup_printf ("%s", ref->ref_id);
             }
+          g_free (refs);
+          refs = refs2;
         }
-
-      g_free (refs);
-      refs = refs2;
     }
 
   return (refs);

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -341,7 +341,7 @@ nvti_name (const nvti_t *n)
  * @return The number of references.
  */
 guint
-nvti_ref_len (const nvti_t *n)
+nvti_vtref_len (const nvti_t *n)
 {
   return (n ? g_slist_length (n->refs) : 0);
 }
@@ -356,7 +356,7 @@ nvti_ref_len (const nvti_t *n)
  * @return The reference. NULL on error.
  */
 vtref_t *
-nvti_ref (const nvti_t *n, guint p)
+nvti_vtref (const nvti_t *n, guint p)
 {
   return (n ? g_slist_nth_data (n->refs, p) : NULL);
 }

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -70,11 +70,11 @@ typedef struct vtref
 /**
  * @brief Create a new vtref structure filled with the given values.
  *
- * @param type The type to be set. A copy is created of this.
+ * @param type The type to be set.
  *
- * @param ref_id The actual reference to be set. A copy is created of this.
+ * @param ref_id The actual reference to be set.
  *
- * @param ref_text The optional text accompanying a reference. A copy is created of this.
+ * @param ref_text The optional text accompanying a reference.
  *
  * @return NULL in case the memory could not be allocated.
  *         Else a vtref structure which needs to be

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -398,15 +398,19 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
   refs2 = NULL;
   exclude = 0;
 
+  if (exclude_types && exclude_types[0])
+      exclude_split = g_strsplit (exclude_types, ",", 0);
+  else
+      exclude_split = NULL;
+
   for (i = 0; i < g_slist_length (n->refs); i ++)
     {
       ref = g_slist_nth_data (n->refs, i);
       if (type && strcasecmp (ref->type, type) != 0)
         continue;
 
-      if (exclude_types && exclude_types[0])
+      if (exclude_split)
         {
-          exclude_split = g_strsplit (exclude_types, ",", 0);
           exclude = 0;
           for (exclude_item = exclude_split; *exclude_item; exclude_item ++)
             {
@@ -416,7 +420,6 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
                   break;
                 }
             }
-          g_strfreev (exclude_split);
         }
 
       if (! exclude)
@@ -439,6 +442,8 @@ nvti_refs (const nvti_t *n, const gchar *type, const gchar *exclude_types, guint
           refs = refs2;
         }
     }
+
+  g_strfreev (exclude_split);
 
   return (refs);
 }

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -378,8 +378,10 @@ nvti_ref (const nvti_t *n, guint p)
  *
  * @return The references as string. This needs to be free'd.
  *         The format of the string depends on the "use_types" parameter.
- *         Either it is a comma-separated list "id, id, id" or additionally
- *         using the type like "type:id, type:id, type:id".
+ *         If use_types is 0 it is a comma-separated list "id, id, id"
+ *         is returned.
+ *         If use_types is not 0 a comma-separated list like
+ *         "type:id, type:id, type:id" is returned.
  *         NULL is returned in case n is NULL.
  */
 gchar *

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -1147,7 +1147,7 @@ nvti_add_required_udp_ports (nvti_t *n, const gchar *port)
  * @return 0 for success. Anything else indicates an error.
  */
 int
-nvti_add_pref (nvti_t *n, nvtpref_t *np)
+nvti_add_vtpref (nvti_t *n, nvtpref_t *np)
 {
   if (!n)
     return (-1);

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -156,8 +156,6 @@ nvti_set_oid (nvti_t *, const gchar *);
 int
 nvti_set_name (nvti_t *, const gchar *);
 int
-nvti_set_xref (nvti_t *, const gchar *);
-int
 nvti_set_tag (nvti_t *, const gchar *);
 int
 nvti_set_cvss_base (nvti_t *, const gchar *);

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -63,16 +63,8 @@ nvtpref_id (const nvtpref_t *);
 
 /**
  * @brief The structure for a cross reference of a VT.
- *
- * The elements of this structure should never be accessed directly.
- * Only the functions corresponding to this module should be used.
  */
-typedef struct vtref
-{
-  gchar *type;     ///< Reference type ("cve", "bid", ...)
-  gchar *ref_id;   ///< The actual reference ID ("CVE-2018-1234", "https://example.org")
-  gchar *ref_text; ///< Optional additional text
-} vtref_t;
+typedef struct vtref vtref_t;
 
 /**
  * @brief The structure of a information record that corresponds to a NVT.

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -102,13 +102,13 @@ vtref_t *
 vtref_new (const gchar *, const gchar *, const gchar *);
 void
 vtref_free (vtref_t *);
-gchar *
+const gchar *
 vtref_type (const vtref_t *);
-gchar *
+const gchar *
 vtref_id (const vtref_t *);
 
 int
-nvti_add_ref (nvti_t *, vtref_t *);
+nvti_add_vtref (nvti_t *, vtref_t *);
 guint
 nvti_ref_len (const nvti_t *);
 vtref_t *
@@ -192,7 +192,7 @@ nvti_add_required_ports (nvti_t *, const gchar *);
 int
 nvti_add_required_udp_ports (nvti_t *, const gchar *);
 int
-nvti_add_vtpref (nvti_t *, nvtpref_t *);
+nvti_add_pref (nvti_t *, nvtpref_t *);
 
 /* Collections of NVT Infos. */
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -189,6 +189,8 @@ int
 nvti_set_family (nvti_t *, const gchar *);
 
 int
+nvti_add_refs_from_csv (nvti_t *, gchar *, gchar *, gchar *);
+int
 nvti_add_cve (nvti_t *, const gchar *);
 int
 nvti_add_bid (nvti_t *, const gchar *);

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -123,9 +123,7 @@ nvti_oid (const nvti_t *);
 gchar *
 nvti_name (const nvti_t *);
 gchar *
-nvti_cve (const nvti_t *);
-gchar *
-nvti_bid (const nvti_t *);
+nvti_refs (const nvti_t *, const gchar *);
 gchar *
 nvti_xref (const nvti_t *);
 gchar *

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -179,7 +179,7 @@ int
 nvti_set_family (nvti_t *, const gchar *);
 
 int
-nvti_add_refs_from_csv (nvti_t *, const gchar *, const gchar *, const gchar *);
+nvti_add_refs (nvti_t *, const gchar *, const gchar *, const gchar *);
 int
 nvti_add_required_keys (nvti_t *, const gchar *);
 int

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -105,6 +105,14 @@ typedef struct nvti
   gchar *family; /**< @brief Family the NVT belongs to */
 } nvti_t;
 
+
+vtref_t *
+vtref_new (gchar *, gchar *, gchar *);
+void
+vtref_free (vtref_t *);
+int
+nvti_add_ref (nvti_t *, vtref_t *);
+
 nvti_t *
 nvti_new (void);
 void

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -110,9 +110,9 @@ vtref_id (const vtref_t *);
 int
 nvti_add_vtref (nvti_t *, vtref_t *);
 guint
-nvti_ref_len (const nvti_t *);
+nvti_vtref_len (const nvti_t *);
 vtref_t *
-nvti_ref (const nvti_t *, guint);
+nvti_vtref (const nvti_t *, guint);
 
 nvti_t *
 nvti_new (void);

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -62,6 +62,19 @@ int
 nvtpref_id (const nvtpref_t *);
 
 /**
+ * @brief The structure for a cross reference of a VT.
+ *
+ * The elements of this structure should never be accessed directly.
+ * Only the functions corresponding to this module should be used.
+ */
+typedef struct vtref
+{
+  gchar *type;     ///< Reference type ("cve", "bid", ...)
+  gchar *ref_id;   ///< The actual reference ID ("CVE-2018-1234", "https://example.org")
+  gchar *ref_text; ///< Optional additional text
+} vtref_t;
+
+/**
  * @brief The structure of a information record that corresponds to a NVT.
  *
  * The elements of this structure should never be accessed directly.
@@ -75,8 +88,6 @@ typedef struct nvti
   gchar *cve;       /**< @brief List of CVEs, this NVT corresponds to */
   gchar *bid;       /**< @brief List of Bugtraq IDs, this NVT
                                 corresponds to */
-  gchar *xref;      /**< @brief List of Cross-references, this NVT
-                                corresponds to */
   gchar *tag;       /**< @brief List of tags attached to this NVT */
   gchar *cvss_base; /**< @brief CVSS base score for this NVT. */
 
@@ -88,6 +99,7 @@ typedef struct nvti
   gchar
     *required_udp_ports; /**< @brief List of required UDP ports of this NVT*/
 
+  GSList *refs;  /**< @brief Collection of VT references */
   GSList *prefs; /**< @brief Collection of NVT preferences */
 
   // The following are not settled yet.

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -123,9 +123,7 @@ nvti_oid (const nvti_t *);
 gchar *
 nvti_name (const nvti_t *);
 gchar *
-nvti_refs (const nvti_t *, const gchar *);
-gchar *
-nvti_xref (const nvti_t *);
+nvti_refs (const nvti_t *, const gchar *, const char *, guint);
 gchar *
 nvti_tag (const nvti_t *);
 gchar *

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -86,8 +86,6 @@ typedef struct nvti
   gchar *name; /**< @brief The name */
 
   gchar *cve;       /**< @brief List of CVEs, this NVT corresponds to */
-  gchar *bid;       /**< @brief List of Bugtraq IDs, this NVT
-                                corresponds to */
   gchar *tag;       /**< @brief List of tags attached to this NVT */
   gchar *cvss_base; /**< @brief CVSS base score for this NVT. */
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -107,7 +107,7 @@ typedef struct nvti
 
 
 vtref_t *
-vtref_new (gchar *, gchar *, gchar *);
+vtref_new (const gchar *, const gchar *, const gchar *);
 void
 vtref_free (vtref_t *);
 int
@@ -189,7 +189,7 @@ int
 nvti_set_family (nvti_t *, const gchar *);
 
 int
-nvti_add_refs_from_csv (nvti_t *, gchar *, gchar *, gchar *);
+nvti_add_refs_from_csv (nvti_t *, const gchar *, const gchar *, const gchar *);
 int
 nvti_add_cve (nvti_t *, const gchar *);
 int

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -110,8 +110,17 @@ vtref_t *
 vtref_new (const gchar *, const gchar *, const gchar *);
 void
 vtref_free (vtref_t *);
+gchar *
+vtref_type (const vtref_t *);
+gchar *
+vtref_id (const vtref_t *);
+
 int
 nvti_add_ref (nvti_t *, vtref_t *);
+guint
+nvti_ref_len (const nvti_t *);
+vtref_t *
+nvti_ref (const nvti_t *, guint);
 
 nvti_t *
 nvti_new (void);

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -85,7 +85,6 @@ typedef struct nvti
   gchar *oid;  /**< @brief Object ID */
   gchar *name; /**< @brief The name */
 
-  gchar *cve;       /**< @brief List of CVEs, this NVT corresponds to */
   gchar *tag;       /**< @brief List of tags attached to this NVT */
   gchar *cvss_base; /**< @brief CVSS base score for this NVT. */
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -160,10 +160,6 @@ nvti_set_oid (nvti_t *, const gchar *);
 int
 nvti_set_name (nvti_t *, const gchar *);
 int
-nvti_set_cve (nvti_t *, const gchar *);
-int
-nvti_set_bid (nvti_t *, const gchar *);
-int
 nvti_set_xref (nvti_t *, const gchar *);
 int
 nvti_set_tag (nvti_t *, const gchar *);
@@ -190,10 +186,6 @@ nvti_set_family (nvti_t *, const gchar *);
 
 int
 nvti_add_refs_from_csv (nvti_t *, const gchar *, const gchar *, const gchar *);
-int
-nvti_add_cve (nvti_t *, const gchar *);
-int
-nvti_add_bid (nvti_t *, const gchar *);
 int
 nvti_add_required_keys (nvti_t *, const gchar *);
 int

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -192,7 +192,7 @@ nvti_add_required_ports (nvti_t *, const gchar *);
 int
 nvti_add_required_udp_ports (nvti_t *, const gchar *);
 int
-nvti_add_pref (nvti_t *, nvtpref_t *);
+nvti_add_vtpref (nvti_t *, nvtpref_t *);
 
 /* Collections of NVT Infos. */
 

--- a/util/kb.c
+++ b/util/kb.c
@@ -864,8 +864,8 @@ redis_get_nvt_all (kb_t kb, const char *oid)
       nvti_set_required_ports (nvti, rep->element[NVT_REQUIRED_PORTS_POS]->str);
       nvti_set_dependencies (nvti, rep->element[NVT_DEPENDENCIES_POS]->str);
       nvti_set_tag (nvti, rep->element[NVT_TAGS_POS]->str);
-      nvti_set_cve (nvti, rep->element[NVT_CVES_POS]->str);
-      nvti_set_bid (nvti, rep->element[NVT_BIDS_POS]->str);
+      nvti_add_refs_from_csv (nvti, "cve", rep->element[NVT_CVES_POS]->str, "");
+      nvti_add_refs_from_csv (nvti, "bid", rep->element[NVT_BIDS_POS]->str, "");
       nvti_set_xref (nvti, rep->element[NVT_XREFS_POS]->str);
       nvti_set_category (nvti, atoi (rep->element[NVT_CATEGORY_POS]->str));
       nvti_set_timeout (nvti, atoi (rep->element[NVT_TIMEOUT_POS]->str));

--- a/util/kb.c
+++ b/util/kb.c
@@ -1288,9 +1288,13 @@ redis_add_nvt (kb_t kb, const nvti_t *nvt, const char *filename)
   redisReply *rep = NULL;
   int rc = 0;
   GSList *element;
+  gchar *cves, *bids;
 
   if (!nvt || !filename)
     return -1;
+
+  cves = nvti_refs (nvt, "cve") ?: "";
+  bids = nvti_refs (nvt, "bid") ?: "";
 
   kbr = redis_kb (kb);
   rep = redis_cmd (
@@ -1298,9 +1302,11 @@ redis_add_nvt (kb_t kb, const nvti_t *nvt, const char *filename)
     nvti_oid (nvt), filename, nvti_required_keys (nvt) ?: "",
     nvti_mandatory_keys (nvt) ?: "", nvti_excluded_keys (nvt) ?: "",
     nvti_required_udp_ports (nvt) ?: "", nvti_required_ports (nvt) ?: "",
-    nvti_dependencies (nvt) ?: "", nvti_tag (nvt) ?: "", nvti_cve (nvt) ?: "",
-    nvti_bid (nvt) ?: "", nvti_xref (nvt) ?: "", nvti_category (nvt),
+    nvti_dependencies (nvt) ?: "", nvti_tag (nvt) ?: "", cves, bids,
+    nvti_xref (nvt) ?: "", nvti_category (nvt),
     nvti_timeout (nvt), nvti_family (nvt), nvti_name (nvt));
+  g_free (cves);
+  g_free (bids);
   if (rep == NULL || rep->type == REDIS_REPLY_ERROR)
     rc = -1;
   if (rep != NULL)

--- a/util/kb.c
+++ b/util/kb.c
@@ -1293,9 +1293,9 @@ redis_add_nvt (kb_t kb, const nvti_t *nvt, const char *filename)
   if (!nvt || !filename)
     return -1;
 
-  cves = nvti_refs (nvt, "cve", "", 0) ?: "";
-  bids = nvti_refs (nvt, "bid", "", 0) ?: "";
-  xrefs = nvti_refs (nvt, NULL, "cve,bid", 1) ?: "";
+  cves = nvti_refs (nvt, "cve", "", 0);
+  bids = nvti_refs (nvt, "bid", "", 0);
+  xrefs = nvti_refs (nvt, NULL, "cve,bid", 1);
 
   kbr = redis_kb (kb);
   rep = redis_cmd (
@@ -1303,8 +1303,8 @@ redis_add_nvt (kb_t kb, const nvti_t *nvt, const char *filename)
     nvti_oid (nvt), filename, nvti_required_keys (nvt) ?: "",
     nvti_mandatory_keys (nvt) ?: "", nvti_excluded_keys (nvt) ?: "",
     nvti_required_udp_ports (nvt) ?: "", nvti_required_ports (nvt) ?: "",
-    nvti_dependencies (nvt) ?: "", nvti_tag (nvt) ?: "", cves, bids, xrefs,
-    nvti_category (nvt),
+    nvti_dependencies (nvt) ?: "", nvti_tag (nvt) ?: "", cves ?: "",
+    bids ?: "", xrefs ?: "", nvti_category (nvt),
     nvti_timeout (nvt), nvti_family (nvt), nvti_name (nvt));
   g_free (cves);
   g_free (bids);

--- a/util/kb.c
+++ b/util/kb.c
@@ -866,7 +866,7 @@ redis_get_nvt_all (kb_t kb, const char *oid)
       nvti_set_tag (nvti, rep->element[NVT_TAGS_POS]->str);
       nvti_add_refs_from_csv (nvti, "cve", rep->element[NVT_CVES_POS]->str, "");
       nvti_add_refs_from_csv (nvti, "bid", rep->element[NVT_BIDS_POS]->str, "");
-      nvti_set_xref (nvti, rep->element[NVT_XREFS_POS]->str);
+      nvti_add_refs_from_csv (nvti, NULL, rep->element[NVT_XREFS_POS]->str, "");
       nvti_set_category (nvti, atoi (rep->element[NVT_CATEGORY_POS]->str));
       nvti_set_timeout (nvti, atoi (rep->element[NVT_TIMEOUT_POS]->str));
       nvti_set_family (nvti, rep->element[NVT_FAMILY_POS]->str);

--- a/util/kb.c
+++ b/util/kb.c
@@ -1288,13 +1288,14 @@ redis_add_nvt (kb_t kb, const nvti_t *nvt, const char *filename)
   redisReply *rep = NULL;
   int rc = 0;
   GSList *element;
-  gchar *cves, *bids;
+  gchar *cves, *bids, *xrefs;
 
   if (!nvt || !filename)
     return -1;
 
-  cves = nvti_refs (nvt, "cve") ?: "";
-  bids = nvti_refs (nvt, "bid") ?: "";
+  cves = nvti_refs (nvt, "cve", "", 0) ?: "";
+  bids = nvti_refs (nvt, "bid", "", 0) ?: "";
+  xrefs = nvti_refs (nvt, NULL, "cve,bid", 1) ?: "";
 
   kbr = redis_kb (kb);
   rep = redis_cmd (
@@ -1302,11 +1303,12 @@ redis_add_nvt (kb_t kb, const nvti_t *nvt, const char *filename)
     nvti_oid (nvt), filename, nvti_required_keys (nvt) ?: "",
     nvti_mandatory_keys (nvt) ?: "", nvti_excluded_keys (nvt) ?: "",
     nvti_required_udp_ports (nvt) ?: "", nvti_required_ports (nvt) ?: "",
-    nvti_dependencies (nvt) ?: "", nvti_tag (nvt) ?: "", cves, bids,
-    nvti_xref (nvt) ?: "", nvti_category (nvt),
+    nvti_dependencies (nvt) ?: "", nvti_tag (nvt) ?: "", cves, bids, xrefs,
+    nvti_category (nvt),
     nvti_timeout (nvt), nvti_family (nvt), nvti_name (nvt));
   g_free (cves);
   g_free (bids);
+  g_free (xrefs);
   if (rep == NULL || rep->type == REDIS_REPLY_ERROR)
     rc = -1;
   if (rep != NULL)

--- a/util/kb.c
+++ b/util/kb.c
@@ -864,9 +864,9 @@ redis_get_nvt_all (kb_t kb, const char *oid)
       nvti_set_required_ports (nvti, rep->element[NVT_REQUIRED_PORTS_POS]->str);
       nvti_set_dependencies (nvti, rep->element[NVT_DEPENDENCIES_POS]->str);
       nvti_set_tag (nvti, rep->element[NVT_TAGS_POS]->str);
-      nvti_add_refs_from_csv (nvti, "cve", rep->element[NVT_CVES_POS]->str, "");
-      nvti_add_refs_from_csv (nvti, "bid", rep->element[NVT_BIDS_POS]->str, "");
-      nvti_add_refs_from_csv (nvti, NULL, rep->element[NVT_XREFS_POS]->str, "");
+      nvti_add_refs (nvti, "cve", rep->element[NVT_CVES_POS]->str, "");
+      nvti_add_refs (nvti, "bid", rep->element[NVT_BIDS_POS]->str, "");
+      nvti_add_refs (nvti, NULL, rep->element[NVT_XREFS_POS]->str, "");
       nvti_set_category (nvti, atoi (rep->element[NVT_CATEGORY_POS]->str));
       nvti_set_timeout (nvti, atoi (rep->element[NVT_TIMEOUT_POS]->str));
       nvti_set_family (nvti, rep->element[NVT_FAMILY_POS]->str);


### PR DESCRIPTION
These changes reflect the unified handling of cross references in the NVT meta data
in the C-libraries, primarily the structure and API around nvti_t.

Essentially a new structure vt_ref_t is introduces, a list of references owned by a nvti_t.
The explicit storage of references as strings is removed from nvti_t.

The API for handling references is reduced to generic functions like nvti_refs(), nvti_add_ref() and nvti_add_refs() that are applicable to any type of reference. All previous API elements to handle cve, bid, xref were removed.

nvt_refs() and nvti_add_refs() are pretty powerful to handle various ways to get/add lists of references. This reflects the two ways how references were used before: cve and bid as simple lists and xref as type-including syntax.

This patch corresponds with changes in modules "openvas-scanner" and "gvmd" where
the API is used. See https://github.com/greenbone/openvas-scanner/pull/317 and https://github.com/greenbone/gvmd/pull/526 .

For the integration test redis was flushed and openvassd restarted to fill the redis database anew.
ospd-openvas was used to retrieve all VT meta data in xml format. This was done before and after the patch. In total over 370K references are concerned and the result lists are identical before and after the patch. 