### PR TITLE
Get details with get_reports in gmp_get_report_ext (11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix sigsegv when no plugin_feed_info.inc file present. [#278](https://github.com/greenbone/gvm-libs/pull/278)
 - Fix missing linking to libgnutls in util/CMakeLists.txt. [#291](https://github.com/greenbone/gvm-libs/pull/291)
 - Fix trust and file handling for S/MIME [#309](https://github.com/greenbone/gvm-libs/pull/309)
+- Get details with get_reports in gmp_get_report_ext [#313](https://github.com/greenbone/gvm-libs/pull/313)
 
 [11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.0...gvm-libs-11.0
 

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -1355,6 +1355,7 @@ gmp_get_report_ext (gnutls_session_t *session, gmp_get_report_opts_t opts,
   if (gvm_server_sendf (
         session,
         "<get_reports"
+        " details=\"1\""
         " report_id=\"%s\""
         " format_id=\"%s\""
         " host_first_result=\"%i\""


### PR DESCRIPTION
To ensure the previous behavior of getting the results etc. the details
attribute has been added to the sent GMP command.

**Checklist**:
- [] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
