### PR TITLE
Fix trust and file handling for S/MIME (11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix sigsegv when no plugin_feed_info.inc file present. [#278](https://github.com/greenbone/gvm-libs/pull/278)
 - Fix missing linking to libgnutls in util/CMakeLists.txt. [#291](https://github.com/greenbone/gvm-libs/pull/291)
+- Fix trust and file handling for S/MIME [#309](https://github.com/greenbone/gvm-libs/pull/309)
 
 [11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.0...gvm-libs-11.0
 

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -445,7 +445,8 @@ create_all_certificates_trustlist (gpgme_ctx_t ctx, const char *homedir)
   GString *trustlist_content;
   GError *g_err;
 
-  g_err = NULL;  gpgme_set_pinentry_mode (ctx, GPGME_PINENTRY_MODE_CANCEL);
+  g_err = NULL;
+  gpgme_set_pinentry_mode (ctx, GPGME_PINENTRY_MODE_CANCEL);
 
   trustlist_filename = g_build_filename (homedir,
                                          "trustlist.txt",

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -359,6 +359,127 @@ find_email_encryption_key (gpgme_ctx_t ctx, const char *uid_email)
 }
 
 /**
+ * @brief Wrapper for fread for use as a GPGME callback.
+ *
+ * @param[in]  handle   The file handle.
+ * @param[out] buffer   The data buffer to read data into.
+ * @param[in]  size     The size of the buffer.
+ *
+ * @return The number of bytes read or -1 on error.
+ */
+static ssize_t
+gvm_gpgme_fread (void *handle, void *buffer, size_t size)
+{
+  int ret;
+  FILE *file = (FILE *)handle;
+
+  ret = fread (buffer, 1, size, file);
+  if (ferror (file))
+    return -1;
+  return ret;
+}
+
+/**
+ * @brief Wrapper for fread for use as a GPGME callback.
+ *
+ * @param[in]  handle   The file handle.
+ * @param[in]  buffer   The data buffer to read data into.
+ * @param[in]  size     The amount of buffered data.
+ *
+ * @return The number of bytes written or -1 on error.
+ */
+static ssize_t
+gvm_gpgme_fwrite (void *handle, const void *buffer, size_t size)
+{
+  int ret;
+  FILE *file = (FILE *)handle;
+
+  ret = fwrite (buffer, 1, size, file);
+  if (ferror (file))
+    return -1;
+  return ret;
+}
+
+/**
+ * @brief Create a GPGME data buffer with custom read and write functions.
+ *
+ * This is neccessary as gpgme_data_new_from_stream may cause problems
+ *  when trying to write to the stream after some operations.
+ *
+ * @param[out]  new_data  The new GPGME data buffer.
+ * @param[in]   file      The stream to read from and write to.
+ *
+ * @return The return value from gpgme_data_new_from_cbs.
+ */
+static gpgme_error_t
+gvm_gpgme_data_new_from_stream (gpgme_data_t *new_data, FILE *file)
+{
+  struct gpgme_data_cbs *callbacks;
+
+  callbacks = malloc (sizeof (struct gpgme_data_cbs));
+  memset (callbacks, 0, sizeof (struct gpgme_data_cbs));
+  callbacks->read = gvm_gpgme_fread;
+  callbacks->write = gvm_gpgme_fwrite;
+
+  return gpgme_data_new_from_cbs (new_data, callbacks, file);
+}
+
+/**
+ * @brief  Adds a trust list of all current certificates to a GPG homedir.
+ *
+ * This will overwrite the existing trustlist, so it should only be used for
+ *  temporary, automatically generated GPG home directories.
+ *
+ * TODO: This should use or be replaced by a trust model inside GVM.
+ *
+ * @param[in]  ctx      The GPGME context to get the keys from.
+ * @param[in]  homedir  The directory to write the trust list file to.
+ *
+ * @return 0 success, -1 error.
+ */
+static int
+create_all_certificates_trustlist (gpgme_ctx_t ctx, const char *homedir)
+{
+  gpgme_key_t key;
+  gchar *trustlist_filename;
+  GString *trustlist_content;
+  GError *g_err;
+
+  g_err = NULL;  gpgme_set_pinentry_mode (ctx, GPGME_PINENTRY_MODE_CANCEL);
+
+  trustlist_filename = g_build_filename (homedir,
+                                         "trustlist.txt",
+                                         NULL);
+
+  trustlist_content = g_string_new ("");
+
+  gpgme_op_keylist_start (ctx, NULL, 0);
+  gpgme_op_keylist_next (ctx, &key);
+  while (key)
+    {
+      g_string_append_printf (trustlist_content, "%s S\n", key->fpr);
+      gpgme_op_keylist_next (ctx, &key);
+    }
+
+  if (g_file_set_contents (trustlist_filename,
+                           trustlist_content->str,
+                           trustlist_content->len,
+                           &g_err) == FALSE)
+    {
+      g_warning ("%s: Could not write trust list: %s",
+                 __func__, g_err->message);
+      g_free (trustlist_filename);
+      g_string_free (trustlist_content, TRUE);
+      return -1;
+    }
+
+  g_free (trustlist_filename);
+  g_string_free (trustlist_content, TRUE);
+
+  return 0;
+}
+
+/**
  * @brief Encrypt a stream for a PGP public key, writing to another stream.
  *
  * The output will use ASCII armor mode and no compression.
@@ -441,10 +562,21 @@ encrypt_stream_internal (FILE *plain_file, FILE *encrypted_file,
 
   // Set up data objects for input and output streams
   gpgme_data_new_from_stream (&plain_data, plain_file);
-  gpgme_data_new_from_stream (&encrypted_data, encrypted_file);
+  gvm_gpgme_data_new_from_stream (&encrypted_data, encrypted_file);
 
   if (protocol == GPGME_PROTOCOL_CMS)
-    gpgme_data_set_encoding (encrypted_data, GPGME_DATA_ENCODING_BASE64);
+    {
+      gpgme_data_set_encoding (encrypted_data, GPGME_DATA_ENCODING_BASE64);
+
+      if (create_all_certificates_trustlist (ctx, gpg_temp_dir))
+        {
+          gpgme_data_release (plain_data);
+          gpgme_data_release (encrypted_data);
+          gpgme_release (ctx);
+          gvm_file_remove_recurse (gpg_temp_dir);
+          return -1;
+        }
+    }
 
   // Encrypt data
   err = gpgme_op_encrypt (ctx, keys, encrypt_flags, plain_data, encrypted_data);

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -416,8 +416,7 @@ gvm_gpgme_data_new_from_stream (gpgme_data_t *new_data, FILE *file)
 {
   struct gpgme_data_cbs *callbacks;
 
-  callbacks = malloc (sizeof (struct gpgme_data_cbs));
-  memset (callbacks, 0, sizeof (struct gpgme_data_cbs));
+  callbacks = g_malloc0 (sizeof (struct gpgme_data_cbs));
   callbacks->read = gvm_gpgme_fread;
   callbacks->write = gvm_gpgme_fwrite;
 


### PR DESCRIPTION
The certificates used for S/MIME encryption are now added to the GPG
trust list automatically because users cannot always confirm trust.

Also, a data buffer with custom I/O functions is used to write the
encrypted data because gpgme_data_new_from_stream can cause problems
when trying to write afterwards.

**Checklist**:

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
