### PR TITLE
Add kb_new_no_lock.

### DIFF
--- a/util/kb.h
+++ b/util/kb.h
@@ -118,6 +118,7 @@ struct kb_operations
 {
   /* ctor/dtor */
   int (*kb_new) (kb_t *, const char *);             /**< New KB. */
+  int (*kb_new_no_lock) (kb_t *, const char *);     /**< New KB without retry. */
   int (*kb_delete) (kb_t);                          /**< Delete KB. */
   kb_t (*kb_find) (const char *, const char *);     /**< Find KB. */
   kb_t (*kb_direct_conn) (const char *, const int); /**< Connect to a KB. */
@@ -247,6 +248,24 @@ kb_new (kb_t *kb, const char *kb_path)
   *kb = NULL;
 
   return KBDefaultOperations->kb_new (kb, kb_path);
+}
+
+/**
+ * @brief Initialize a new Knowledge Base object. If it fails, it does not retry.
+ * @param[in] kb  Reference to a kb_t to initialize.
+ * @param[in] kb_path   Path to KB.
+ * @return 0 on success, non-null on error.
+ */
+static inline int
+kb_new_no_lock (kb_t *kb, const char *kb_path)
+{
+  assert (kb);
+  assert (KBDefaultOperations);
+  assert (KBDefaultOperations->kb_new_no_lock);
+
+  *kb = NULL;
+
+  return KBDefaultOperations->kb_new_no_lock (kb, kb_path);
 }
 
 /**


### PR DESCRIPTION
In case there is no more available redis databases, it does not wait for available one.
Instead, it returns an error code which makes possible to identify this problem. To do this,
get_redis_ctx return an integer instead of redisContext, and receive a flag to select it
as a blocking or not blocking function.