### PR TITLE
Add function osp_get_vts_filtered().

### DIFF
--- a/osp/osp.c
+++ b/osp/osp.c
@@ -365,7 +365,7 @@ osp_get_vts_version (osp_connection_t *connection, char **vts_version)
 }
 
 /**
- * @brief Get the VTs version from an OSP server.
+ * @brief Get all VTs from an OSP server.
  *
  * @param[in]   connection    Connection to an OSP server.
  * @param[out]  vts           VTs.
@@ -382,6 +382,29 @@ osp_get_vts (osp_connection_t *connection, entity_t *vts)
     return 1;
 
   if (osp_send_command (connection, vts, "<get_vts/>"))
+    return 1;
+
+  return 0;
+}
+
+/**
+ * @brief Get filtered set of VTs from an OSP server.
+ *
+ * @param[in]   connection    Connection to an OSP server.
+ * @param[out]  vts           VTs.
+ *
+ * @return 0 if success, 1 if error.
+ */
+int
+osp_get_vts_filtered (osp_connection_t *connection, const gchar *filter, entity_t *vts)
+{
+  if (!connection)
+    return 1;
+
+  if (vts == NULL)
+    return 1;
+
+  if (osp_send_command (connection, vts, "<get_vts filter='%s'/>", filter))
     return 1;
 
   return 0;

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -390,13 +390,14 @@ osp_get_vts (osp_connection_t *connection, entity_t *vts)
 /**
  * @brief Get filtered set of VTs from an OSP server.
  *
- * @param[in]   connection    Connection to an OSP server.
- * @param[out]  vts           VTs.
+ * @param[in]   connection  Connection to an OSP server.
+ * @param[in]   opts        Struct containing the options to apply.
+ * @param[out]  vts         VTs.
  *
  * @return 0 if success, 1 if error.
  */
 int
-osp_get_vts_filtered (osp_connection_t *connection, const gchar *filter, entity_t *vts)
+osp_get_vts_ext (osp_connection_t *connection, osp_get_vts_opts_t opts, entity_t *vts)
 {
   if (!connection)
     return 1;
@@ -404,7 +405,7 @@ osp_get_vts_filtered (osp_connection_t *connection, const gchar *filter, entity_
   if (vts == NULL)
     return 1;
 
-  if (osp_send_command (connection, vts, "<get_vts filter='%s'/>", filter))
+  if (osp_send_command (connection, vts, "<get_vts filter='%s'/>", opts.filter))
     return 1;
 
   return 0;

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -77,8 +77,12 @@ osp_get_vts_version (osp_connection_t *, char **);
 int
 osp_get_vts (osp_connection_t *, entity_t *);
 
+typedef struct {
+  char *filter; ///< the filter to apply for a vt sub-selection.
+} osp_get_vts_opts_t;
+
 int
-osp_get_vts_filtered (osp_connection_t *, const gchar *, entity_t *);
+osp_get_vts_ext (osp_connection_t *, osp_get_vts_opts_t, entity_t *);
 
 int
 osp_start_scan (osp_connection_t *, const char *, const char *, GHashTable *,

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -78,6 +78,9 @@ int
 osp_get_vts (osp_connection_t *, entity_t *);
 
 int
+osp_get_vts_filtered (osp_connection_t *, const gchar *, entity_t *);
+
+int
 osp_start_scan (osp_connection_t *, const char *, const char *, GHashTable *,
                 const char *, char **);
 


### PR DESCRIPTION
In contrast to function get_vts(), this function allows to
call GET_VTS with the "filters" parameter.