### PR TITLE
Use correct type size for port elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add function to get duplicated hosts from the hosts list. [#387](https://github.com/greenbone/gvm-libs/pull/387)
 
+### Fixed
+- Fix port list for tcp pings when using test_alive_hosts_only feature. [#392](https://github.com/greenbone/gvm-libs/pull/392)
+
 [20.8.1]: https://github.com/greenbone/gvm-libs/compare/v20.8.0...gvm-libs-20.08
 
 ## [20.8.0] (2020-08-12)

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -227,7 +227,8 @@ alive_detection_init (gvm_hosts_t *hosts, alive_test_t alive_test)
        * again. */
       port_list = prefs_get ("port_range");
     }
-  scanner.ports = g_array_new (FALSE, TRUE, sizeof (int));
+  /* Use uint16_t for port array elements. tcphdr port type is uint16_t. */
+  scanner.ports = g_array_new (FALSE, TRUE, sizeof (uint16_t));
   if (port_list)
     portranges_array = port_range_ranges (port_list);
   else

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -287,7 +287,9 @@ fill_ports_array (gpointer range, gpointer ports_array)
   gboolean range_exclude;
   int range_start;
   int range_end;
-  int port;
+  int i;
+  /* Use uint16_t for port array elements. tcphdr port type is uint16_t. */
+  uint16_t port_sized;
 
   range_start = ((range_t *) range)->start;
   range_end = ((range_t *) range)->end;
@@ -300,13 +302,18 @@ fill_ports_array (gpointer range, gpointer ports_array)
   /* Only single port in range. */
   if (range_end == 0 || (range_start == range_end))
     {
-      g_array_append_val (ports_array, range_start);
+      port_sized = (uint16_t) range_start;
+      g_array_append_val (ports_array, port_sized);
       return;
     }
   else
     {
-      for (port = range_start; port <= range_end; port++)
-        g_array_append_val (ports_array, port);
+
+      for (i = range_start; i <= range_end; i++)
+        {
+          port_sized = (uint16_t) i;
+          g_array_append_val (ports_array, port_sized);
+        }
     }
 }
 


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Fix type conversion bug. Because of this bug it could happen that not all ports are added correctly to the port list for TCP pings.
If we init an GArray with elements of type int and then get elements from this array with g_array_index (array, uint16_t, index) we get 0 every second port. This is fixed by always using uint16_t when initing the array and when filling it.

**Why**:

<!-- Why are these changes necessary? -->
Bugs have to be fixed.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Printed out the array of ports after it got filled. Before fix every second port was 0, after fix all ports are filled as expected.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
