### PR TITLE
Modify osp_get_vts_version()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Improve validation in is_hostname [#353](https://github.com/greenbone/gvm-libs/pull/353)
+- Use get_vts instead of get_version to get the feed version is osp_get_vts_version(). [#357](https://github.com/greenbone/gvm-libs/pull/357)
 
 ### Fixed
 - Fix is_cidr_block(). [#322](https://github.com/greenbone/gvm-libs/pull/322)

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -335,15 +335,30 @@ err_get_version:
  * @return 0 if success, 1 if error.
  */
 int
-osp_get_vts_version (osp_connection_t *connection, char **vts_version)
+osp_get_vts_version (osp_connection_t *connection, char **vts_version,
+                     char **error)
 {
-  entity_t entity, vts, version;
+  entity_t entity, vts;
+  const char *version;
+  const char *status, *status_text;
 
   if (!connection)
     return 1;
 
-  if (osp_send_command (connection, &entity, "<get_version/>"))
+  if (osp_send_command (connection, &entity, "<get_vts version_only='1'/>"))
     return 1;
+
+  status = entity_attribute (entity, "status");
+
+  if (status != NULL && !strcmp (status, "400"))
+    {
+      status_text = entity_attribute (entity, "status_text");
+      g_debug ("%s: %s - %s.", __func__, status, status_text);
+      if (error)
+        *error = g_strdup (status_text);
+      free_entity (entity);
+      return 1;
+    }
 
   vts = entity_child (entity, "vts");
   if (!vts)
@@ -353,16 +368,10 @@ osp_get_vts_version (osp_connection_t *connection, char **vts_version)
       return 1;
     }
 
-  version = entity_child (vts, "version");
-  if (!version)
-    {
-      g_warning ("%s: element VERSION missing.", __func__);
-      free_entity (entity);
-      return 1;
-    }
+  version = entity_attribute (vts, "vts_version");
 
   if (vts_version)
-    *vts_version = g_strdup (entity_text (version));
+    *vts_version = g_strdup (version);
 
   free_entity (entity);
   return 0;
@@ -409,6 +418,13 @@ osp_get_vts_ext (osp_connection_t *connection, osp_get_vts_opts_t opts,
 
   if (vts == NULL)
     return 1;
+
+  if (opts.version_only == 1)
+    {
+      if (osp_send_command (connection, vts, "<get_vts version_only='1'/>"))
+        return 1;
+      return 0;
+    }
 
   if (opts.filter)
     {

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -331,6 +331,7 @@ err_get_version:
  *
  * @param[in]   connection    Connection to an OSP server.
  * @param[out]  vts_version   Parsed scanner version.
+ * @param[out]  error         Pointer to error, if any.
  *
  * @return 0 if success, 1 if error.
  */
@@ -341,11 +342,14 @@ osp_get_vts_version (osp_connection_t *connection, char **vts_version,
   entity_t entity, vts;
   const char *version;
   const char *status, *status_text;
+  osp_get_vts_opts_t get_vts_opts;
 
   if (!connection)
     return 1;
 
-  if (osp_send_command (connection, &entity, "<get_vts version_only='1'/>"))
+  get_vts_opts.filter = NULL;
+  get_vts_opts.version_only = 1;
+  if (osp_get_vts_ext (connection, get_vts_opts, &entity))
     return 1;
 
   status = entity_attribute (entity, "status");

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -99,14 +99,15 @@ osp_get_version (osp_connection_t *, char **, char **, char **, char **,
                  char **, char **);
 
 int
-osp_get_vts_version (osp_connection_t *, char **);
+osp_get_vts_version (osp_connection_t *, char **, char **error);
 
 int
 osp_get_vts (osp_connection_t *, entity_t *);
 
 typedef struct
 {
-  char *filter; ///< the filter to apply for a vt sub-selection.
+  char *filter;     ///< the filter to apply for a vt sub-selection.
+  int version_only; ///< if get only feed info or the vt collection
 } osp_get_vts_opts_t;
 
 int


### PR DESCRIPTION
As get_vts OSP command was extended with a new attribute version_only,
the function use get_vts with this attribute instead of the get_version command,
because now all wrappers have a vts collection and therefore, not always
get_version response has a vts entity.