### PR TITLE
Disable testhosts test as it's not really a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make solution and solution_type explicit for nvti. [#255](https://github.com/greenbone/gvm-libs/pull/255)
 - Internalize struct nvtpref_t. [#260](https://github.com/greenbone/gvm-libs/pull/260)
 - Extend redis connection error msg with actual path. [#264](https://github.com/greenbone/gvm-libs/pull/264)
+- Disable testhosts test as it's not really a test. [#287](https://github.com/greenbone/gvm-libs/pull/287)
 
 ### Fixed
 - Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,11 +236,8 @@ endif (NOT SKIP_SRC)
 
 add_subdirectory (doc)
 
-## Tests
+## Test tools
 
 add_subdirectory (tests)
-add_test (NAME testhosts COMMAND test-hosts localhost)
-
-enable_testing ()
 
 ## End


### PR DESCRIPTION
The binary test-host is more of a tool than a test.  It only has one
fail case, but this failure is not possible with the way it is called in
testhosts.