### PR TITLE
Fix printing valid xml attributes for an entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix missing linking to libgnutls in util/CMakeLists.txt. [#291](https://github.com/greenbone/gvm-libs/pull/291)
 - Fix trust and file handling for S/MIME [#309](https://github.com/greenbone/gvm-libs/pull/309)
 - Get details with get_reports in gmp_get_report_ext [#313](https://github.com/greenbone/gvm-libs/pull/313)
+- Fix escaping entity attributes in print_entity_to_string [#318](https://github.com/greenbone/gvm-libs/pull/318)
 
 [11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.0...gvm-libs-11.0
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -1274,8 +1274,11 @@ static void
 foreach_print_attribute_to_string (gpointer name, gpointer value,
                                    gpointer string)
 {
+  gchar *text_escaped;
+  text_escaped = g_markup_escape_text ((gchar *) value, -1);
   g_string_append_printf ((GString *) string, " %s=\"%s\"", (char *) name,
-                          (char *) value);
+                          text_escaped);
+  g_free (text_escaped);
 }
 
 /**


### PR DESCRIPTION
For exporting a XML report in gsad the `print_entity_to_string` function
is used. While reading the report entity from the response all XML
entities are unescaped. Therefore when using the
`print_entity_to_string` it may create invalid XML attributes. Therefore
ensure that all invalid characters for attributes (like &) are escaped
before writing the entity to the GString.