### PR TITLE
Smooth progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)
+- Alternate between different methods of alive detection when sending pings and add support for smooth progress bar. [#380](https://github.com/greenbone/gvm-libs/pull/380)
 
 [unreleased]: https://github.com/greenbone/gvm-libs/compare/gvm-libs-20.08...master
 

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -366,8 +366,8 @@ send_dead_hosts_to_ospd_openvas (int count_dead_hosts)
     }
 
   snprintf (dead_host_msg_to_ospd_openvas,
-            sizeof (dead_host_msg_to_ospd_openvas), "DEADHOST||| ||| ||| ||| |||%d",
-            count_dead_hosts);
+            sizeof (dead_host_msg_to_ospd_openvas),
+            "DEADHOST||| ||| ||| ||| |||%d", count_dead_hosts);
   kb_item_push_str (main_kb, "internal/results", dead_host_msg_to_ospd_openvas);
 
   kb_lnk_reset (main_kb);

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -607,3 +607,37 @@ count_difference (GHashTable *hashtable_A, GHashTable *hashtable_B)
 
   return count;
 }
+
+/**
+ * @brief Get the current amount of hosts which are considered to be dead
+ *
+ * This function only gets the currently approximated number of dead hosts
+ * in the number of pinged hosts. Scan restrictions are considered as well.
+ *
+ * @param scanner The scanner struct which holds all necessary data.
+ * @param ping_sent Number of pings already sent out.
+ *
+ * @return Approximate number of dead hosts in list of already pinged hosts.
+ */
+int
+get_considered_dead (struct scanner *scanner, int pings_sent)
+{
+  int number_of_dead_hosts;
+  int alive_hosts;
+  int hosts_considered_dead;
+  int number_of_targets;
+
+  number_of_targets = g_hash_table_size (scanner->hosts_data->targethosts);
+  number_of_dead_hosts = count_difference (scanner->hosts_data->targethosts,
+                                           scanner->hosts_data->alivehosts);
+
+  alive_hosts = number_of_targets - number_of_dead_hosts;
+  hosts_considered_dead = pings_sent - alive_hosts;
+
+  /* We need to consider the scan restrictions.*/
+  if (scanner->scan_restrictions->max_scan_hosts_reached)
+    hosts_considered_dead =
+      pings_sent - scanner->scan_restrictions->max_scan_hosts;
+
+  return hosts_considered_dead;
+}

--- a/boreas/util.h
+++ b/boreas/util.h
@@ -50,4 +50,7 @@ close_all_needed_sockets (struct scanner *, alive_test_t);
 int
 count_difference (GHashTable *, GHashTable *);
 
+int
+get_considered_dead (struct scanner *, int);
+
 #endif /* not BOREAS_UTIL_H */

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -413,12 +413,11 @@ gvm_gpgme_fwrite (void *handle, const void *buffer, size_t size)
   return ret;
 }
 
-#define CHECK_ERR(func) \
-  if (err)                                            \
-    {                                                 \
-      printf ("%s: %s failed: %s\n",                  \
-              __func__, func, gpgme_strerror (err));  \
-      return -1;                                      \
+#define CHECK_ERR(func)                                                     \
+  if (err)                                                                  \
+    {                                                                       \
+      printf ("%s: %s failed: %s\n", __func__, func, gpgme_strerror (err)); \
+      return -1;                                                            \
     }
 
 /**
@@ -482,19 +481,18 @@ create_all_certificates_trustlist (gpgme_ctx_t ctx, const char *homedir)
 }
 
 #undef CHECK_ERR
-#define CHECK_ERR(func) \
-  if (err)                                            \
-    {                                                 \
-      printf ("%s: %s failed: %s\n",                  \
-              __func__, func, gpgme_strerror (err));  \
-      if (plain_data)                                 \
-        gpgme_data_release (plain_data);              \
-      if (encrypted_data)                             \
-        gpgme_data_release (encrypted_data);          \
-      if (ctx)                                        \
-        gpgme_release (ctx);                          \
-      gvm_file_remove_recurse (gpg_temp_dir);         \
-      return -1;                                      \
+#define CHECK_ERR(func)                                                     \
+  if (err)                                                                  \
+    {                                                                       \
+      printf ("%s: %s failed: %s\n", __func__, func, gpgme_strerror (err)); \
+      if (plain_data)                                                       \
+        gpgme_data_release (plain_data);                                    \
+      if (encrypted_data)                                                   \
+        gpgme_data_release (encrypted_data);                                \
+      if (ctx)                                                              \
+        gpgme_release (ctx);                                                \
+      gvm_file_remove_recurse (gpg_temp_dir);                               \
+      return -1;                                                            \
     }
 
 /**


### PR DESCRIPTION
Alternate between methods of alive detection when sending pings.
This way we can achieve a a smooth progress bar for ospd-openvas without the problem of needing to correct the progress in the wrong direction if a later alive test methods detected more results than a previous one.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
