### PR TITLE
Send the correct num of dead hosts to ospd-openvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix is_cidr_block(). [#322](https://github.com/greenbone/gvm-libs/pull/322)
 - Fix is_cidr6_block() and is_short_range_network(). [#337](https://github.com/greenbone/gvm-libs/pull/337)
 - Fix S/MIME keylist and improve error handling [#345](https://github.com/greenbone/gvm-libs/pull/345)
+- Fix interrupted state by sending correct number of dead hosts. [#371](https://github.com/greenbone/gvm-libs/pull/371)
 
 ### Removed
 - Remove parallel from target options [#347](https://github.com/greenbone/gvm-libs/pull/347)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move alive detection module Boreas into gvm-libs. [#346](https://github.com/greenbone/gvm-libs/pull/346)
 - Add new scan status INTERRUPTED. [#356](https://github.com/greenbone/gvm-libs/pull/356)
 - Add sensible default values for osp_get_vts_opts_t. [#360](https://github.com/greenbone/gvm-libs/pull/360)
+- Add cli support for boreas standalone tool. [#359](https://github.com/greenbone/gvm-libs/pull/359)
 
 ### Changed
 - Improve validation in is_hostname [#353](https://github.com/greenbone/gvm-libs/pull/353)
 - Use get_vts instead of get_version to get the feed version is osp_get_vts_version(). [#357](https://github.com/greenbone/gvm-libs/pull/357)
+- Allow all alive test combination for boreas. [#370](https://github.com/greenbone/gvm-libs/pull/370)
 
 ### Fixed
 - Fix is_cidr_block(). [#322](https://github.com/greenbone/gvm-libs/pull/322)

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -137,9 +137,20 @@ scan (alive_test_t alive_test)
 
   stop_sniffer_thread (&scanner, sniffer_thread_id);
 
-  /* Send info about dead hosts to ospd-openvas. This is needed for the
-   * calculation of the progress bar for gsa. */
-  number_of_dead_hosts = send_dead_hosts_to_ospd_openvas (scanner.hosts_data);
+  number_of_dead_hosts = count_difference (scanner.hosts_data->targethosts,
+                                           scanner.hosts_data->alivehosts);
+
+  /* Send number of dead hosts to ospd-openvas. We need to consider the scan
+   * restrictions.*/
+  if (scanner.scan_restrictions->max_scan_hosts_reached)
+    {
+      send_dead_hosts_to_ospd_openvas (
+        number_of_targets - scanner.scan_restrictions->max_scan_hosts);
+    }
+  else
+    {
+      send_dead_hosts_to_ospd_openvas (number_of_dead_hosts);
+    }
 
   gettimeofday (&end_time, NULL);
 

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -340,19 +340,19 @@ handle_scan_restrictions (struct scanner *scanner, gchar *addr_str)
  * @brief Send the number of dead hosts to ospd-openvas.
  *
  * This information is needed for the calculation of the progress bar for gsa in
- * ospd-openvas.
+ * ospd-openvas. The number of dead hosts sent to ospd-openvas may not
+ * necessarily reflect the acutal number of dead hosts in the target list.
  *
  * @param hosts_data  Includes all data which is needed for calculating the
  * number of dead hosts.
  *
  * @return number of dead hosts, or -1 in case of an error.
  */
-int
-send_dead_hosts_to_ospd_openvas (struct hosts_data *hosts_data)
+void
+send_dead_hosts_to_ospd_openvas (int count_dead_hosts)
 {
   kb_t main_kb;
   int maindbid;
-  int count_dead_hosts;
   char dead_host_msg_to_ospd_openvas[2048];
 
   maindbid = atoi (prefs_get ("ov_maindbid"));
@@ -363,12 +363,7 @@ send_dead_hosts_to_ospd_openvas (struct hosts_data *hosts_data)
       g_debug ("%s: Could not connect to main_kb for sending dead hosts to "
                "ospd-openvas.",
                __func__);
-      return -1;
     }
-
-  /* Number of targethosts - alivehosts. */
-  count_dead_hosts =
-    count_difference (hosts_data->targethosts, hosts_data->alivehosts);
 
   snprintf (dead_host_msg_to_ospd_openvas,
             sizeof (dead_host_msg_to_ospd_openvas), "DEADHOST||| ||| ||| |||%d",
@@ -376,8 +371,6 @@ send_dead_hosts_to_ospd_openvas (struct hosts_data *hosts_data)
   kb_item_push_str (main_kb, "internal/results", dead_host_msg_to_ospd_openvas);
 
   kb_lnk_reset (main_kb);
-
-  return count_dead_hosts;
 }
 
 /**

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -31,8 +31,8 @@ get_host_from_queue (kb_t, gboolean *);
 void
 put_finish_signal_on_queue (void *);
 
-int
-send_dead_hosts_to_ospd_openvas (struct hosts_data *);
+void
+send_dead_hosts_to_ospd_openvas (int);
 
 void
 init_scan_restrictions (struct scanner *, int);

--- a/boreas/cli.c
+++ b/boreas/cli.c
@@ -110,7 +110,7 @@ run_cli_scan (struct scanner *scanner, alive_test_t alive_test)
   gettimeofday (&start_time, NULL);
   number_of_targets = g_hash_table_size (scanner->hosts_data->targethosts);
 
-  printf ("Alive scan started: Target has %d hosts\n", number_of_targets);
+  printf ("Alive scan started: Target has %d hosts.\n", number_of_targets);
 
   error = start_sniffer_thread (scanner, &sniffer_thread_id);
   if (error)


### PR DESCRIPTION
When we reach the max_scan_hosts limit we do not need send the true number of dead hosts.
The number needed by ospd-opevas for calculating the correct progress bar and not ending a scan in the interrupted state is calculated by subtracting the number of max_scan_hosts and alive hosts from the number of target hosts.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
