### PR TITLE
Add multiple severities for nvti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use dedicated port list for alive detection (Boreas only) if supplied via OSP. [#391](https://github.com/greenbone/gvm-libs/pull/391)
 - Allow to re allocate the finish flag in the host queue for alive tests. [#407](https://github.com/greenbone/gvm-libs/pull/407)
 
+### Added
+- Add multiple severities for nvti [#317](https://github.com/greenbone/gvm-libs/pull/317)
+
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)
 - Continuously send dead hosts to ospd-openvas to enable a smooth progess bar if only ICMP is chosen as alive test.  [#389](https://github.com/greenbone/gvm-libs/pull/389)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -909,6 +909,31 @@ nvti_vtseverity (const nvti_t *n, guint p)
 }
 
 /**
+ * @brief Get the maximum severity score
+ *
+ * @param n The NVT Info structure.
+ *
+ * @return The severity score, -1 indicates an error.
+ */
+int
+nvti_severity_score (const nvti_t *n)
+{
+  unsigned int i;
+  int score = -1;
+
+  for (i = 0; i < nvti_vtseverities_len (n); i++)
+    {
+      vtseverity_t *severity;
+
+      severity = nvti_vtseverity (n, i);
+      if (vtseverity_score (severity) > score)
+        score = vtseverity_score (severity);
+    }
+
+  return score;
+}
+
+/**
  * @brief Get the solution.
  *
  * @param n The NVT Info structure of which the solution should

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -168,11 +168,12 @@ vtref_text (const vtref_t *r)
  */
 typedef struct vtseverity
 {
-  gchar *type;     ///< Severity type ("cvss_base_v2", ...)
-  gchar *origin;   ///< Optional: Where does the severity come from ("CVE-2018-1234", "Greenbone Research")
+  gchar *type;   ///< Severity type ("cvss_base_v2", ...)
+  gchar *origin; ///< Optional: Where does the severity come from
+                 ///< ("CVE-2018-1234", "Greenbone Research")
   int date; ///< Timestamp in seconds since epoch, defaults to VT creation date.
-  int score; ///< The score derived from the value in range [0-100]
-  gchar *value;   ///< The value which corresponds to the type.
+  int score;    ///< The score derived from the value in range [0-100]
+  gchar *value; ///< The value which corresponds to the type.
 } vtseverity_t;
 
 /**
@@ -292,7 +293,6 @@ vtseverity_score (const vtseverity_t *s)
 {
   return s->score;
 }
-
 
 /* Support function for timestamps */
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -103,6 +103,8 @@ guint
 nvti_vtseverities_len (const nvti_t *);
 vtseverity_t *
 nvti_vtseverity (const nvti_t *, guint);
+int
+nvti_severity_score (const nvti_t *);
 
 nvti_t *
 nvti_new (void);

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2019 Greenbone Networks GmbH
+/* Copyright (C) 2009-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -55,6 +55,11 @@ nvtpref_id (const nvtpref_t *);
 typedef struct vtref vtref_t;
 
 /**
+ * @brief The structure for a severity of a VT.
+ */
+typedef struct vtseverity vtseverity_t;
+
+/**
  * @brief The structure of a information record that corresponds to a NVT.
  */
 typedef struct nvti nvti_t;
@@ -70,12 +75,34 @@ vtref_id (const vtref_t *);
 const gchar *
 vtref_text (const vtref_t *);
 
+vtseverity_t *
+vtseverity_new (const gchar *, const gchar *, int, int, const gchar *);
+void
+vtseverity_free (vtseverity_t *);
+const gchar *
+vtseverity_type (const vtseverity_t *);
+const gchar *
+vtseverity_origin (const vtseverity_t *);
+const gchar *
+vtseverity_value (const vtseverity_t *);
+int
+vtseverity_date (const vtseverity_t *);
+int
+vtseverity_score (const vtseverity_t *);
+
 int
 nvti_add_vtref (nvti_t *, vtref_t *);
 guint
 nvti_vtref_len (const nvti_t *);
 vtref_t *
 nvti_vtref (const nvti_t *, guint);
+
+int
+nvti_add_vtseverity (nvti_t *, vtseverity_t *);
+guint
+nvti_vtseverities_len (const nvti_t *);
+vtseverity_t *
+nvti_vtseverity (const nvti_t *, guint);
 
 nvti_t *
 nvti_new (void);


### PR DESCRIPTION
This adds a handling for severities similar to refs.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
