### PR TITLE
Create CHANGELOG.md with new format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+- A new data model for unified handling of cross references in the NVT meta data as been added. All previous API elements to handle cve, bid, xref werehas been removed. [#225](https://github.com/greenbone/gvm-libs/pull/225) [#232](https://github.com/greenbone/gvm-libs/pull/232).
+
+### Changed
+- Handle EAI_AGAIN in gvm_host_reverse_lookup() IPv6 case and function refactor. [#229](https://github.com/greenbone/gvm-libs/pull/229)
+- Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)
+
+### Fixed
+- Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)
+
+### Removed
+- Remove inconsistent delays in kb routines. [#230](https://github.com/greenbone/gvm-libs/pull/230)
+
+[Unreleased]: https://github.com/greenbone/gvm-libs/compare/gvm-libs-10.0...master
+
+## [10.0.1] (unreleased)
+
+### Added
+- Allow multiple certificate formats for S/MIME. [#231](https://github.com/greenbone/gvm-libs/pull/231)
+- Add cmake options to build with ldap and radius support. [#235](https://github.com/greenbone/gvm-libs/pull/235)
+
+### Changed
+- Always add hostnames and vhosts in lower-case format. [#218](https://github.com/greenbone/gvm-libs/pull/218)
+- Plugin feed version file: Show message only once if it is not found. [#220](https://github.com/greenbone/gvm-libs/pull/220)
+- Use g_log instead of g_debug for No redis DB available message. [#224](https://github.com/greenbone/gvm-libs/pull/224)
+
+### Fixed
+- Fix prefs key in nvticache_delete(). [#214](https://github.com/greenbone/gvm-libs/pull/214)
+- Fix redis_find(). [#216](https://github.com/greenbone/gvm-libs/pull/216)
+- Fixes to gvm_hosts_resolve(). [#228](https://github.com/greenbone/gvm-libs/pull/228)
+
+[10.0.1]: https://github.com/greenbone/gvm-libs/compare/v10.0.0...gvm-libs-10.0
+
+## [10.0.0] (2019-04-05)
+
+### Changed
+- The function gvm_hosts_shuffle has been improved. [#200](https://github.com/greenbone/gvm-libs/pull/200)
+
+### Fixed
+- An issue which caused duplicated or removed values in the nvticache as addressed. [#196](https://github.com/greenbone/gvm-libs/pull/196)
+- Performance fixes related to handling large sets of hosts have been done.[203](https://github.com/greenbone/gvm-libs/pull/203) [#208](https://github.com/greenbone/gvm-libs/pull/208)
+- Memory management issues have been addressed. [#187](https://github.com/greenbone/gvm-libs/pull/187)
+
+
+[10.0.0]: https://github.com/greenbone/gvm-libs/compare/1.0.0...v10.0.0

--- a/CHANGES-OLD
+++ b/CHANGES-OLD
@@ -7,6 +7,35 @@ or get the entire source code repository and view log history:
 $ git clone https://github.com/greenbone/gvm-libs.git
 $ cd gvm-libs && git log
 
+
+Changelog for versions before gvm-libs-10-0
+Please refer to CHANGELOG.md for the newer versions.
+
+gvm-libs 1.0.0 (2019-01-31)
+
+This is the first release of the gvm-libs module 1.0 for the Greenbone
+Vulnerability Management 10 (GVM-10) framework.
+
+It derives from the former openvas-libraries module. Any elements of the
+old module that were used by OpenVAS Scanner only, were moved into the
+module openvas-scanner. Also the protocol OMP was renamed to GMP.
+
+Compared to the previous openvas-libraries major release, it covers
+various improvements for the GVM services and applications, as well as a
+number of significant advances and clean-ups.
+
+Main changes compared to gvm-libs 1.0+beta2:
+* Several changes in KB backend has been done to improve Redis performance.
+* New filename placeholders for the last modification date were added.
+* Initialization of gcrypt was improved to avoid trying to initialize the
+  memory pool twice.
+* An issue which causes the loss of the path to the configuration file has
+  been addressed.
+* Code used for Windows support has been removed.
+* Memory management issues have been addressed.
+* Several code improvements and clean-ups have been done.
+* Documentation has been improved.
+
 gvm-libs 1.0+beta2 (2018-12-04)
 
 This is the second beta release of the gvm-libs module 1.0 for the Greenbone


### PR DESCRIPTION
The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/).

Move the old CHANGES file with the release changes summary for gvm-libs versions before 10.0.0 to CHANGES-OLD. This file was updated also with the last missing changes for gvm-libs-1.0