### PR TITLE
Allow to configure the path to the redis socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Allow to configure the path to the redis socket via CMake [#256](https://github.com/greenbone/gvm-libs/pull/256)
 - A new data model for unified handling of cross references in the NVT meta data as been added. All previous API elements to handle cve, bid, xref werehas been removed. [#225](https://github.com/greenbone/gvm-libs/pull/225) [#232](https://github.com/greenbone/gvm-libs/pull/232).
 
 ### Changed
+- Change the default path to the redis socket to /run/redis/redis.sock [#256](https://github.com/greenbone/gvm-libs/pull/256)
 - Handle EAI_AGAIN in gvm_host_reverse_lookup() IPv6 case and function refactor. [#229](https://github.com/greenbone/gvm-libs/pull/229)
 - Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,14 @@ if (NOT GVM_SYSCONF_DIR)
   set (GVM_SYSCONF_DIR "${SYSCONFDIR}/gvm")
 endif (NOT GVM_SYSCONF_DIR)
 
+
+if (NOT REDIS_SOCKET_PATH)
+  set (REDIS_SOCKET_PATH "/run/redis/redis.sock")
+endif ()
+
+add_definitions (-DREDIS_SOCKET_PATH="${REDIS_SOCKET_PATH}")
+message ("-- Using redis socket ${REDIS_SOCKET_PATH}")
+
 message ("-- Install prefix: ${CMAKE_INSTALL_PREFIX}")
 
 if (ENABLE_COVERAGE)

--- a/util/kb.h
+++ b/util/kb.h
@@ -34,7 +34,11 @@
 /**
  * @brief Default KB location.
  */
-#define KB_PATH_DEFAULT "/tmp/redis.sock"
+#ifdef REDIS_SOCKET_PATH
+#define KB_PATH_DEFAULT REDIS_SOCKET_PATH
+#else
+#define KB_PATH_DEFAULT "/run/redis/redis.sock"
+#endif
 
 /**
  * @brief Possible type of a kb_item.


### PR DESCRIPTION
Add a new CMake directive (-DREDIS_SOCKET_PATH=/path/to/socket)to allow
to set the path to the redis unix socket at build time.

Additionally change the default path to use the default socket path of
redis on debian and ubuntu which is (/var)/run/redis/redis.sock.