### PR TITLE
Ignore redundant tag cvss_base.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle EAI_AGAIN in gvm_host_reverse_lookup() IPv6 case and function refactor. [#229](https://github.com/greenbone/gvm-libs/pull/229)
 - Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)
 - Timestamps for NVTI modification date and creation date now internally handled as seconds since epoch. [#265](https://github.com/greenbone/gvm-libs/pull/265)
+- The tag cvss_base is not added to redis anymore. [#267](https://github.com/greenbone/gvm-libs/pull/267)
 
 ### Fixed
 - Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -1171,6 +1171,7 @@ nvti_set_solution_type (nvti_t *n, const gchar *solution_type)
  *        treated special: The value is expected to be a timestamp
  *        and it is being converted to seconds since epoch before
  *        added as a tag value.
+ *        The tag name "cvss_base" will be ignored and not added.
  *
  * @param n     The NVT Info structure.
  *
@@ -1203,6 +1204,17 @@ nvti_add_tag (nvti_t *n, const gchar *name, const gchar *value)
     {
       nvti_set_creation_time (n, parse_nvt_timestamp (value));
       newvalue = g_strdup_printf ("%i", (int) nvti_creation_time (n));
+    }
+  else if (!strcmp (name, "cvss_base"))
+    {
+      /* Ignore this tag because it is not being used.
+       * It is redundant with the tag cvss_base_vector from which
+       * it is computed.
+       * Once GOS 6 and GVM 11 are retired, all set_tag commands
+       * in the NASL scripts can be removed that set "cvss_base".
+       * Once this happened this exception can be removed from the code.
+       */
+      return (0);
     }
 
   if (n->tag)


### PR DESCRIPTION
When a NASL script sets the tag "cvss_base" it will not be added
to the tags for the respective NVT anymore. Thus it will also not
be stored anymore in the redis database.

This saves some space and, when tags are parsed, computing time.
Not a fundamental improvement though.

The OSP protocol already ignores this tag because the value
can be computed from the vector anyway.
So, this does not require other changes.