### PR TITLE
Smooth progress icmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)
+- Continuously send dead hosts to ospd-openvas to enable a smooth progess bar if only ICMP is chosen as alive test.  [#389](https://github.com/greenbone/gvm-libs/pull/389)
 
 ### Removed
 - Remove version from the nvticache name. [#386](https://github.com/greenbone/gvm-libs/pull/386)

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -91,39 +91,66 @@ scan (alive_test_t alive_test)
   sniffer_thread_id = 0;
   start_sniffer_thread (&scanner, &sniffer_thread_id);
 
-  /* Use smooth progress bar if only ICMP was chosen. */
+  /* Continuously send dead hosts to ospd if only ICMP was chosen instead of
+   * sending all at once at the end. This is done for displaying a progressbar
+   * that increases gradually. */
   if (alive_test == ALIVE_TEST_ICMP)
     {
       g_hash_table_iter_init (&target_hosts_iter,
                               scanner.hosts_data->targethosts);
       int batch = 1000;
-      int packets_send = 0;
+      gboolean limit_reached_handled = FALSE; /* Scan restrictions related. */
       int curr_alive = 0;
-      gboolean last_update_done = 0; /* Scan restrictions related. */
-      /* Number of hosts to check in last batch of packets. */
-      remaining_batch = number_of_targets;
       prev_alive = 0;
-      for (; g_hash_table_iter_next (&target_hosts_iter, &key, &value);)
+      /* Number of hosts in last batch. Depending on the total number of hosts
+       * the last batch size maybe be double the normal size. Info about the
+       * last batch is send after all hosts were checked and we waited for last
+       * packets to arrive.*/
+      remaining_batch = number_of_targets;
+      for (int packets_send = 0;
+           g_hash_table_iter_next (&target_hosts_iter, &key, &value);)
         {
           send_icmp (key, value, &scanner);
           packets_send++;
+          /* Send dead hosts update after batch number of packets were send and
+           * we still have more than batch size packets remaining. */
           if (packets_send % batch == 0
               && (number_of_targets - packets_send) > batch)
             {
+              /* The number of dead hosts we have to send to ospd is the batch
+               * size minus the newly found alive hosts. The newly found alive
+               * hosts is the diff between the current total of alive hosts and
+               * the total of the last batch. */
               curr_alive = g_hash_table_size (scanner.hosts_data->alivehosts);
               number_of_dead_hosts = batch - (curr_alive - prev_alive);
 
-              /* Handle scan restrictions and send dead hosts. */
+              /* If the max_scan_hosts limit was reached we can not tell ospd
+               * the true number of dead hosts. The number of alive hosts which
+               * are above the max_scan_hosts limit are not to be substracted
+               * form the dead hosts to send. They are considered as dead hosts
+               * for the progress bar.*/
               if (scanner.scan_restrictions->max_scan_hosts_reached)
                 {
-                  if (!last_update_done)
+                  /* Handle the case where we reach the max_scan_hosts for the
+                   * first time. We may have to considere some of the new alive
+                   * hosts as dead because of the restriction. E.g
+                   * curr_alive=110 prev_alive=90 max_scan_hosts=100 batch=100.
+                   * Normally we would send 80 as dead in this batch (20 new
+                   * alive hosts) but because of the restriction we send 90 as
+                   * dead. The 10 hosts which are over the limit are considered
+                   * as dead.
+                   * After this limit case was handled we just always send the
+                   * complete batch as dead hosts.*/
+                  if (!limit_reached_handled)
                     {
-                      int last_hosts_consideres_alive =
+                      /* Number of alive hosts until limit was reached. */
+                      int last_hosts_considered_as_alive =
                         scanner.scan_restrictions->max_scan_hosts - prev_alive;
                       number_of_dead_hosts =
-                        batch - last_hosts_consideres_alive;
+                        batch - last_hosts_considered_as_alive;
                       send_dead_hosts_to_ospd_openvas (number_of_dead_hosts);
                       remaining_batch -= batch;
+                      limit_reached_handled = TRUE;
                     }
                   else
                     {
@@ -188,7 +215,11 @@ scan (alive_test_t alive_test)
 
   stop_sniffer_thread (&scanner, sniffer_thread_id);
 
-  /* Smooth progress bar implemented for ICMP only. */
+  /* If only ICMP was specified we continously sent updates about dead hosts to
+   * ospd while checking the hosts. We now only have to send the dead hosts of
+   * the last batch. This is done here to catch the last alive hosts which may
+   * have arrived after all packets were already sent.
+   * Else send total number of dead host at once.*/
   if (alive_test == ALIVE_TEST_ICMP)
     {
       int curr_alive = g_hash_table_size (scanner.hosts_data->alivehosts);
@@ -217,7 +248,8 @@ scan (alive_test_t alive_test)
 
   g_message ("Alive scan %s finished in %ld seconds: %d alive hosts of %d.",
              scan_id, end_time.tv_sec - start_time.tv_sec,
-             number_of_targets - number_of_dead_hosts, number_of_targets);
+             g_hash_table_size (scanner.hosts_data->alivehosts),
+             number_of_targets);
   g_free (scan_id);
 
   return 0;

--- a/boreas/alivedetection.h
+++ b/boreas/alivedetection.h
@@ -83,8 +83,7 @@ struct scanner
 struct hosts_data
 {
   /* Set of the form (ip_str, ip_str).
-   * Hosts which passed our pcap filter. May include hosts which are alive but
-   * are not in the targethosts list */
+   * Target hosts which were detected as alive. */
   GHashTable *alivehosts;
   /* Hashtable of the form (ip_str, gvm_host_t *). The gvm_host_t pointers point
    * to hosts which are to be freed by the caller of start_alive_detection(). */

--- a/boreas/sniffer.c
+++ b/boreas/sniffer.c
@@ -153,10 +153,11 @@ got_packet (u_char *user_data,
           "%s: Failed to transform IPv4 address into string representation: %s",
           __func__, strerror (errno));
 
-      /* Do not put already found host on Queue and only put hosts on Queue we
-       * are searching for. */
-      if (g_hash_table_add (hosts_data->alivehosts, g_strdup (addr_str))
-          && g_hash_table_contains (hosts_data->targethosts, addr_str) == TRUE)
+      /* Only put unique hosts on queue and in hash table. Use short circuit
+       * evaluation to not add hosts to the hash table which are not in our
+       * target list.*/
+      if ((g_hash_table_contains (hosts_data->targethosts, addr_str) == TRUE)
+          && (g_hash_table_add (hosts_data->alivehosts, g_strdup (addr_str))))
         {
           /* handle max_scan_hosts related restrictions. */
           handle_scan_restrictions (scanner, addr_str);
@@ -174,10 +175,11 @@ got_packet (u_char *user_data,
         g_debug ("%s: Failed to transform IPv6 into string representation: %s",
                  __func__, strerror (errno));
 
-      /* Do not put already found host on Queue and only put hosts on Queue we
-       * are searching for. */
-      if (g_hash_table_add (hosts_data->alivehosts, g_strdup (addr_str))
-          && g_hash_table_contains (hosts_data->targethosts, addr_str) == TRUE)
+      /* Only put unique hosts on queue and in hash table. Use short circuit
+       * evaluation to not add hosts to the hash table which are not in our
+       * target list.*/
+      if ((g_hash_table_contains (hosts_data->targethosts, addr_str) == TRUE)
+          && (g_hash_table_add (hosts_data->alivehosts, g_strdup (addr_str))))
         {
           /* handle max_scan_hosts related restrictions. */
           handle_scan_restrictions (scanner, addr_str);
@@ -201,10 +203,11 @@ got_packet (u_char *user_data,
         g_debug ("%s: Failed to transform IP into string representation: %s",
                  __func__, strerror (errno));
 
-      /* Do not put already found host on Queue and only put hosts on Queue
-      we are searching for. */
-      if (g_hash_table_add (hosts_data->alivehosts, g_strdup (addr_str))
-          && g_hash_table_contains (hosts_data->targethosts, addr_str) == TRUE)
+      /* Only put unique hosts on queue and in hash table. Use short circuit
+       * evaluation to not add hosts to the hash table which are not in our
+       * target list.*/
+      if ((g_hash_table_contains (hosts_data->targethosts, addr_str) == TRUE)
+          && (g_hash_table_add (hosts_data->alivehosts, g_strdup (addr_str))))
         {
           /* handle max_scan_hosts related restrictions. */
           handle_scan_restrictions (scanner, addr_str);


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Continuously send new dead hosts to ospd-openvas to gradually update the progress bar for the case that only ICMP was chosen as alive test.

**Why**:

<!-- Why are these changes necessary? -->

To get a better user experience when looking at the progress bar for the most common case of ICMP ping.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Tested with scans via gvm-cli and looked if the count of dead hosts which are send to ospd-openvas are correct. 
* Few hosts in target list and many hosts in target list
* max_scan_hosts set and not set
* max_scan_hosts reached in last batch of packet and in previous batch of packets.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
