### PR TITLE
Add function vtref_text().

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -142,6 +142,20 @@ vtref_id (const vtref_t *r)
 }
 
 /**
+ * @brief Get the text of a reference.
+ *
+ * @param r The VT Reference structure of which the id should
+ *          be returned.
+ *
+ * @return The id string. Don't free this.
+ */
+const gchar *
+vtref_text (const vtref_t *r)
+{
+  return (r ? r->ref_text : NULL);
+}
+
+/**
  * @brief Add a reference to the VT Info.
  *
  * @param vt  The VT Info structure.

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -106,6 +106,8 @@ const gchar *
 vtref_type (const vtref_t *);
 const gchar *
 vtref_id (const vtref_t *);
+const gchar *
+vtref_text (const vtref_t *);
 
 int
 nvti_add_vtref (nvti_t *, vtref_t *);


### PR DESCRIPTION
This function was missing. Now the API is complete for vtref.