### PR TITLE
Fix S/MIME keylist and improve error handling (11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [11.0.2] (unreleased)
+
+### Fixed
+- Fix S/MIME keylist and improve error handling [#343](https://github.com/greenbone/gvm-libs/pull/343)
+
+[11.0.1]: https://github.com/greenbone/gvm-libs/compare/v11.0.1...gvm-libs-11.0
+
 ## [11.0.1] (2020-05-12)
 
 ### Added


### PR DESCRIPTION
This fixes an issue where iterating over the key list could get stuck
in a loop and after fetching the key for the email address.
Also, more GPGME calls are now checked for errors.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
