### PR TITLE
Use dedicated memory for nvtis keys

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -80,8 +80,16 @@ add_test (array-test array-test)
 
 target_link_libraries (array-test cgreen ${GLIB_LDFLAGS} ${LINKER_HARDENING_FLAGS})
 
+add_executable (nvti-test
+                EXCLUDE_FROM_ALL
+                nvti_tests.c)
+
+add_test (nvti-test nvti-test)
+
+target_link_libraries (nvti-test cgreen ${GLIB_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+
 add_custom_target (tests
-                   DEPENDS array-test)
+                   DEPENDS array-test nvti-test)
 
 
 ## Install

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -1822,11 +1822,9 @@ void
 nvtis_add (nvtis_t *nvtis, nvti_t *nvti)
 {
   if (nvti)
-    g_hash_table_insert (nvtis,
-                         (gpointer) (nvti_oid (nvti)
-                                      ? g_strdup (nvti_oid (nvti))
-                                      : NULL),
-                         (gpointer) nvti);
+    g_hash_table_insert (
+      nvtis, (gpointer) (nvti_oid (nvti) ? g_strdup (nvti_oid (nvti)) : NULL),
+      (gpointer) nvti);
 }
 
 /**

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -1796,7 +1796,7 @@ free_nvti_for_hash_table (gpointer nvti)
 nvtis_t *
 nvtis_new (void)
 {
-  return g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
+  return g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
                                 free_nvti_for_hash_table);
 }
 
@@ -1822,7 +1822,11 @@ void
 nvtis_add (nvtis_t *nvtis, nvti_t *nvti)
 {
   if (nvti)
-    g_hash_table_insert (nvtis, (gpointer) nvti_oid (nvti), (gpointer) nvti);
+    g_hash_table_insert (nvtis,
+                         (gpointer) (nvti_oid (nvti)
+                                      ? g_strdup (nvti_oid (nvti))
+                                      : NULL),
+                         (gpointer) nvti);
 }
 
 /**

--- a/base/nvti_tests.c
+++ b/base/nvti_tests.c
@@ -1,0 +1,55 @@
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "nvti.c"
+
+#include <cgreen/cgreen.h>
+#include <cgreen/mocks.h>
+
+Describe (nvti);
+BeforeEach (nvti)
+{
+}
+AfterEach (nvti)
+{
+}
+
+/* make_nvti */
+
+Ensure (nvti, nvti_new_never_returns_null)
+{
+  assert_that (nvti_new (), is_not_null);
+}
+
+/* Test suite. */
+
+int
+main (int argc, char **argv)
+{
+  TestSuite *suite;
+
+  suite = create_test_suite ();
+
+  add_test_with_context (suite, nvti, nvti_new_never_returns_null);
+
+  if (argc > 1)
+    return run_single_test (suite, argv[1], create_text_reporter ());
+
+  return run_test_suite (suite, create_text_reporter ());
+}


### PR DESCRIPTION
This makes the nvtis code allocate strings for the keys of nvtis_t hashtables, instead of reusing the nvt->oid pointers as keys.

The problem with reusing the nvt->oid pointer is that any call to nvt_set_oid will free that pointer.

I don't think this affects any of our current code because we always call nvt_set_oid only once.  But this caught me out during my first attempt at greenbone/gvmd/pull/826, and I had to spend too much time debugging that.