### PR TITLE
Convert incoming timestamp tags to seconds since epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A function to get an osp scan status and a enum type for the different status [#259](https://github.com/greenbone/gvm-libs/pull/259)
 - API functions for NVTI to handle timestamps [#261](https://github.com/greenbone/gvm-libs/pull/261)
 - API function for NVTI to add a single tag [#263](https://github.com/greenbone/gvm-libs/pull/263)
+- Add osp_get_performance() function. [#262](https://github.com/greenbone/gvm-libs/pull/262)
+
 ### Changed
 - Change the default path to the redis socket to /run/redis/redis.sock [#256](https://github.com/greenbone/gvm-libs/pull/256)
 - Handle EAI_AGAIN in gvm_host_reverse_lookup() IPv6 case and function refactor. [#229](https://github.com/greenbone/gvm-libs/pull/229)
 - Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)
-- Add osp_get_performance() function. [#262](https://github.com/greenbone/gvm-libs/pull/262)
+- Timestamps for NVTI modification date and creation date now internally handled as seconds since epoch. [#265](https://github.com/greenbone/gvm-libs/pull/265)
 
 ### Fixed
 - Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -169,10 +169,11 @@ vtref_text (const vtref_t *r)
  *
  * @return Time as seconds since the epoch.
  */
-static int
+static time_t
 parse_nvt_timestamp (const gchar *str_time)
 {
-  int epoch_time, offset;
+  time_t epoch_time;
+  int offset;
   struct tm tm;
 
   if ((strcmp ((char *) str_time, "") == 0)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -169,7 +169,7 @@ vtref_text (const vtref_t *r)
  *
  * @return Time as seconds since the epoch.
  */
-int
+static int
 parse_nvt_timestamp (const gchar *str_time)
 {
   int epoch_time, offset;

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -47,13 +47,12 @@
 /* For strptime in time.h. */
 #undef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
-#include <time.h>   // for strptime
-
 #include "nvti.h"
 
 #include <stdio.h>   // for sscanf
 #include <string.h>  // for strcmp
 #include <strings.h> // for strcasecmp
+#include <time.h>    // for strptime
 
 #undef G_LOG_DOMAIN
 #define G_LOG_DOMAIN "lib  nvti"
@@ -176,12 +175,12 @@ parse_nvt_timestamp (const gchar *str_time)
   int epoch_time, offset;
   struct tm tm;
 
-  if ((strcmp ((char*) str_time, "") == 0)
-      || (strcmp ((char*) str_time, "$Date: $") == 0)
-      || (strcmp ((char*) str_time, "$Date$") == 0)
-      || (strcmp ((char*) str_time, "$Date:$") == 0)
-      || (strcmp ((char*) str_time, "$Date") == 0)
-      || (strcmp ((char*) str_time, "$$") == 0))
+  if ((strcmp ((char *) str_time, "") == 0)
+      || (strcmp ((char *) str_time, "$Date: $") == 0)
+      || (strcmp ((char *) str_time, "$Date$") == 0)
+      || (strcmp ((char *) str_time, "$Date:$") == 0)
+      || (strcmp ((char *) str_time, "$Date") == 0)
+      || (strcmp ((char *) str_time, "$$") == 0))
     {
       return 0;
     }
@@ -192,24 +191,25 @@ parse_nvt_timestamp (const gchar *str_time)
   /* $Date: 2012-02-17 16:05:26 +0100 (Fr, 17. Feb 2012) $ */
   /* $Date: Fri, 11 Nov 2011 14:42:28 +0100 $ */
   memset (&tm, 0, sizeof (struct tm));
-  if (strptime ((char*) str_time, "%F %T %z", &tm) == NULL)
+  if (strptime ((char *) str_time, "%F %T %z", &tm) == NULL)
     {
       memset (&tm, 0, sizeof (struct tm));
-      if (strptime ((char*) str_time, "$Date: %F %T %z", &tm) == NULL)
+      if (strptime ((char *) str_time, "$Date: %F %T %z", &tm) == NULL)
         {
           memset (&tm, 0, sizeof (struct tm));
-          if (strptime ((char*) str_time, "%a %b %d %T %Y %z", &tm) == NULL)
+          if (strptime ((char *) str_time, "%a %b %d %T %Y %z", &tm) == NULL)
             {
               memset (&tm, 0, sizeof (struct tm));
-              if (strptime ((char*) str_time, "$Date: %a, %d %b %Y %T %z", &tm)
+              if (strptime ((char *) str_time, "$Date: %a, %d %b %Y %T %z", &tm)
                   == NULL)
                 {
                   memset (&tm, 0, sizeof (struct tm));
-                  if (strptime ((char*) str_time, "$Date: %a %b %d %T %Y %z", &tm)
+                  if (strptime ((char *) str_time, "$Date: %a %b %d %T %Y %z",
+                                &tm)
                       == NULL)
                     {
-                      g_warning ("%s: Failed to parse time: %s",
-                                 __FUNCTION__, str_time);
+                      g_warning ("%s: Failed to parse time: %s", __FUNCTION__,
+                                 str_time);
                       return 0;
                     }
                 }
@@ -225,20 +225,19 @@ parse_nvt_timestamp (const gchar *str_time)
 
   /* Get the timezone offset from the str_time. */
 
-  if ((sscanf ((char*) str_time, "%*u-%*u-%*u %*u:%*u:%*u %d%*[^]]", &offset)
-               != 1)
-      && (sscanf ((char*) str_time, "$Date: %*u-%*u-%*u %*u:%*u:%*u %d%*[^]]",
+  if ((sscanf ((char *) str_time, "%*u-%*u-%*u %*u:%*u:%*u %d%*[^]]", &offset)
+       != 1)
+      && (sscanf ((char *) str_time, "$Date: %*u-%*u-%*u %*u:%*u:%*u %d%*[^]]",
                   &offset)
           != 1)
-      && (sscanf ((char*) str_time, "%*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
+      && (sscanf ((char *) str_time, "%*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
                   &offset)
           != 1)
-      && (sscanf ((char*) str_time,
-                  "$Date: %*s %*s %*s %*u %*u:%*u:%*u %d%*[^]]",
-                  &offset)
+      && (sscanf ((char *) str_time,
+                  "$Date: %*s %*s %*s %*u %*u:%*u:%*u %d%*[^]]", &offset)
           != 1)
-      && (sscanf ((char*) str_time, "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
-                  &offset)
+      && (sscanf ((char *) str_time,
+                  "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]", &offset)
           != 1))
     {
       g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
@@ -1194,23 +1193,23 @@ nvti_add_tag (nvti_t *n, const gchar *name, const gchar *value)
   if (!value || !value[0])
     return (-3);
 
-  if (! strcmp (name, "last_modification"))
+  if (!strcmp (name, "last_modification"))
     {
       nvti_set_modification_time (n, parse_nvt_timestamp (value));
-      newvalue = g_strdup_printf ("%i", (int)nvti_modification_time (n));
+      newvalue = g_strdup_printf ("%i", (int) nvti_modification_time (n));
     }
-  else if (! strcmp (name, "creation_date"))
+  else if (!strcmp (name, "creation_date"))
     {
       nvti_set_creation_time (n, parse_nvt_timestamp (value));
-      newvalue = g_strdup_printf ("%i", (int)nvti_creation_time (n));
+      newvalue = g_strdup_printf ("%i", (int) nvti_creation_time (n));
     }
 
   if (n->tag)
     {
       gchar *newtag;
 
-      newtag = g_strconcat (n->tag, "|", name, "=",
-                            newvalue ? newvalue : value, NULL);
+      newtag =
+        g_strconcat (n->tag, "|", name, "=", newvalue ? newvalue : value, NULL);
       g_free (n->tag);
       n->tag = newtag;
     }


### PR DESCRIPTION
OSP should only use seconds since epoch for timestamps to provide
the OSP clients with a reliable format/syntax.

This patch transforms incoming timestamps immediately.
The OpenVAS-specific parsing code for timestamp is moved here and can
later be remove from gvmd where it currently is used to parse the various
syntax's.

A positive side effect is the reduced size consumption in redis:
The string "2019-05-14 08:13:05 +0000 (Tue, 14 May 2019)"
becomes "1557821585"