### PR TITLE
Separate duplicated hosts from removed hosts in the hosts structure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20.8.1] (unreleased)
+
+### Added
+- Add function to get duplicated hosts from the hosts list. [#387](https://github.com/greenbone/gvm-libs/pull/387)
+
+[20.8.1]: https://github.com/greenbone/gvm-libs/compare/v20.8.0...gvm-libs-20.08
+
 ## [20.8.0] (2020-08-12)
 
 ### Added

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1066,7 +1066,7 @@ gvm_hosts_deduplicate (gvm_hosts_t *hosts)
     gvm_hosts_fill_gaps (hosts);
   g_hash_table_destroy (name_table);
   hosts->count -= duplicates;
-  hosts->removed += duplicates;
+  hosts->duplicated += duplicates;
   hosts->current = 0;
   malloc_trim (0);
 }
@@ -1882,6 +1882,20 @@ unsigned int
 gvm_hosts_removed (const gvm_hosts_t *hosts)
 {
   return hosts ? hosts->removed : 0;
+}
+
+/**
+ * @brief Gets the count of single values in hosts string that were duplicated
+ * and therefore removed from the list
+ *
+ * @param[in] hosts The hosts collection.
+ *
+ * @return The number of duplicated values.
+ */
+unsigned int
+gvm_hosts_duplicated (const gvm_hosts_t *hosts)
+{
+  return hosts ? hosts->duplicated : 0;
 }
 
 /**

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -95,6 +95,7 @@ struct gvm_hosts
   size_t current;     /**< Current host index in iteration. */
   size_t count;       /**< Number of single host objects in hosts list. */
   size_t removed;     /**< Number of duplicate/excluded values. */
+  size_t duplicated;  /**< Number of duplicated values. */
 };
 
 /* Function prototypes. */
@@ -148,6 +149,9 @@ gvm_hosts_count (const gvm_hosts_t *);
 
 unsigned int
 gvm_hosts_removed (const gvm_hosts_t *);
+
+unsigned int
+gvm_hosts_duplicated (const gvm_hosts_t *);
 
 /* gvm_host_t related */
 


### PR DESCRIPTION
Also add a function to access this variable directly.
