### PR TITLE
get new gvm_host_t by string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extend osp with target's alive test option.[#312](https://github.com/greenbone/gvm-libs/pull/312)
 - Extend osp with target's reverse_lookup_* options.[#314](https://github.com/greenbone/gvm-libs/pull/314)
 - Add unit tests for osp. [#315](https://github.com/greenbone/gvm-libs/pull/315)
+- Add support for test_alive_hosts_only feature of openvas. [#320](https://github.com/greenbone/gvm-libs/pull/320)
 
 [20.4]: https://github.com/greenbone/gvm-libs/compare/gvm-libs-11.0...master
 

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1537,10 +1537,10 @@ gvm_hosts_exclude (gvm_hosts_t *hosts, const char *excluded_str)
 
 /**
  * @brief Creates a new gvm_host_t from the provided host_str. host_str can
- * consist of hostnam, IPv4 address or IPv6 address.
+ * consist of hostname, IPv4 address or IPv6 address.
  *
- * @param[in] host_str The host string. A copy will be created of this within
- *                      the returned struct.
+ * @param[in] host_str The host string. A copy will be created for the returned
+ * struct.
  *
  * @return NULL if error. Otherwise, a single host structure that should be put
  * into a gvm_hosts_t structure for freeing with @ref gvm_hosts_free or

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -894,7 +894,7 @@ gvm_host_free (gpointer host)
  * @param[in] hosts Hosts in which to insert the host.
  * @param[in] host  Host to insert.
  */
-static void
+void
 gvm_hosts_add (gvm_hosts_t *hosts, gvm_host_t *host)
 {
   if (hosts->count == hosts->max_size)
@@ -1533,6 +1533,60 @@ int
 gvm_hosts_exclude (gvm_hosts_t *hosts, const char *excluded_str)
 {
   return gvm_hosts_exclude_with_max (hosts, excluded_str, 0);
+}
+
+/**
+ * @brief Creates a new gvm_host_t from the provided host_str. host_str can
+ * consist of hostnam, IPv4 address or IPv6 address.
+ *
+ * @param[in] host_str The host string. A copy will be created of this within
+ *                      the returned struct.
+ *
+ * @return NULL if error. Otherwise, a single host structure that should be put
+ * into a gvm_hosts_t structure for freeing with @ref gvm_hosts_free or
+ * freed directly via @ref gvm_host_free.
+ */
+gvm_host_t *
+gvm_host_from_str (const gchar *host_str)
+{
+  if (host_str == NULL)
+    {
+      return NULL;
+    }
+  int host_type;
+
+  /* IPv4, hostname, IPv6 */
+  /* -1 if error. */
+  host_type = gvm_get_host_type (host_str);
+
+  switch (host_type)
+    {
+    case HOST_TYPE_NAME:
+    case HOST_TYPE_IPV4:
+    case HOST_TYPE_IPV6:
+      {
+        /* New host. */
+        gvm_host_t *host = gvm_host_new ();
+        host->type = host_type;
+        if (host_type == HOST_TYPE_NAME)
+          host->name = g_ascii_strdown (host_str, -1);
+        else if (host_type == HOST_TYPE_IPV4)
+          {
+            if (inet_pton (AF_INET, host_str, &host->addr) != 1)
+              break;
+          }
+        else if (host_type == HOST_TYPE_IPV6)
+          {
+            if (inet_pton (AF_INET6, host_str, &host->addr6) != 1)
+              break;
+          }
+        return host;
+      }
+    case -1:
+    default:
+      return NULL;
+    }
+  return NULL;
 }
 
 /**

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1536,11 +1536,10 @@ gvm_hosts_exclude (gvm_hosts_t *hosts, const char *excluded_str)
 }
 
 /**
- * @brief Creates a new gvm_host_t from the provided host_str. host_str can
- * consist of hostname, IPv4 address or IPv6 address.
+ * @brief Creates a new gvm_host_t from a host string.
  *
- * @param[in] host_str The host string. A copy will be created for the returned
- * struct.
+ * @param[in] host_str The host string can consist of a hostname, IPv4 address
+ * or IPv6 address.
  *
  * @return NULL if error. Otherwise, a single host structure that should be put
  * into a gvm_hosts_t structure for freeing with @ref gvm_hosts_free or
@@ -1549,11 +1548,10 @@ gvm_hosts_exclude (gvm_hosts_t *hosts, const char *excluded_str)
 gvm_host_t *
 gvm_host_from_str (const gchar *host_str)
 {
-  if (host_str == NULL)
-    {
-      return NULL;
-    }
   int host_type;
+
+  if (host_str == NULL)
+    return NULL;
 
   /* IPv4, hostname, IPv6 */
   /* -1 if error. */

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -100,8 +100,6 @@ struct gvm_hosts
 /* Function prototypes. */
 
 /* gvm_hosts_t related */
-void
-gvm_hosts_add (gvm_hosts_t *, gvm_host_t *);
 
 gvm_hosts_t *
 gvm_hosts_new (const gchar *);
@@ -120,6 +118,9 @@ gvm_hosts_shuffle (gvm_hosts_t *);
 
 void
 gvm_hosts_reverse (gvm_hosts_t *);
+
+void
+gvm_hosts_add (gvm_hosts_t *, gvm_host_t *);
 
 GSList *
 gvm_hosts_resolve (gvm_hosts_t *);

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -100,6 +100,9 @@ struct gvm_hosts
 /* Function prototypes. */
 
 /* gvm_hosts_t related */
+void
+gvm_hosts_add (gvm_hosts_t *, gvm_host_t *);
+
 gvm_hosts_t *
 gvm_hosts_new (const gchar *);
 
@@ -146,6 +149,9 @@ unsigned int
 gvm_hosts_removed (const gvm_hosts_t *);
 
 /* gvm_host_t related */
+
+gvm_host_t *
+gvm_host_from_str (const gchar *hosts_str);
 
 int
 gvm_host_in_hosts (const gvm_host_t *, const struct in6_addr *,


### PR DESCRIPTION
Add function for getting a gvm_host_t by string. This is used in the test_alive_hosts_only feature of openvas.

Related PR:
- [openvas](https://github.com/greenbone/openvas/pull/456)
- [ospd-openvas](https://github.com/greenbone/ospd-openvas/pull/204)