### PR TITLE
Add explicit attributes in nvti struct

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -164,6 +164,10 @@ typedef struct nvti
   gchar *oid;  /**< @brief Object ID */
   gchar *name; /**< @brief The name */
 
+  gchar *summary;  /**< @brief The summary */
+  gchar *insight;  /**< @brief The insight */
+  gchar *affected; /**< @brief Affected systems */
+
   gchar *solution;      /**< @brief The solution */
   gchar *solution_type; /**< @brief The solution type */
 
@@ -178,7 +182,8 @@ typedef struct nvti
   gchar
     *required_udp_ports; /**< @brief List of required UDP ports of this NVT*/
 
-  gchar *qod_type; /**< @brief Quality of detection type */
+  gchar *detection; /**< @brief Detection description */
+  gchar *qod_type;  /**< @brief Quality of detection type */
 
   GSList *refs;  /**< @brief Collection of VT references */
   GSList *prefs; /**< @brief Collection of NVT preferences */
@@ -341,6 +346,9 @@ nvti_free (nvti_t *n)
 
   g_free (n->oid);
   g_free (n->name);
+  g_free (n->summary);
+  g_free (n->insight);
+  g_free (n->affected);
   g_free (n->solution);
   g_free (n->solution_type);
   g_free (n->tag);
@@ -351,6 +359,7 @@ nvti_free (nvti_t *n)
   g_free (n->excluded_keys);
   g_free (n->required_ports);
   g_free (n->required_udp_ports);
+  g_free (n->detection);
   g_free (n->qod_type);
   g_free (n->family);
   g_slist_free_full (n->refs, (void (*) (void *)) vtref_free);
@@ -384,6 +393,48 @@ gchar *
 nvti_name (const nvti_t *n)
 {
   return (n ? n->name : NULL);
+}
+
+/**
+ * @brief Get the summary.
+ *
+ * @param n The NVT Info structure of which the summary should
+ *          be returned.
+ *
+ * @return The summary string. Don't free this.
+ */
+gchar *
+nvti_summary (const nvti_t *n)
+{
+  return (n ? n->summary : NULL);
+}
+
+/**
+ * @brief Get the text about insight.
+ *
+ * @param n The NVT Info structure of which the insight description should
+ *          be returned.
+ *
+ * @return The insight string. Don't free this.
+ */
+gchar *
+nvti_insight (const nvti_t *n)
+{
+  return (n ? n->insight : NULL);
+}
+
+/**
+ * @brief Get the text about affected systems.
+ *
+ * @param n The NVT Info structure of which the affected description should
+ *          be returned.
+ *
+ * @return The affected string. Don't free this.
+ */
+gchar *
+nvti_affected (const nvti_t *n)
+{
+  return (n ? n->affected : NULL);
 }
 
 /**
@@ -645,6 +696,20 @@ nvti_required_udp_ports (const nvti_t *n)
 }
 
 /**
+ * @brief Get the text about detection.
+ *
+ * @param n The NVT Info structure of which the detection should
+ *          be returned.
+ *
+ * @return The detection string. Don't free this.
+ */
+gchar *
+nvti_detection (const nvti_t *n)
+{
+  return (n ? n->detection : NULL);
+}
+
+/**
  * @brief Get the QoD type.
  *
  * @param n The NVT Info structure of which the QoD type should
@@ -766,6 +831,69 @@ nvti_set_name (nvti_t *n, const gchar *name)
   if (n->name)
     g_free (n->name);
   n->name = g_strdup (name);
+  return (0);
+}
+
+/**
+ * @brief Set the summary of a NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param solution The summary to set. A copy will be created from this.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_set_summary (nvti_t *n, const gchar *summary)
+{
+  if (!n)
+    return (-1);
+
+  if (n->summary)
+    g_free (n->summary);
+  n->summary = g_strdup (summary);
+  return (0);
+}
+
+/**
+ * @brief Set the insight text of a NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param insight The insight text to set. A copy will be created from this.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_set_insight (nvti_t *n, const gchar *insight)
+{
+  if (!n)
+    return (-1);
+
+  if (n->insight)
+    g_free (n->insight);
+  n->insight = g_strdup (insight);
+  return (0);
+}
+
+/**
+ * @brief Set the affected text of a NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param affected The affected text to set. A copy will be created from this.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_set_affected (nvti_t *n, const gchar *affected)
+{
+  if (!n)
+    return (-1);
+
+  if (n->affected)
+    g_free (n->affected);
+  n->affected = g_strdup (affected);
   return (0);
 }
 
@@ -1007,6 +1135,27 @@ nvti_set_required_udp_ports (nvti_t *n, const gchar *required_udp_ports)
     n->required_udp_ports = g_strdup (required_udp_ports);
   else
     n->required_udp_ports = NULL;
+  return (0);
+}
+
+/**
+ * @brief Set the detection text of a NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param detection The detection text to set. A copy will be created from this.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_set_detection (nvti_t *n, const gchar *detection)
+{
+  if (!n)
+    return (-1);
+
+  if (n->detection)
+    g_free (n->detection);
+  n->detection = g_strdup (detection);
   return (0);
 }
 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -167,6 +167,7 @@ typedef struct nvti
   gchar *summary;  /**< @brief The summary */
   gchar *insight;  /**< @brief The insight */
   gchar *affected; /**< @brief Affected systems */
+  gchar *impact;   /**< @brief Impact of vulnerability */
 
   gchar *solution;      /**< @brief The solution */
   gchar *solution_type; /**< @brief The solution type */
@@ -349,6 +350,7 @@ nvti_free (nvti_t *n)
   g_free (n->summary);
   g_free (n->insight);
   g_free (n->affected);
+  g_free (n->impact);
   g_free (n->solution);
   g_free (n->solution_type);
   g_free (n->tag);
@@ -435,6 +437,20 @@ gchar *
 nvti_affected (const nvti_t *n)
 {
   return (n ? n->affected : NULL);
+}
+
+/**
+ * @brief Get the text about impact.
+ *
+ * @param n The NVT Info structure of which the impact description should
+ *          be returned.
+ *
+ * @return The impact string. Don't free this.
+ */
+gchar *
+nvti_impact (const nvti_t *n)
+{
+  return (n ? n->impact : NULL);
 }
 
 /**
@@ -894,6 +910,27 @@ nvti_set_affected (nvti_t *n, const gchar *affected)
   if (n->affected)
     g_free (n->affected);
   n->affected = g_strdup (affected);
+  return (0);
+}
+
+/**
+ * @brief Set the impact text of a NVT.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param affected The impact text to set. A copy will be created from this.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_set_impact (nvti_t *n, const gchar *impact)
+{
+  if (!n)
+    return (-1);
+
+  if (n->impact)
+    g_free (n->impact);
+  n->impact = g_strdup (impact);
   return (0);
 }
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -99,6 +99,12 @@ nvti_oid (const nvti_t *);
 gchar *
 nvti_name (const nvti_t *);
 gchar *
+nvti_summary (const nvti_t *);
+gchar *
+nvti_affected (const nvti_t *);
+gchar *
+nvti_insight (const nvti_t *);
+gchar *
 nvti_refs (const nvti_t *, const gchar *, const char *, guint);
 gchar *
 nvti_solution (const nvti_t *);
@@ -121,6 +127,8 @@ nvti_required_ports (const nvti_t *);
 gchar *
 nvti_required_udp_ports (const nvti_t *);
 gchar *
+nvti_detection (const nvti_t *);
+gchar *
 nvti_qod_type (const nvti_t *);
 gint
 nvti_timeout (const nvti_t *);
@@ -137,6 +145,12 @@ int
 nvti_set_oid (nvti_t *, const gchar *);
 int
 nvti_set_name (nvti_t *, const gchar *);
+int
+nvti_set_summary (nvti_t *, const gchar *);
+int
+nvti_set_insight (nvti_t *, const gchar *);
+int
+nvti_set_affected (nvti_t *, const gchar *);
 int
 nvti_set_solution (nvti_t *, const gchar *);
 int
@@ -157,6 +171,8 @@ int
 nvti_set_required_ports (nvti_t *, const gchar *);
 int
 nvti_set_required_udp_ports (nvti_t *, const gchar *);
+int
+nvti_set_detection (nvti_t *, const gchar *);
 int
 nvti_set_qod_type (nvti_t *, const gchar *);
 int

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -103,6 +103,8 @@ nvti_summary (const nvti_t *);
 gchar *
 nvti_affected (const nvti_t *);
 gchar *
+nvti_impact (const nvti_t *);
+gchar *
 nvti_insight (const nvti_t *);
 gchar *
 nvti_refs (const nvti_t *, const gchar *, const char *, guint);
@@ -151,6 +153,8 @@ int
 nvti_set_insight (nvti_t *, const gchar *);
 int
 nvti_set_affected (nvti_t *, const gchar *);
+int
+nvti_set_impact (nvti_t *, const gchar *);
 int
 nvti_set_solution (nvti_t *, const gchar *);
 int


### PR DESCRIPTION
This makes "summary", "insight", "affected", "impact" and "detection"
explicit elements of the nvti struct. Including the functions
to get and set them.