### PR TITLE
Remove parallel from target options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix is_cidr6_block() and is_short_range_network(). [#337](https://github.com/greenbone/gvm-libs/pull/337)
 - Fix S/MIME keylist and improve error handling [#345](https://github.com/greenbone/gvm-libs/pull/345)
 
+### Removed
+- Remove parallel from target options [#347](https://github.com/greenbone/gvm-libs/pull/347)
+
 [20.8]: https://github.com/greenbone/gvm-libs/compare/gvm-libs-11.0...master
 
 ## [11.0.1] (unreleased)

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -965,8 +965,6 @@ osp_start_scan_ext (osp_connection_t *connection, osp_start_scan_opts_t opts,
 
   xml = g_string_sized_new (10240);
   g_string_append (xml, "<start_scan");
-  if (opts.parallel)
-    xml_string_append (xml, " parallel=\"%d\"", opts.parallel);
   xml_string_append (xml, " scan_id=\"%s\">", opts.scan_id ? opts.scan_id : "");
 
   g_string_append (xml, "<targets>");

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -121,7 +121,6 @@ typedef struct
   GSList *vt_groups;          ///< VT groups to use for the scan.
   GSList *vts;                ///< Single VTs to use for the scan.
   GHashTable *scanner_params; ///< Table of scanner parameters.
-  int parallel;               ///< Number of parallel scans.
   const char *scan_id;        ///< UUID to set for scan, null otherwise.
 } osp_start_scan_opts_t;
 


### PR DESCRIPTION
Because the parallel option for multitarget task is deprecated in OSP