### PR TITLE
Ping host only once if alive

### DIFF
--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -97,9 +97,11 @@ scan (alive_test_t alive_test)
       scanner.tcp_flag = TH_ACK;
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_tcp,
                             &scanner);
+      usleep (500000);
       g_debug ("%s: ICMP Ping", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_icmp,
                             &scanner);
+      usleep (500000);
       g_debug ("%s: ARP Ping", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_arp,
                             &scanner);
@@ -111,6 +113,7 @@ scan (alive_test_t alive_test)
       scanner.tcp_flag = TH_ACK;
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_tcp,
                             &scanner);
+      usleep (500000);
       g_debug ("%s: ARP Ping", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_arp,
                             &scanner);
@@ -121,6 +124,7 @@ scan (alive_test_t alive_test)
       g_debug ("%s: ICMP PING", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_icmp,
                             &scanner);
+      usleep (500000);
       g_debug ("%s: ARP Ping", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_arp,
                             &scanner);
@@ -131,6 +135,7 @@ scan (alive_test_t alive_test)
       g_debug ("%s: ICMP PING", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_icmp,
                             &scanner);
+      usleep (500000);
       g_debug ("%s: TCP-ACK Service Ping", __func__);
       scanner.tcp_flag = TH_ACK;
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_tcp,

--- a/boreas/ping.c
+++ b/boreas/ping.c
@@ -166,8 +166,7 @@ send_icmp_v4 (int soc, struct in_addr *dst)
  * @param scanner_p Pointer to scanner struct.
  */
 void
-send_icmp (__attribute__ ((unused)) gpointer key, gpointer value,
-           gpointer scanner_p)
+send_icmp (gpointer key, gpointer value, gpointer scanner_p)
 {
   struct scanner *scanner;
   struct in6_addr dst6;
@@ -177,6 +176,9 @@ send_icmp (__attribute__ ((unused)) gpointer key, gpointer value,
   static int count = 0;
 
   scanner = (struct scanner *) scanner_p;
+
+  if (g_hash_table_contains (scanner->hosts_data->alivehosts, key))
+    return;
 
   count++;
   if (count % BURST == 0)
@@ -398,8 +400,7 @@ send_tcp_v4 (struct scanner *scanner, struct in_addr *dst_p)
  * @param scanner_p Pointer to scanner struct.
  */
 void
-send_tcp (__attribute__ ((unused)) gpointer key, gpointer value,
-          gpointer scanner_p)
+send_tcp (gpointer key, gpointer value, gpointer scanner_p)
 {
   struct scanner *scanner;
   struct in6_addr dst6;
@@ -409,6 +410,9 @@ send_tcp (__attribute__ ((unused)) gpointer key, gpointer value,
   static int count = 0;
 
   scanner = (struct scanner *) scanner_p;
+
+  if (g_hash_table_contains (scanner->hosts_data->alivehosts, key))
+    return;
 
   count++;
   if (count % BURST == 0)
@@ -555,8 +559,7 @@ send_arp_v4 (int soc, struct in_addr *dst_p)
  * @param scanner_p Pointer to scanner struct.
  */
 void
-send_arp (__attribute__ ((unused)) gpointer key, gpointer value,
-          gpointer scanner_p)
+send_arp (gpointer key, gpointer value, gpointer scanner_p)
 {
   struct scanner *scanner;
   struct in6_addr dst6;
@@ -566,6 +569,9 @@ send_arp (__attribute__ ((unused)) gpointer key, gpointer value,
   static int count = 0;
 
   scanner = (struct scanner *) scanner_p;
+
+  if (g_hash_table_contains (scanner->hosts_data->alivehosts, key))
+    return;
 
   count++;
   if (count % BURST == 0)


### PR DESCRIPTION
Only ping a host once if it is alive.
Hosts may still be pinged twice If the list of target hosts is short and the pinged host takes longer than the specified timeout to reply.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
