### PR TITLE
Prepare 11.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [11.0.1] (unreleased)
+## [11.0.2] (2020-05-12)
 
 ### Added
 - Add option to set finished hosts in OSP targets [#298](https://github.com/greenbone/gvm-libs/pull/298)
 - Add a fast memory-only XML parser [#299](https://github.com/greenbone/gvm-libs/pull/299)
 - Add new function gvm_libs_version [#301](https://github.com/greenbone/gvm-libs/pull/301)
 
+### Changed
+- Don't create an entity tree during read_string_c. [#305](https://github.com/greenbone/gvm-libs/pull/305)
+
 ### Fixed
 - Fix sigsegv when no plugin_feed_info.inc file present. [#278](https://github.com/greenbone/gvm-libs/pull/278)
 - Fix missing linking to libgnutls in util/CMakeLists.txt. [#291](https://github.com/greenbone/gvm-libs/pull/291)
+- Free string in all error exit cases [#308](https://github.com/greenbone/gvm-libs/pull/308)
 - Fix trust and file handling for S/MIME [#309](https://github.com/greenbone/gvm-libs/pull/309)
 - Get details with get_reports in gmp_get_report_ext [#313](https://github.com/greenbone/gvm-libs/pull/313)
 - Fix escaping entity attributes in print_entity_to_string [#318](https://github.com/greenbone/gvm-libs/pull/318)
+- Fix is_cidr_block() [#323][https://github.com/greenbone/gvm-libs/pull/323]
 
-[11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.0...gvm-libs-11.0
+[11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.1...v11.0.2
 
 ## [11.0.0] (2019-10-11)
 
@@ -46,7 +51,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make solution and solution_type explicit for nvti. [#255](https://github.com/greenbone/gvm-libs/pull/255)
 - Internalize struct nvtpref_t. [#260](https://github.com/greenbone/gvm-libs/pull/260)
 - Extend redis connection error msg with actual path. [#264](https://github.com/greenbone/gvm-libs/pull/264)
-- Don't create an entity tree during read_string_c. [#305](https://github.com/greenbone/gvm-libs/pull/305)
 
 ### Fixed
 - Prevent g_strsplit to be called with NULL. [#238](https://github.com/greenbone/gvm-libs/pull/238)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.0)
 message ("-- Configuring the Greenbone Vulnerability Management Libraries...")
 
 project (gvm-libs
-  VERSION 11.0.1
+  VERSION 11.0.2
   LANGUAGES C)
 
 if (POLICY CMP0005)


### PR DESCRIPTION
This cleans up and updates the Changelog and CMake files for the coming 11.0.2 release.

**Checklist**:

- Tests N/A
- [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry N/A
