### PR TITLE
Make QoD Type an explicit element of stuct nvti.

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -314,6 +314,7 @@ nvti_free (nvti_t *n)
   g_free (n->excluded_keys);
   g_free (n->required_ports);
   g_free (n->required_udp_ports);
+  g_free (n->qod_type);
   g_free (n->family);
   g_slist_free_full (n->refs, (void (*) (void *)) vtref_free);
   g_slist_free_full (n->prefs, (void (*) (void *)) nvtpref_free);
@@ -576,6 +577,20 @@ gchar *
 nvti_required_udp_ports (const nvti_t *n)
 {
   return (n ? n->required_udp_ports : NULL);
+}
+
+/**
+ * @brief Get the QoD type.
+ *
+ * @param n The NVT Info structure of which the QoD type should
+ *          be returned.
+ *
+ * @return The QoD type as string. Don't free this.
+ */
+gchar *
+nvti_qod_type (const nvti_t *n)
+{
+  return (n ? n->qod_type : NULL);
 }
 
 /**
@@ -884,6 +899,31 @@ nvti_set_required_udp_ports (nvti_t *n, const gchar *required_udp_ports)
     n->required_udp_ports = g_strdup (required_udp_ports);
   else
     n->required_udp_ports = NULL;
+  return (0);
+}
+
+/**
+ * @brief Set the QoD type of a NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param qod_type The QoD type to set. A copy will be created from this.
+ *                 The string is not checked, any string is accepted as type.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_set_qod_type (nvti_t *n, const gchar *qod_type)
+{
+  if (!n)
+    return (-1);
+
+  if (n->qod_type)
+    g_free (n->qod_type);
+  if (qod_type && qod_type[0])
+    n->qod_type = g_strdup (qod_type);
+  else
+    n->qod_type = NULL;
   return (0);
 }
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -88,6 +88,8 @@ typedef struct nvti
   gchar
     *required_udp_ports; /**< @brief List of required UDP ports of this NVT*/
 
+  gchar *qod_type; /**< @brief Quality of detection type */
+
   GSList *refs;  /**< @brief Collection of VT references */
   GSList *prefs; /**< @brief Collection of NVT preferences */
 
@@ -142,6 +144,8 @@ gchar *
 nvti_required_ports (const nvti_t *);
 gchar *
 nvti_required_udp_ports (const nvti_t *);
+gchar *
+nvti_qod_type (const nvti_t *);
 gint
 nvti_timeout (const nvti_t *);
 gint
@@ -173,6 +177,8 @@ int
 nvti_set_required_ports (nvti_t *, const gchar *);
 int
 nvti_set_required_udp_ports (nvti_t *, const gchar *);
+int
+nvti_set_qod_type (nvti_t *, const gchar *);
 int
 nvti_set_timeout (nvti_t *, const gint);
 int


### PR DESCRIPTION
This makes it unnecessary to handle the QoD Type in the "tags" parts.

If it is added to the tags, it still will be. This is how openvas uses it.

The change is intended to support gvmd so it can use this new API element
and prevent qod_type to enter the tags element.