### PR TITLE
Add libldap2-dev to prerequisites

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,8 +37,16 @@ Prerequisites for building documentation:
 
 Install prerequisites on Debian GNU/Linux 'Stretch' 9:
 
-    apt-get install cmake pkg-config libglib2.0-dev libgpgme11-dev \
-    libgnutls28-dev uuid-dev libssh-gcrypt-dev libhiredis-dev
+    apt-get install \
+    cmake \
+    pkg-config \
+    libglib2.0-dev \
+    libgpgme11-dev \
+    libgnutls28-dev \
+    uuid-dev \
+    libssh-gcrypt-dev \
+    libldap2-dev \
+    libhiredis-dev
 
 
 Compiling gvm-libs


### PR DESCRIPTION
`libldap2` is a prerequisite library, but it's not listed in the `apt-get` section. This causes the library to compile without LDAP support.

I also reindented the `apt-get` command to list one library per line, for clarity. This makes explicit that there is not a 1-to-1 correspondence between the prerequisites and the `apt-get` command. For instance, `libgio` is not explicitly included. Since adding `libldap2-dev` fixed my issues I haven't investigated that further, but an expert might want to take a closer look.