### PR TITLE
Backport PR #230

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -350,31 +350,25 @@ get_redis_ctx (struct kb_redis *kbr)
   if (kbr->rctx != NULL)
     return kbr->rctx;
 
-  do
+  kbr->rctx = redisConnectUnix (kbr->path);
+  if (kbr->rctx == NULL || kbr->rctx->err)
     {
-      kbr->rctx = redisConnectUnix (kbr->path);
-      if (kbr->rctx == NULL || kbr->rctx->err)
-        {
-          g_log (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
-                 "%s: redis connection error: %s", __func__,
-                 kbr->rctx ? kbr->rctx->errstr : strerror (ENOMEM));
-          redisFree (kbr->rctx);
-          kbr->rctx = NULL;
-          return NULL;
-        }
-
-      rc = select_database (kbr);
-      if (rc)
-        {
-          g_log (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
-                 "%s: No redis DB available, retrying in %ds...", __func__,
-                 KB_RETRY_DELAY);
-          sleep (KB_RETRY_DELAY);
-          redisFree (kbr->rctx);
-          kbr->rctx = NULL;
-        }
+      g_log (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+             "%s: redis connection error: %s", __func__,
+             kbr->rctx ? kbr->rctx->errstr : strerror (ENOMEM));
+      redisFree (kbr->rctx);
+      kbr->rctx = NULL;
+      return NULL;
     }
-  while (rc != 0);
+
+  rc = select_database (kbr);
+  if (rc)
+    {
+      g_log (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL, "No redis DB available");
+      redisFree (kbr->rctx);
+      kbr->rctx = NULL;
+      return NULL;
+    }
 
   g_debug ("%s: connected to redis://%s/%d", __func__, kbr->path, kbr->db);
   return kbr->rctx;

--- a/util/kb.h
+++ b/util/kb.h
@@ -235,7 +235,7 @@ kb_item_free (struct kb_item *);
  * @brief Initialize a new Knowledge Base object.
  * @param[in] kb  Reference to a kb_t to initialize.
  * @param[in] kb_path   Path to KB.
- * @return 0 on success, non-null on error.
+ * @return 0 on success, -1 on connection error, -2 on unavailable DB spot.
  */
 static inline int
 kb_new (kb_t *kb, const char *kb_path)


### PR DESCRIPTION
Remove inconsistent delays in kb routines.
It is up to the caller to retry if needed. Otherwise, it is possible to be stuck in sleep & retry loops waiting for DB slots.
Original PR #230 from Hani.