### PR TITLE
Get interface used for routing to given destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add gmp_start_task_ext_c. [#327](https://github.com/greenbone/gvm-libs/pull/327)
 - Make log mutex visible. [#328](https://github.com/greenbone/gvm-libs/pull/328)
 - Add new scan status PENDING. [#336](https://github.com/greenbone/gvm-libs/pull/336)
+- Add gvm_routethrough which is used by Boreas alive detection module. [#339](https://github.com/greenbone/gvm-libs/pull/339)
 
 ### Fixed
 - Fix is_cidr_block(). [#322](https://github.com/greenbone/gvm-libs/pull/322)

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -87,8 +87,11 @@ if (BUILD_TESTS)
                   EXCLUDE_FROM_ALL
                   networking_tests.c)
   add_test (networking-test networking-test)
+  set (NETWORKING_TEST_LINKER_WRAP_OPTIONS
+      "-Wl,-wrap,g_io_channel_new_file,-wrap,g_io_channel_shutdown")
   target_include_directories (networking-test PRIVATE ${CGREEN_INCLUDE_DIRS} )
-  target_link_libraries (networking-test gvm_base_shared ${CGREEN_LIBRARIES} ${GLIB_LDFLAGS} ${LINKER_HARDENING_FLAGS})
+  target_link_libraries (networking-test gvm_base_shared ${CGREEN_LIBRARIES} ${GLIB_LDFLAGS} ${LINKER_HARDENING_FLAGS}
+                       ${NETWORKING_TEST_LINKER_WRAP_OPTIONS})
 
   add_executable (version-test
                   EXCLUDE_FROM_ALL

--- a/base/networking.c
+++ b/base/networking.c
@@ -954,7 +954,7 @@ get_routes (void)
   return proc_routes;
 }
 
-__attribute__ ((unused)) static gchar *
+gchar *
 gvm_routethrough (struct sockaddr_storage *storage_dest,
                   struct sockaddr_storage *storage_source)
 {

--- a/base/networking.c
+++ b/base/networking.c
@@ -848,13 +848,13 @@ ip_islocalhost (struct sockaddr_storage *storage)
   return FALSE;
 }
 
-
 struct proc_entry
 {
   gchar *interface;
   unsigned long mask;
   unsigned long dest;
 };
+
 static GSList *
 get_routes (void)
 {

--- a/base/networking.c
+++ b/base/networking.c
@@ -955,8 +955,8 @@ get_routes (void)
 }
 
 __attribute__ ((unused)) static gchar *
-my_routethrough (struct sockaddr_storage *storage_dest,
-                 struct sockaddr_storage *storage_source)
+gvm_routethrough (struct sockaddr_storage *storage_dest,
+                  struct sockaddr_storage *storage_source)
 {
   if (!storage_dest)
     return NULL;

--- a/base/networking.h
+++ b/base/networking.h
@@ -113,4 +113,8 @@ port_in_port_ranges (int, port_protocol_t, array_t *);
 int
 ipv6_is_enabled ();
 
+gchar *
+gvm_routethrough (struct sockaddr_storage *storage_dest,
+                  struct sockaddr_storage *storage_source);
+
 #endif /* not _GVM_NETWORKING_H */

--- a/base/networking.h
+++ b/base/networking.h
@@ -114,7 +114,6 @@ int
 ipv6_is_enabled ();
 
 gchar *
-gvm_routethrough (struct sockaddr_storage *storage_dest,
-                  struct sockaddr_storage *storage_source);
+gvm_routethrough (struct sockaddr_storage *, struct sockaddr_storage *);
 
 #endif /* not _GVM_NETWORKING_H */

--- a/base/networking_tests.c
+++ b/base/networking_tests.c
@@ -937,8 +937,6 @@ Ensure (networking, port_in_port_ranges)
 
 Ensure (networking, ip_islocalhost)
 {
-  cgreen_mocks_are (loose_mocks);
-
   /* IPv4 */
   struct in_addr addr;
   struct sockaddr_storage storage;
@@ -976,7 +974,7 @@ Ensure (networking, ip_islocalhost)
   /* IPv6 */
   struct in6_addr addr_6;
   struct sockaddr_in6 sin6;
-  memset (&sin, 0, sizeof (struct sockaddr_in6));
+  memset (&sin6, 0, sizeof (struct sockaddr_in6));
   sin6.sin6_family = AF_INET6;
 
   inet_pton (AF_INET6, "::FFFF:127.0.0.1", &(addr_6));

--- a/base/networking_tests.c
+++ b/base/networking_tests.c
@@ -961,7 +961,7 @@ Ensure (networking, ip_islocalhost)
   memcpy (&storage, &sin, sizeof (sin));
   assert_that (ip_islocalhost (&storage), is_true);
 
-  //!! local interface address
+  /* dependent on local environment */
   // inet_pton (AF_INET, <some local interface address>, &(addr.s_addr));
   // sin.sin_addr.s_addr = addr.s_addr;
   // memcpy (&storage, &sin, sizeof (sin));
@@ -1094,7 +1094,7 @@ Ensure (networking, get_routes)
     g_warning ("%s: Could not delete file \"./myfile\");", __func__);
 }
 
-Ensure (networking, my_routethrough_v4)
+Ensure (networking, gvm_routethrough_v4)
 {
   struct in_addr dst;
   struct sockaddr_storage storage_src;
@@ -1107,89 +1107,53 @@ Ensure (networking, my_routethrough_v4)
   memset (&sin_always_empty, 0, sizeof (struct sockaddr_in));
   sin_src.sin_family = AF_INET;
   sin_dst.sin_family = AF_INET;
-
-  /* TODO: finish attempt to mock file "/proc/net/route". */
-  // GIOChannel *file_channel;
-  // int status, ret;
-  // GError *err = NULL;
-  // /* Content for mocked file. */
-  // gchar *procnetroute_testfile =
-  //   "\nIface\tDestination\tGateway "
-  //   "\tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT " " "
-  //   "\nenp0s9\t00000000\t01B2A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0 " " "
-  //   "\nenp0s8\t0038A8C0\t00000000\t0001\t0\t0\t0\t00FFFFFF\t0\t0\t0 " " "
-  //   "\nenp0s9\t00B2A8C0\t00000000\t0001\t0\t0\t100\t00FFFFFF\t0\t0\t0 " "
-  //   \n";
-  // /* Create mock file. */
-  // file_channel =
-  //   g_io_channel_new_file ("./my_routethrough_v4_test", "w+", NULL);
-  // if (!file_channel)
-  //   g_warning ("Not my channel");
-  // g_io_channel_write_chars (file_channel, procnetroute_testfile, -1, NULL,
-  //                           NULL);
-  // g_io_channel_seek_position (file_channel, 0, G_SEEK_SET, NULL);
-  // /* Test get_routes with mocked "/proc/net/route". */
-  // g_g_io_channel_new_file_use_real = false;
-  // g_g_io_channel_shutdown_use_real = false;
-  // always_expect (__wrap_g_io_channel_new_file,
-  //                when (filename, is_equal_to_string ("/proc/net/route")),
-  //                will_return (file_channel));
-  // expect (__wrap_g_io_channel_shutdown, will_return
-  // (G_IO_STATUS_NORMAL),times(8));
+  gchar *interface = NULL;
 
   /* No destination address. */
-  assert_that (my_routethrough (NULL, &storage_src), is_null);
+  interface = gvm_routethrough (NULL, &storage_src);
+  assert_that (interface, is_null);
 
   /* Destination address localhost and no source address. */
   inet_pton (AF_INET, "127.0.0.1", &(dst.s_addr));
   sin_dst.sin_addr.s_addr = dst.s_addr;
   memcpy (&storage_dst, &sin_dst, sizeof (sin_dst));
-  assert_that (my_routethrough (&storage_dst, NULL), is_not_null);
-  // AA only working if on all environments if mocked
-  assert_that (my_routethrough (&storage_dst, NULL), is_equal_to_string ("lo"));
+  interface = gvm_routethrough (&storage_dst, NULL);
+  assert_that (interface, is_not_null);
+  /* Dependent on local environment. */
+  // assert_that (interface, is_equal_to_string ("lo"));
 
   /* Destination address not localhost and no source address. */
   inet_pton (AF_INET, "93.184.216.34", &(dst.s_addr)); // example.com
   sin_dst.sin_addr.s_addr = dst.s_addr;
   memcpy (&storage_dst, &sin_dst, sizeof (sin_dst));
-  assert_that (my_routethrough (&storage_dst, NULL), is_not_null);
+  interface = gvm_routethrough (&storage_dst, NULL);
+  assert_that (interface, is_not_null);
   /* Dependent on local environment. */
-  assert_that (my_routethrough (&storage_dst, NULL),
-               is_equal_to_string ("enp0s9"));
+  // assert_that (interface, is_equal_to_string ("enp0s9"));
 
   /* Destination address localhost and source address */
   inet_pton (AF_INET, "127.0.0.1", &(dst.s_addr));
   sin_dst.sin_addr.s_addr = dst.s_addr;
   memcpy (&storage_dst, &sin_dst, sizeof (sin_dst));
-  assert_that (my_routethrough (&storage_dst, &storage_src), is_not_null);
+  interface = gvm_routethrough (&storage_dst, &storage_src);
+  assert_that (interface, is_not_null);
   assert_that (((struct sockaddr_in *) (&storage_src))->sin_addr.s_addr
                == htonl (0x7F000001));
   /* Dependent on local environment. */
-  assert_that (my_routethrough (&storage_dst, NULL), is_equal_to_string ("lo"));
+  // assert_that (interface, is_equal_to_string ("lo"));
 
   /* Dst address not localhost and src address */
   inet_pton (AF_INET, "93.184.216.34", &(dst.s_addr));
   sin_dst.sin_addr.s_addr = dst.s_addr;
   memcpy (&storage_dst, &sin_dst, sizeof (sin_dst));
   memcpy (&storage_src, &sin_always_empty, sizeof (struct sockaddr_in));
-  assert_that (my_routethrough (&storage_dst, &storage_src), is_not_null);
+  interface = gvm_routethrough (&storage_dst, &storage_src);
+  assert_that (interface, is_not_null);
   assert_that (((struct sockaddr_in *) (&storage_src))->sin_addr.s_addr
                != htonl (0x7F000001));
-
-  assert_that (((struct sockaddr_in *) (&storage_src))->sin_addr.s_addr != 0);
   /* Dependent on local environment. */
-  assert_that (my_routethrough (&storage_dst, NULL),
-               is_equal_to_string ("enp0s9"));
-
-  // g_g_io_channel_new_file_use_real = true;
-  // g_g_io_channel_shutdown_use_real = true;
-  // /* Close channel and delete mock file. */
-  // status = g_io_channel_shutdown (file_channel, TRUE, &err);
-  // if ((G_IO_STATUS_NORMAL != status) || err)
-  //   g_warning ("%s: Could not shutdown channel.", __func__);
-  // ret = unlink ("./myfile");
-  // if (0 != ret)
-  //   g_warning ("%s: Could not delete file \"./myfile\");", __func__);
+  // assert_that (((struct sockaddr_in *) (&storage_src))->sin_addr.s_addr !=
+  // 0); assert_that (interface, is_equal_to_string ("enp0s9"));
 }
 
 TestSuite *
@@ -1198,7 +1162,7 @@ gvm_routethough ()
   TestSuite *suite = create_test_suite ();
   add_test_with_context (suite, networking, ip_islocalhost);
   add_test_with_context (suite, networking, get_routes);
-  add_test_with_context (suite, networking, my_routethrough_v4);
+  add_test_with_context (suite, networking, gvm_routethrough_v4);
 
   return suite;
 }


### PR DESCRIPTION
Add implementation for getting the interface which is used for routing to a given destination. If provided a source address is set to the address of the interface to use.

- [X] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
