### PR TITLE
Fix S/MIME keylist and improve error handling (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix is_cidr_block(). [#322](https://github.com/greenbone/gvm-libs/pull/322)
 - Fix is_cidr6_block() and is_short_range_network(). [#337](https://github.com/greenbone/gvm-libs/pull/337)
+- Fix S/MIME keylist and improve error handling [#345](https://github.com/greenbone/gvm-libs/pull/345)
 
 [20.8]: https://github.com/greenbone/gvm-libs/compare/gvm-libs-11.0...master
 


### PR DESCRIPTION
This fixes an issue where iterating over the key list could get stuck
in a loop and after fetching the key for the email address.
Also, more GPGME calls are now checked for errors.

**Checklist**:
- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
