### PR TITLE
[11.0] Fix missing linking to libgnutls in util/CMakeLists.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix sigsegv when no plugin_feed_info.inc file present. [#278](https://github.com/greenbone/gvm-libs/pull/278)
+- Fix missing linking to libgnutls in util/CMakeLists.txt. [#291](https://github.com/greenbone/gvm-libs/pull/291)
 
 [11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.0...gvm-libs-11.0
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -158,7 +158,7 @@ if (BUILD_SHARED)
 
   target_link_libraries (gvm_util_shared LINK_PRIVATE ${GLIB_LDFLAGS}
                          ${GIO_LDFLAGS} ${GPGME_LDFLAGS} ${ZLIB_LDFLAGS}
-                         ${RADIUS_LDFLAGS} ${LIBSSH_LDFLAGS}
+                         ${RADIUS_LDFLAGS} ${LIBSSH_LDFLAGS} ${GNUTLS_LDFLAGS}
                          ${GCRYPT_LDFLAGS} ${LDAP_LDFLAGS} ${REDIS_LDFLAGS}
                          ${UUID_LDFLAGS} ${LINKER_HARDENING_FLAGS})
 endif (BUILD_SHARED)


### PR DESCRIPTION
Fix issue #277 