### PR TITLE
Use dedicated port lists for alive detection if supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.04] (unreleased)
 
+### Added
+- Use dedicated port list for alive detection (Boreas only) if supplied via OSP. [#391](https://github.com/greenbone/gvm-libs/pull/391)
+
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)
 - Continuously send dead hosts to ospd-openvas to enable a smooth progess bar if only ICMP is chosen as alive test.  [#389](https://github.com/greenbone/gvm-libs/pull/389)

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -329,14 +329,17 @@ alive_detection_init (gvm_hosts_t *hosts, alive_test_t alive_test)
 
   /* Init ports used for scanning. */
   scanner.ports = NULL;
-  port_list = "80,137,587,3128,8081";
+
+  port_list = get_alive_test_ports ();
+  if (NULL == port_list)
+    port_list = "80,137,587,3128,8081";
   if (validate_port_range (port_list))
     {
       g_warning ("%s: Invalid port range supplied for alive detection module. "
                  "Using global port range instead.",
                  __func__);
-      /* This port list was already validated by openvas so we don't do it here
-       * again. */
+      /* This port list is also used by openvas for scanning and was already
+       * validated by openvas so we don't do it here again. */
       port_list = prefs_get ("port_range");
     }
   /* Use uint16_t for port array elements. tcphdr port type is uint16_t. */

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -421,3 +421,15 @@ get_alive_test_methods (alive_test_t *alive_test)
     }
   return error;
 }
+
+/**
+ * @brief Get ports which should be used for alive detection in case of TCP-ACK
+ * or TCP-SYN ping.
+ *
+ * @return string containing the ports. NULL otherwise.
+ */
+const gchar *
+get_alive_test_ports (void)
+{
+  return prefs_get ("ALIVE_TEST_PORTS");
+}

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -366,8 +366,8 @@ send_dead_hosts_to_ospd_openvas (int count_dead_hosts)
     }
 
   snprintf (dead_host_msg_to_ospd_openvas,
-            sizeof (dead_host_msg_to_ospd_openvas), "DEADHOST||| ||| ||| ||| |||%d",
-            count_dead_hosts);
+            sizeof (dead_host_msg_to_ospd_openvas),
+            "DEADHOST||| ||| ||| ||| |||%d", count_dead_hosts);
   kb_item_push_str (main_kb, "internal/results", dead_host_msg_to_ospd_openvas);
 
   kb_lnk_reset (main_kb);

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -46,4 +46,7 @@ get_openvas_scan_id (const gchar *, int);
 boreas_error_t
 get_alive_test_methods (alive_test_t *);
 
+const gchar *
+get_alive_test_ports (void);
+
 #endif /* not BOREAS_IO_H */

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -413,12 +413,11 @@ gvm_gpgme_fwrite (void *handle, const void *buffer, size_t size)
   return ret;
 }
 
-#define CHECK_ERR(func) \
-  if (err)                                            \
-    {                                                 \
-      printf ("%s: %s failed: %s\n",                  \
-              __func__, func, gpgme_strerror (err));  \
-      return -1;                                      \
+#define CHECK_ERR(func)                                                     \
+  if (err)                                                                  \
+    {                                                                       \
+      printf ("%s: %s failed: %s\n", __func__, func, gpgme_strerror (err)); \
+      return -1;                                                            \
     }
 
 /**
@@ -482,19 +481,18 @@ create_all_certificates_trustlist (gpgme_ctx_t ctx, const char *homedir)
 }
 
 #undef CHECK_ERR
-#define CHECK_ERR(func) \
-  if (err)                                            \
-    {                                                 \
-      printf ("%s: %s failed: %s\n",                  \
-              __func__, func, gpgme_strerror (err));  \
-      if (plain_data)                                 \
-        gpgme_data_release (plain_data);              \
-      if (encrypted_data)                             \
-        gpgme_data_release (encrypted_data);          \
-      if (ctx)                                        \
-        gpgme_release (ctx);                          \
-      gvm_file_remove_recurse (gpg_temp_dir);         \
-      return -1;                                      \
+#define CHECK_ERR(func)                                                     \
+  if (err)                                                                  \
+    {                                                                       \
+      printf ("%s: %s failed: %s\n", __func__, func, gpgme_strerror (err)); \
+      if (plain_data)                                                       \
+        gpgme_data_release (plain_data);                                    \
+      if (encrypted_data)                                                   \
+        gpgme_data_release (encrypted_data);                                \
+      if (ctx)                                                              \
+        gpgme_release (ctx);                                                \
+      gvm_file_remove_recurse (gpg_temp_dir);                               \
+      return -1;                                                            \
     }
 
 /**


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

The related PRs make it possible to supply a dedicated port list for alive detection via OSP. This PR enabled the usage of this port list.

Depends on:
https://github.com/greenbone/ospd/pull/323
https://github.com/greenbone/ospd-openvas/pull/327


**Why**:

<!-- Why are these changes necessary? -->

It enhances the flexibility when doing alive scans.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Used gvm-cli for scans. Added <alive_test_ports>22,80<alive_test_ports> and checked with a print if these ports were actually used. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
