### PR TITLE
Replace __FUNCTION__ with __func__

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -241,8 +241,7 @@ parse_nvt_timestamp (const gchar *str_time)
                   "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]", &offset)
           != 1))
     {
-      g_warning ("%s: Failed to parse timezone offset: %s", __func__,
-                 str_time);
+      g_warning ("%s: Failed to parse timezone offset: %s", __func__, str_time);
       return 0;
     }
 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -209,7 +209,7 @@ parse_nvt_timestamp (const gchar *str_time)
                                 &tm)
                       == NULL)
                     {
-                      g_warning ("%s: Failed to parse time: %s", __FUNCTION__,
+                      g_warning ("%s: Failed to parse time: %s", __func__,
                                  str_time);
                       return 0;
                     }
@@ -220,7 +220,7 @@ parse_nvt_timestamp (const gchar *str_time)
   epoch_time = mktime (&tm);
   if (epoch_time == -1)
     {
-      g_warning ("%s: Failed to make time: %s", __FUNCTION__, str_time);
+      g_warning ("%s: Failed to make time: %s", __func__, str_time);
       return 0;
     }
 
@@ -241,7 +241,7 @@ parse_nvt_timestamp (const gchar *str_time)
                   "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]", &offset)
           != 1))
     {
-      g_warning ("%s: Failed to parse timezone offset: %s", __FUNCTION__,
+      g_warning ("%s: Failed to parse timezone offset: %s", __func__,
                  str_time);
       return 0;
     }

--- a/base/pidfile.c
+++ b/base/pidfile.c
@@ -59,7 +59,7 @@ pidfile_create (gchar *daemon_name)
 
   if (pidfile == NULL)
     {
-      g_critical ("%s: failed to open pidfile: %s\n", __FUNCTION__,
+      g_critical ("%s: failed to open pidfile: %s\n", __func__,
                   strerror (errno));
       return 1;
     }

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -344,7 +344,7 @@ osp_get_vts_version (osp_connection_t *connection, char **vts_version)
   vts = entity_child (entity, "vts");
   if (!vts)
     {
-      g_warning ("%s: element VTS missing.", __FUNCTION__);
+      g_warning ("%s: element VTS missing.", __func__);
       free_entity (entity);
       return 1;
     }
@@ -352,7 +352,7 @@ osp_get_vts_version (osp_connection_t *connection, char **vts_version)
   version = entity_child (vts, "version");
   if (!version)
     {
-      g_warning ("%s: element VERSION missing.", __FUNCTION__);
+      g_warning ("%s: element VERSION missing.", __func__);
       free_entity (entity);
       return 1;
     }
@@ -1375,7 +1375,7 @@ osp_credential_set_auth_data (osp_credential_t *credential,
     }
   else
     {
-      g_warning ("%s: Invalid auth data name: %s", __FUNCTION__, name);
+      g_warning ("%s: Invalid auth data name: %s", __func__, name);
     }
 }
 

--- a/util/authutils.c
+++ b/util/authutils.c
@@ -123,7 +123,7 @@ gvm_auth_init ()
    * test. */
   if (!gcry_check_version (NULL))
     {
-      g_critical ("%s: libgcrypt version check failed\n", __FUNCTION__);
+      g_critical ("%s: libgcrypt version check failed\n", __func__);
       return -1;
     }
 

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -136,7 +136,7 @@ gvm_file_copy (const gchar *source_file, const gchar *dest_file)
     g_file_copy (sfile, dfile, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, &error);
   if (!rc)
     {
-      g_warning ("%s: g_file_copy(%s, %s) failed - %s\n", __FUNCTION__,
+      g_warning ("%s: g_file_copy(%s, %s) failed - %s\n", __func__,
                  source_file, dest_file, error->message);
       g_error_free (error);
     }
@@ -171,7 +171,7 @@ gvm_file_move (const gchar *source_file, const gchar *dest_file)
     g_file_move (sfile, dfile, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, &error);
   if (!rc)
     {
-      g_warning ("%s: g_file_move(%s, %s) failed - %s\n", __FUNCTION__,
+      g_warning ("%s: g_file_move(%s, %s) failed - %s\n", __func__,
                  source_file, dest_file, error->message);
       g_error_free (error);
     }
@@ -373,7 +373,7 @@ gvm_export_file_name (const char *fname_format, const char *username,
               break;
             default:
               g_warning ("%s : Unknown file name format placeholder: %%%c.",
-                         __FUNCTION__, *fname_point);
+                         __func__, *fname_point);
               format_state = -1;
             }
         }
@@ -382,7 +382,7 @@ gvm_export_file_name (const char *fname_format, const char *username,
 
   if (format_state || strcmp (file_name_buf->str, "") == 0)
     {
-      g_warning ("%s : Invalid file name format", __FUNCTION__);
+      g_warning ("%s : Invalid file name format", __func__);
       g_string_free (file_name_buf, TRUE);
       return NULL;
     }

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -197,7 +197,7 @@ gvm_gpg_import_many_types_from_string (gpgme_ctx_t ctx,
   if (given_key_type == GPGME_DATA_TYPE_INVALID)
     {
       ret = 1;
-      g_warning ("%s: key_str is invalid", __FUNCTION__);
+      g_warning ("%s: key_str is invalid", __func__);
     }
   else
     {
@@ -225,7 +225,7 @@ gvm_gpg_import_many_types_from_string (gpgme_ctx_t ctx,
             }
           g_warning ("%s: key_str is not the expected type: "
                      " expected: %s, got %d",
-                     __FUNCTION__, expected_buffer->str, given_key_type);
+                     __func__, expected_buffer->str, given_key_type);
           g_string_free (expected_buffer, TRUE);
         }
     }
@@ -240,12 +240,12 @@ gvm_gpg_import_many_types_from_string (gpgme_ctx_t ctx,
   gpgme_data_release (key_data);
   if (err)
     {
-      g_warning ("%s: Import failed: %s", __FUNCTION__, gpgme_strerror (err));
+      g_warning ("%s: Import failed: %s", __func__, gpgme_strerror (err));
       return 3;
     }
 
   import_result = gpgme_op_import_result (ctx);
-  g_debug ("%s: %d imported, %d not imported", __FUNCTION__,
+  g_debug ("%s: %d imported, %d not imported", __func__,
            import_result->imported, import_result->not_imported);
 
   gpgme_import_status_t status;
@@ -253,10 +253,10 @@ gvm_gpg_import_many_types_from_string (gpgme_ctx_t ctx,
   while (status)
     {
       if (status->result != GPG_ERR_NO_ERROR)
-        g_warning ("%s: '%s' could not be imported: %s", __FUNCTION__,
+        g_warning ("%s: '%s' could not be imported: %s", __func__,
                    status->fpr, gpgme_strerror (status->result));
       else
-        g_debug ("%s: Imported '%s'", __FUNCTION__, status->fpr);
+        g_debug ("%s: Imported '%s'", __func__, status->fpr);
 
       status = status->next;
     };
@@ -320,19 +320,19 @@ find_email_encryption_key (gpgme_ctx_t ctx, const char *uid_email)
     {
       if (key->can_encrypt)
         {
-          g_debug ("%s: key '%s' OK for encryption", __FUNCTION__,
+          g_debug ("%s: key '%s' OK for encryption", __func__,
                    key->subkeys->fpr);
 
           gpgme_user_id_t uid;
           uid = key->uids;
           while (uid && recipient_found == FALSE)
             {
-              g_debug ("%s: UID email: %s", __FUNCTION__, uid->email);
+              g_debug ("%s: UID email: %s", __func__, uid->email);
 
               if (strcmp (uid->email, uid_email) == 0
                   || strstr (uid->email, bracket_email))
                 {
-                  g_message ("%s: Found matching UID for %s", __FUNCTION__,
+                  g_message ("%s: Found matching UID for %s", __func__,
                              uid_email);
                   recipient_found = TRUE;
                 }
@@ -341,7 +341,7 @@ find_email_encryption_key (gpgme_ctx_t ctx, const char *uid_email)
         }
       else
         {
-          g_debug ("%s: key '%s' cannot be used for encryption", __FUNCTION__,
+          g_debug ("%s: key '%s' cannot be used for encryption", __func__,
                    key->subkeys->fpr);
         }
 
@@ -353,7 +353,7 @@ find_email_encryption_key (gpgme_ctx_t ctx, const char *uid_email)
     return key;
   else
     {
-      g_warning ("%s: No suitable key found for %s", __FUNCTION__, uid_email);
+      g_warning ("%s: No suitable key found for %s", __func__, uid_email);
       return NULL;
     }
 }
@@ -391,7 +391,7 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
   if (uid_email == NULL || strcmp (uid_email, "") == 0)
     {
       g_warning ("%s: No email address for user identification given",
-                 __FUNCTION__);
+                 __func__);
       return -1;
     }
 
@@ -403,7 +403,7 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
   // Create temporary GPG home directory, set up context and encryption flags
   if (mkdtemp (gpg_temp_dir) == NULL)
     {
-      g_warning ("%s: mkdtemp failed\n", __FUNCTION__);
+      g_warning ("%s: mkdtemp failed\n", __func__);
       return -1;
     }
 
@@ -421,7 +421,7 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
   // Import public key into context
   if (gvm_gpg_import_many_types_from_string (ctx, key_str, key_len, key_types))
     {
-      g_warning ("%s: Import of %s failed", __FUNCTION__, key_type_str);
+      g_warning ("%s: Import of %s failed", __func__, key_type_str);
       gpgme_release (ctx);
       gvm_file_remove_recurse (gpg_temp_dir);
       return -1;
@@ -431,7 +431,7 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
   key = find_email_encryption_key (ctx, uid_email);
   if (key == NULL)
     {
-      g_warning ("%s: Could not find %s for encryption", __FUNCTION__,
+      g_warning ("%s: Could not find %s for encryption", __func__,
                  key_type_str);
       gpgme_release (ctx);
       gvm_file_remove_recurse (gpg_temp_dir);
@@ -451,7 +451,7 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
 
   if (err)
     {
-      g_warning ("%s: Encryption failed: %s", __FUNCTION__,
+      g_warning ("%s: Encryption failed: %s", __func__,
                  gpgme_strerror (err));
       gpgme_data_release (plain_data);
       gpgme_data_release (encrypted_data);

--- a/util/radiusutils.c
+++ b/util/radiusutils.c
@@ -81,7 +81,7 @@ radius_init (const char *hostname, const char *secret)
   if (config_fd == -1)
     {
       g_warning ("%s: Couldn't create temp radius config file: %s\n",
-                 __FUNCTION__, strerror (errno));
+                 __func__, strerror (errno));
       goto radius_init_fail;
     }
 
@@ -90,7 +90,7 @@ radius_init (const char *hostname, const char *secret)
     {
       close (config_fd);
       g_warning ("%s: Couldn't open temp radius config file %s: %s\n",
-                 __FUNCTION__, config_filename, strerror (errno));
+                 __func__, config_filename, strerror (errno));
       goto radius_init_fail;
     }
 
@@ -109,7 +109,7 @@ radius_init (const char *hostname, const char *secret)
     {
       fclose (config_file);
       g_warning ("%s: Couldn't write to temp radius config file %s:%s\n",
-                 __FUNCTION__, config_filename, strerror (errno));
+                 __func__, config_filename, strerror (errno));
       unlink (config_filename);
       goto radius_init_fail;
     }
@@ -118,7 +118,7 @@ radius_init (const char *hostname, const char *secret)
   rh = rc_read_config (config_filename);
   if (rh == NULL)
     {
-      g_warning ("%s: Couldn't read temp radius config file %s\n", __FUNCTION__,
+      g_warning ("%s: Couldn't read temp radius config file %s\n", __func__,
                  config_filename);
       unlink (config_filename);
       goto radius_init_fail;

--- a/util/serverutils.c
+++ b/util/serverutils.c
@@ -78,7 +78,7 @@ close_unix (gvm_connection_t *client_connection)
   /* Turn off blocking. */
   if (fcntl (client_connection->socket, F_SETFL, O_NONBLOCK) == -1)
     {
-      g_warning ("%s: failed to set server socket flag: %s\n", __FUNCTION__,
+      g_warning ("%s: failed to set server socket flag: %s\n", __func__,
                  strerror (errno));
       return -1;
     }
@@ -87,14 +87,14 @@ close_unix (gvm_connection_t *client_connection)
     {
       if (errno == ENOTCONN)
         return 0;
-      g_warning ("%s: failed to shutdown server socket: %s\n", __FUNCTION__,
+      g_warning ("%s: failed to shutdown server socket: %s\n", __func__,
                  strerror (errno));
       return -1;
     }
 
   if (close (client_connection->socket) == -1)
     {
-      g_warning ("%s: failed to close server socket: %s\n", __FUNCTION__,
+      g_warning ("%s: failed to close server socket: %s\n", __func__,
                  strerror (errno));
       return -1;
     }
@@ -135,32 +135,32 @@ gvm_server_verify (gnutls_session_t session)
   ret = gnutls_certificate_verify_peers2 (session, &status);
   if (ret < 0)
     {
-      g_warning ("%s: failed to verify peers: %s", __FUNCTION__,
+      g_warning ("%s: failed to verify peers: %s", __func__,
                  gnutls_strerror (ret));
       return -1;
     }
 
   if (status & GNUTLS_CERT_INVALID)
-    g_warning ("%s: the certificate is not trusted", __FUNCTION__);
+    g_warning ("%s: the certificate is not trusted", __func__);
 
   if (status & GNUTLS_CERT_SIGNER_NOT_CA)
-    g_warning ("%s: the certificate's issuer is not a CA", __FUNCTION__);
+    g_warning ("%s: the certificate's issuer is not a CA", __func__);
 
   if (status & GNUTLS_CERT_INSECURE_ALGORITHM)
     g_warning ("%s: the certificate was signed using an insecure algorithm",
-               __FUNCTION__);
+               __func__);
 
   if (status & GNUTLS_CERT_SIGNER_NOT_FOUND)
-    g_warning ("%s: the certificate hasn't got a known issuer", __FUNCTION__);
+    g_warning ("%s: the certificate hasn't got a known issuer", __func__);
 
   if (status & GNUTLS_CERT_REVOKED)
-    g_warning ("%s: the certificate has been revoked", __FUNCTION__);
+    g_warning ("%s: the certificate has been revoked", __func__);
 
   if (status & GNUTLS_CERT_EXPIRED)
-    g_warning ("%s: the certificate has expired", __FUNCTION__);
+    g_warning ("%s: the certificate has expired", __func__);
 
   if (status & GNUTLS_CERT_NOT_ACTIVATED)
-    g_warning ("%s: the certificate is not yet activated", __FUNCTION__);
+    g_warning ("%s: the certificate is not yet activated", __func__);
 
   if (status)
     return 1;
@@ -630,7 +630,7 @@ gvm_server_vsendf_internal (gnutls_session_t *session, const char *fmt,
             {
               /* \todo Rehandshake. */
               if (quiet == 0)
-                g_message ("   %s rehandshake", __FUNCTION__);
+                g_message ("   %s rehandshake", __func__);
               continue;
             }
           g_warning ("Failed to write to server: %s", gnutls_strerror (count));
@@ -1013,7 +1013,7 @@ server_new_gnutls_init (gnutls_certificate_credentials_t *server_credentials)
   /* Setup server session. */
   if (gnutls_certificate_allocate_credentials (server_credentials))
     {
-      g_warning ("%s: failed to allocate server credentials\n", __FUNCTION__);
+      g_warning ("%s: failed to allocate server credentials\n", __func__);
       return -1;
     }
   return 0;
@@ -1037,7 +1037,7 @@ server_new_gnutls_set (unsigned int end_type, const char *priority,
 
   if (gnutls_init (server_session, end_type))
     {
-      g_warning ("%s: failed to initialise server session\n", __FUNCTION__);
+      g_warning ("%s: failed to initialise server session\n", __func__);
       return -1;
     }
 
@@ -1052,7 +1052,7 @@ server_new_gnutls_set (unsigned int end_type, const char *priority,
   if ((err_gnutls = gnutls_priority_set_direct (
          *server_session, priority ? priority : "NORMAL", NULL)))
     {
-      g_warning ("%s: failed to set tls priorities: %s\n", __FUNCTION__,
+      g_warning ("%s: failed to set tls priorities: %s\n", __func__,
                  gnutls_strerror (err_gnutls));
       gnutls_deinit (*server_session);
       return -1;
@@ -1061,7 +1061,7 @@ server_new_gnutls_set (unsigned int end_type, const char *priority,
   if (gnutls_credentials_set (*server_session, GNUTLS_CRD_CERTIFICATE,
                               *server_credentials))
     {
-      g_warning ("%s: failed to set server credentials\n", __FUNCTION__);
+      g_warning ("%s: failed to set server credentials\n", __func__);
       gnutls_deinit (*server_session);
       return -1;
     }
@@ -1104,9 +1104,9 @@ server_new_internal (unsigned int end_type, const char *priority,
       if (ret < 0)
         {
           g_warning ("%s: failed to set credentials key file: %s\n",
-                     __FUNCTION__, gnutls_strerror (ret));
-          g_warning ("%s:   cert file: %s\n", __FUNCTION__, cert_file);
-          g_warning ("%s:   key file : %s\n", __FUNCTION__, key_file);
+                     __func__, gnutls_strerror (ret));
+          g_warning ("%s:   cert file: %s\n", __func__, cert_file);
+          g_warning ("%s:   key file : %s\n", __func__, key_file);
           gnutls_certificate_free_credentials (*server_credentials);
           return -1;
         }
@@ -1121,8 +1121,8 @@ server_new_internal (unsigned int end_type, const char *priority,
       if (ret < 0)
         {
           g_warning ("%s: failed to set credentials trust file: %s\n",
-                     __FUNCTION__, gnutls_strerror (ret));
-          g_warning ("%s: trust file: %s\n", __FUNCTION__, ca_cert_file);
+                     __func__, gnutls_strerror (ret));
+          g_warning ("%s: trust file: %s\n", __func__, ca_cert_file);
           gnutls_certificate_free_credentials (*server_credentials);
           return -1;
         }
@@ -1196,7 +1196,7 @@ gvm_server_new_mem (unsigned int end_type, const char *ca_cert,
                                                  GNUTLS_X509_FMT_PEM);
       if (ret < 0)
         {
-          g_warning ("%s: %s\n", __FUNCTION__, gnutls_strerror (ret));
+          g_warning ("%s: %s\n", __func__, gnutls_strerror (ret));
           return -1;
         }
     }
@@ -1212,7 +1212,7 @@ gvm_server_new_mem (unsigned int end_type, const char *ca_cert,
                                                    GNUTLS_X509_FMT_PEM);
       if (ret < 0)
         {
-          g_warning ("%s: %s\n", __FUNCTION__, gnutls_strerror (ret));
+          g_warning ("%s: %s\n", __func__, gnutls_strerror (ret));
           gnutls_certificate_free_credentials (*credentials);
           return -1;
         }
@@ -1277,7 +1277,7 @@ gvm_server_free (int server_socket, gnutls_session_t server_session,
   // FIX get flags first
   if (fcntl (server_socket, F_SETFL, O_NONBLOCK) == -1)
     {
-      g_warning ("%s: failed to set server socket flag: %s\n", __FUNCTION__,
+      g_warning ("%s: failed to set server socket flag: %s\n", __func__,
                  strerror (errno));
       return -1;
     }
@@ -1310,7 +1310,7 @@ gvm_server_free (int server_socket, gnutls_session_t server_session,
     {
       if (close (server_socket) == -1)
         {
-          g_warning ("%s: failed to close server socket: %s\n", __FUNCTION__,
+          g_warning ("%s: failed to close server socket: %s\n", __func__,
                      strerror (errno));
           return -1;
         }

--- a/util/uuidutils.c
+++ b/util/uuidutils.c
@@ -44,7 +44,7 @@ gvm_uuid_make (void)
   uuid_generate (uuid);
   if (uuid_is_null (uuid) == 1)
     {
-      g_warning ("%s: failed to generate UUID", __FUNCTION__);
+      g_warning ("%s: failed to generate UUID", __func__);
       return NULL;
     }
 
@@ -52,7 +52,7 @@ gvm_uuid_make (void)
   id = g_malloc0 (sizeof (char) * 37);
   if (id == NULL)
     {
-      g_warning ("%s: Cannot export UUID to text: out of memory", __FUNCTION__);
+      g_warning ("%s: Cannot export UUID to text: out of memory", __func__);
       return NULL;
     }
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -523,7 +523,7 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
                       g_warning ("   timeout\n");
                       if (fcntl (socket, F_SETFL, 0L) < 0)
                         g_warning ("%s :failed to set socket flag: %s",
-                                   __FUNCTION__, strerror (errno));
+                                   __func__, strerror (errno));
                       g_markup_parse_context_free (xml_context);
                       g_free (buffer);
                       return -4;
@@ -544,7 +544,7 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
                 {
                   if (fcntl (socket, F_SETFL, 0L) < 0)
                     g_warning ("%s :failed to set socket flag: %s",
-                               __FUNCTION__, strerror (errno));
+                               __func__, strerror (errno));
                 }
               g_markup_parse_context_free (xml_context);
               g_free (buffer);
@@ -570,7 +570,7 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
                 {
                   if (fcntl (socket, F_SETFL, 0L) < 0)
                     g_warning ("%s :failed to set socket flag: %s",
-                               __FUNCTION__, strerror (errno));
+                               __func__, strerror (errno));
                 }
               g_markup_parse_context_free (xml_context);
               g_free (buffer);
@@ -598,7 +598,7 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
           if (timeout > 0)
             {
               if (fcntl (socket, F_SETFL, 0L) < 0)
-                g_warning ("%s :failed to set socket flag: %s", __FUNCTION__,
+                g_warning ("%s :failed to set socket flag: %s", __func__,
                            strerror (errno));
             }
           g_markup_parse_context_free (xml_context);
@@ -638,7 +638,7 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
           g_warning ("   failed to get current time (1): %s\n",
                      strerror (errno));
           if (fcntl (socket, F_SETFL, 0L) < 0)
-            g_warning ("%s :failed to set socket flag: %s", __FUNCTION__,
+            g_warning ("%s :failed to set socket flag: %s", __func__,
                        strerror (errno));
           g_markup_parse_context_free (xml_context);
           g_free (buffer);
@@ -743,7 +743,7 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
                           g_warning ("   timeout\n");
                           if (fcntl (socket, F_SETFL, 0L) < 0)
                             g_warning ("%s :failed to set socket flag: %s",
-                                       __FUNCTION__, strerror (errno));
+                                       __func__, strerror (errno));
                           g_markup_parse_context_free (xml_context);
                           g_free (buffer);
                           return -4;
@@ -784,7 +784,7 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
                 {
                   if (fcntl (socket, F_SETFL, 0L) < 0)
                     g_warning ("%s :failed to set socket flag: %s",
-                               __FUNCTION__, strerror (errno));
+                               __func__, strerror (errno));
                 }
               g_markup_parse_context_free (xml_context);
               g_free (buffer);
@@ -813,7 +813,7 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
           if (timeout > 0)
             {
               if (fcntl (socket, F_SETFL, 0L) < 0)
-                g_warning ("%s :failed to set socket flag: %s", __FUNCTION__,
+                g_warning ("%s :failed to set socket flag: %s", __func__,
                            strerror (errno));
             }
           g_markup_parse_context_free (xml_context);
@@ -854,7 +854,7 @@ try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
           g_warning ("   failed to get current time (1): %s\n",
                      strerror (errno));
           if (fcntl (socket, F_SETFL, 0L) < 0)
-            g_warning ("%s :failed to set server socket flag: %s", __FUNCTION__,
+            g_warning ("%s :failed to set server socket flag: %s", __func__,
                        strerror (errno));
           g_markup_parse_context_free (xml_context);
           g_free (buffer);
@@ -1468,7 +1468,7 @@ xml_search_handle_start_element (GMarkupParseContext *ctx,
   if (strcmp (element_name, search_data->find_element) == 0
       && search_data->found == 0)
     {
-      g_debug ("%s: Found element <%s>", __FUNCTION__, element_name);
+      g_debug ("%s: Found element <%s>", __func__, element_name);
 
       if (search_data->find_attributes
           && g_hash_table_size (search_data->find_attributes))
@@ -1486,13 +1486,13 @@ xml_search_handle_start_element (GMarkupParseContext *ctx,
               if (searched_value
                   && strcmp (searched_value, attribute_values[index]) == 0)
                 {
-                  g_debug ("%s: Found attribute %s=\"%s\"", __FUNCTION__,
+                  g_debug ("%s: Found attribute %s=\"%s\"", __func__,
                            attribute_names[index], searched_value);
                   g_hash_table_add (found_attributes, searched_value);
                 }
               index++;
             }
-          g_debug ("%s: Found %d of %d attributes", __FUNCTION__,
+          g_debug ("%s: Found %d of %d attributes", __func__,
                    g_hash_table_size (found_attributes),
                    g_hash_table_size (search_data->find_attributes));
 
@@ -1549,7 +1549,7 @@ find_element_in_xml_file (gchar *file_path, gchar *find_element,
   if (file == NULL)
     {
       g_markup_parse_context_free (xml_context);
-      g_warning ("%s: Failed to open '%s':", __FUNCTION__, strerror (errno));
+      g_warning ("%s: Failed to open '%s':", __func__, strerror (errno));
       return 0;
     }
 


### PR DESCRIPTION
We were mixing `__func__` and `__FUNCTION__`, so we're switching all to `__func__`.

GCC manual: `__FUNCTION__` is another name for `__func__`, provided for backward compatibility with old versions of GCC. 
