### PR TITLE
Smooth progress

### DIFF
--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -72,6 +72,7 @@ scan (alive_test_t alive_test)
   int number_of_targets;
   int number_of_dead_hosts;
   int pings_sent;
+  gboolean pings_sent_min_once;
   pthread_t sniffer_thread_id;
   GHashTableIter target_hosts_iter;
   gpointer key, value;
@@ -81,6 +82,7 @@ scan (alive_test_t alive_test)
 
   gettimeofday (&start_time, NULL);
   number_of_targets = g_hash_table_size (scanner.hosts_data->targethosts);
+  pings_sent_min_once = FALSE;
 
   scandb_id = atoi (prefs_get ("ov_maindbid"));
   scan_id = get_openvas_scan_id (prefs_get ("db_address"), scandb_id);
@@ -102,9 +104,10 @@ scan (alive_test_t alive_test)
           send_icmp (key, value, &scanner);
           pings_sent++;
           if ((pings_sent % 1000) == 0)
-            send_dead_hosts_to_ospd_openvas (
-              get_considered_dead (&scanner, pings_sent));
+            send_dead_hosts_to_ospd_openvas (get_considered_dead (
+              &scanner, pings_sent_min_once ? number_of_targets : pings_sent));
         }
+      pings_sent_min_once = TRUE;
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
@@ -119,9 +122,10 @@ scan (alive_test_t alive_test)
           send_tcp (key, value, &scanner);
           pings_sent++;
           if ((pings_sent % 1000) == 0)
-            send_dead_hosts_to_ospd_openvas (
-              get_considered_dead (&scanner, pings_sent));
+            send_dead_hosts_to_ospd_openvas (get_considered_dead (
+              &scanner, pings_sent_min_once ? number_of_targets : pings_sent));
         }
+      pings_sent_min_once = TRUE;
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_TCP_ACK_SERVICE)
@@ -136,9 +140,10 @@ scan (alive_test_t alive_test)
           send_tcp (key, value, &scanner);
           pings_sent++;
           if ((pings_sent % 1000) == 0)
-            send_dead_hosts_to_ospd_openvas (
-              get_considered_dead (&scanner, pings_sent));
+            send_dead_hosts_to_ospd_openvas (get_considered_dead (
+              &scanner, pings_sent_min_once ? number_of_targets : pings_sent));
         }
+      pings_sent_min_once = TRUE;
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_ARP)
@@ -152,8 +157,8 @@ scan (alive_test_t alive_test)
           send_arp (key, value, &scanner);
           pings_sent++;
           if ((pings_sent % 1000) == 0)
-            send_dead_hosts_to_ospd_openvas (
-              get_considered_dead (&scanner, pings_sent));
+            send_dead_hosts_to_ospd_openvas (get_considered_dead (
+              &scanner, pings_sent_min_once ? number_of_targets : pings_sent));
         }
     }
   if (alive_test & ALIVE_TEST_CONSIDER_ALIVE)

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -71,6 +71,7 @@ scan (alive_test_t alive_test)
 {
   int number_of_targets;
   int number_of_dead_hosts;
+  int pings_sent;
   pthread_t sniffer_thread_id;
   GHashTableIter target_hosts_iter;
   gpointer key, value;
@@ -92,31 +93,68 @@ scan (alive_test_t alive_test)
   if (alive_test & ALIVE_TEST_ICMP)
     {
       g_debug ("%s: ICMP Ping", __func__);
-      g_hash_table_foreach (scanner.hosts_data->targethosts, send_icmp,
-                            &scanner);
+
+      g_hash_table_iter_init (&target_hosts_iter,
+                              scanner.hosts_data->targethosts);
+      for (pings_sent = 0;
+           g_hash_table_iter_next (&target_hosts_iter, &key, &value);)
+        {
+          send_icmp (key, value, &scanner);
+          pings_sent++;
+          if ((pings_sent % 1000) == 0)
+            send_dead_hosts_to_ospd_openvas (
+              get_considered_dead (&scanner, pings_sent));
+        }
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
     {
       g_debug ("%s: TCP-SYN Service Ping", __func__);
       scanner.tcp_flag = TH_SYN; /* SYN */
-      g_hash_table_foreach (scanner.hosts_data->targethosts, send_tcp,
-                            &scanner);
+      g_hash_table_iter_init (&target_hosts_iter,
+                              scanner.hosts_data->targethosts);
+      for (pings_sent = 0;
+           g_hash_table_iter_next (&target_hosts_iter, &key, &value);)
+        {
+          send_tcp (key, value, &scanner);
+          pings_sent++;
+          if ((pings_sent % 1000) == 0)
+            send_dead_hosts_to_ospd_openvas (
+              get_considered_dead (&scanner, pings_sent));
+        }
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_TCP_ACK_SERVICE)
     {
       g_debug ("%s: TCP-ACK Service Ping", __func__);
       scanner.tcp_flag = TH_ACK; /* ACK */
-      g_hash_table_foreach (scanner.hosts_data->targethosts, send_tcp,
-                            &scanner);
+      g_hash_table_iter_init (&target_hosts_iter,
+                              scanner.hosts_data->targethosts);
+      for (pings_sent = 0;
+           g_hash_table_iter_next (&target_hosts_iter, &key, &value);)
+        {
+          send_tcp (key, value, &scanner);
+          pings_sent++;
+          if ((pings_sent % 1000) == 0)
+            send_dead_hosts_to_ospd_openvas (
+              get_considered_dead (&scanner, pings_sent));
+        }
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_ARP)
     {
       g_debug ("%s: ARP Ping", __func__);
-      g_hash_table_foreach (scanner.hosts_data->targethosts, send_arp,
-                            &scanner);
+      g_hash_table_iter_init (&target_hosts_iter,
+                              scanner.hosts_data->targethosts);
+      for (pings_sent = 0;
+           g_hash_table_iter_next (&target_hosts_iter, &key, &value);)
+        {
+          send_arp (key, value, &scanner);
+          pings_sent++;
+          if ((pings_sent % 1000) == 0)
+            send_dead_hosts_to_ospd_openvas (
+              get_considered_dead (&scanner, pings_sent));
+        }
     }
   if (alive_test & ALIVE_TEST_CONSIDER_ALIVE)
     {

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -607,3 +607,37 @@ count_difference (GHashTable *hashtable_A, GHashTable *hashtable_B)
 
   return count;
 }
+
+/**
+ * @brief Get the current amount of hosts which are considered to be dead
+ *
+ * This function only gets the currently approximated number of dead hosts
+ * in the number of pinged hosts. Scan restrictions are considered as well.
+ *
+ * @param scanner The scanner struct which holds all necessary data.
+ * @param ping_sent Number of pings already sent out.
+ *
+ * @return Approximate number of dead hosts in list of already pinged hosts.
+ */
+int
+get_considered_dead (struct scanner *scanner, int pings_sent)
+{
+  int number_of_dead_hosts;
+  int alive_hosts;
+  int hosts_considered_dead;
+  int number_of_targets;
+
+  number_of_targets = g_hash_table_size (scanner->hosts_data->targethosts);
+  number_of_dead_hosts = count_difference (scanner->hosts_data->targethosts,
+                                           scanner->hosts_data->alivehosts);
+
+  alive_hosts = number_of_targets - number_of_dead_hosts;
+  hosts_considered_dead = pings_sent - alive_hosts;
+
+  /* We need to consider the scan restrictions.*/
+  if (scanner->scan_restrictions->max_scan_hosts_reached)
+    hosts_considered_dead =
+      pings_sent - scanner->scan_restrictions->max_scan_hosts;
+
+  return hosts_considered_dead;
+}

--- a/boreas/util.h
+++ b/boreas/util.h
@@ -50,4 +50,7 @@ close_all_needed_sockets (struct scanner *, alive_test_t);
 int
 count_difference (GHashTable *, GHashTable *);
 
+int
+get_considered_dead (struct scanner *, int);
+
 #endif /* not BOREAS_UTIL_H */


### PR DESCRIPTION
Allow smooth progress bar.
Every 1000 pings the approximate number of dead hosts is sent to ospd.

Eventual unexpected behavior:
Number of dead hosts may get smaller again after some time if e.g. the second method of alive detection detects more alive hosts than the first one.

Depends on:
* https://github.com/greenbone/ospd/pull/298
* https://github.com/greenbone/ospd-openvas/pull/283

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
