### PR TITLE
Prepare 11.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [11.0.2] (2020-05-12)
+## [11.0.1] (2020-05-12)
 
 ### Added
 - Add option to set finished hosts in OSP targets [#298](https://github.com/greenbone/gvm-libs/pull/298)
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix escaping entity attributes in print_entity_to_string [#318](https://github.com/greenbone/gvm-libs/pull/318)
 - Fix is_cidr_block() [#323][https://github.com/greenbone/gvm-libs/pull/323]
 
-[11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.1...v11.0.2
+[11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.0...v11.0.1
 
 ## [11.0.0] (2019-10-11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.0)
 message ("-- Configuring the Greenbone Vulnerability Management Libraries...")
 
 project (gvm-libs
-  VERSION 11.0.2
+  VERSION 11.0.1
   LANGUAGES C)
 
 if (POLICY CMP0005)


### PR DESCRIPTION
This changes the version number to 11.0.1

**Checklist**:
- Tests N/A
- [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry N/A
