### PR TITLE
Internalize struct nvtpref_t

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -217,6 +217,17 @@ nvti_add_vtref (nvti_t *vt, vtref_t *ref)
 /* VT preferences */
 
 /**
+ * @brief The structure for a preference of a NVT.
+ */
+typedef struct nvtpref
+{
+  int id;      ///< Preference ID
+  gchar *type; ///< Preference type
+  gchar *name; ///< Name of the preference
+  gchar *dflt; ///< Default value of the preference
+} nvtpref_t;
+
+/**
  * @brief Create a new nvtpref structure filled with the given values.
  *
  * @param id The ID to be set.

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -29,19 +29,7 @@
 
 #include <glib.h>
 
-/**
- * @brief The structure for a preference of a NVT.
- *
- * The elements of this structure should never be accessed directly.
- * Only the functions corresponding to this module should be used.
- */
-typedef struct nvtpref
-{
-  int id;      ///< Preference ID
-  gchar *type; ///< Preference type
-  gchar *name; ///< Name of the preference
-  gchar *dflt; ///< Default value of the preference
-} nvtpref_t;
+typedef struct nvtpref nvtpref_t;
 
 nvtpref_t *
 nvtpref_new (int, gchar *, gchar *, gchar *);

--- a/util/nvticache.c
+++ b/util/nvticache.c
@@ -543,12 +543,8 @@ nvticache_get_prefs (const char *oid)
 
       assert (array[3]);
       assert (!array[4]);
-      np = g_malloc0 (sizeof (nvtpref_t));
-      np->id = atoi (array[0]);
-      np->name = array[1];
-      np->type = array[2];
-      np->dflt = array[3];
-      g_free (array);
+      np = nvtpref_new (atoi (array[0]), array[1], array[2], array[3]);
+      g_strfreev (array);
       list = g_slist_append (list, np);
       element = element->next;
     }


### PR DESCRIPTION
This makes the internal structure of nvtpref_t
invisible to functions using it. Using the official
API is enforced.
