### PR TITLE
Retry if response via tls1.3 is still not received.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)
 - Continuously send dead hosts to ospd-openvas to enable a smooth progess bar if only ICMP is chosen as alive test.  [#389](https://github.com/greenbone/gvm-libs/pull/389)
+- Retry if response via tls1.3 is still not received. [#394](https://github.com/greenbone/gvm-libs/pull/394)
 
 ### Removed
 - Remove version from the nvticache name. [#386](https://github.com/greenbone/gvm-libs/pull/386)

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -587,6 +587,7 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
   while (1)
     {
       ssize_t count;
+      int retries = 10;
       while (1)
         {
           g_debug ("   asking for %i\n", BUFFER_SIZE);
@@ -611,6 +612,18 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
                     }
                   continue;
                 }
+              else if ((timeout == 0) && (count == GNUTLS_E_AGAIN))
+                {
+                  /* Server still busy, try read again.
+                     If there is no timeout set and the server is still not ready,
+                     it will try up to 10 times before closing the socket.*/
+                  if (retries > 0)
+                    {
+                     retries = retries - 1;
+                     continue;
+                    }
+                }
+
               if (count == GNUTLS_E_REHANDSHAKE)
                 /* Try again. TODO Rehandshake. */
                 continue;


### PR DESCRIPTION
**What**:
Retry if xml response via tls1.3 is still not received.
This is done only for those cases in which a timeout is not set.

**Why**:

For some reason, TLS1.3 behaves different than TLS1.2. For the first try of receiving a response, a GNUTLS_EAGAIN error is received, and currently only check again if there is a timeout set. Otherwise, connection is closed immediately.
As workaround, it will try now up to 10 times before closing the connection.

**How**:
In debian buster TLS1.3 is the default one. Set an ospd-openvas server with connection type TLS. Add the scanner to gvmd. Start a Task. It should end successfully. Without the patch, the connection is closed and the task is set as done with errors.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
