### PR TITLE
Always fill gaps in gvm_hosts_resolve().

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1335,7 +1335,7 @@ gvm_hosts_reverse (gvm_hosts_t *hosts)
 GSList *
 gvm_hosts_resolve (gvm_hosts_t *hosts)
 {
-  size_t i, new_entries = 0;
+  size_t i, new_entries = 0, resolved = 0;
   GSList *unresolved = NULL;
 
   for (i = 0; i < hosts->count; i++)
@@ -1376,15 +1376,16 @@ gvm_hosts_resolve (gvm_hosts_t *hosts)
       /* Remove hostname from list, as it was either replaced by IPs, or
        * is unresolvable. */
       hosts->hosts[i] = NULL;
-      hosts->count--;
-      hosts->removed++;
+      resolved++;
       if (!list)
         unresolved = g_slist_prepend (unresolved, g_strdup (host->name));
-      else
-        gvm_hosts_fill_gaps (hosts);
       gvm_host_free (host);
       g_slist_free_full (list, g_free);
     }
+  if (resolved)
+    gvm_hosts_fill_gaps (hosts);
+  hosts->count -= resolved;
+  hosts->removed += resolved;
   if (new_entries)
     gvm_hosts_deduplicate (hosts);
   hosts->current = 0;


### PR DESCRIPTION
As a hostname entry is removed from the array, even if it didn't resolve
to an IP address.

Also don't decrement hosts count inside the loop.