### PR TITLE
Remove handling of severity class from auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Retry if response via tls1.3 is still not received. [#394](https://github.com/greenbone/gvm-libs/pull/394)
 
 ### Removed
+- Remove handling of severity class from auth [#402](https://github.com/greenbone/gvm-libs/pull/402)
 - Remove version from the nvticache name. [#386](https://github.com/greenbone/gvm-libs/pull/386)
 
 [unreleased]: https://github.com/greenbone/gvm-libs/compare/gvm-libs-20.08...master

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2019 Greenbone Networks GmbH
+/* Copyright (C) 2009-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -421,7 +421,7 @@ gmp_authenticate_info_ext (gnutls_session_t *session,
   first = status[0];
   if (first == '2')
     {
-      entity_t timezone_entity, role_entity, severity_entity, pw_warn_entity;
+      entity_t timezone_entity, role_entity, pw_warn_entity;
       /* Get the extra info. */
       timezone_entity = entity_child (entity, "timezone");
       if (timezone_entity)
@@ -429,9 +429,6 @@ gmp_authenticate_info_ext (gnutls_session_t *session,
       role_entity = entity_child (entity, "role");
       if (role_entity)
         *opts.role = g_strdup (entity_text (role_entity));
-      severity_entity = entity_child (entity, "severity");
-      if (severity_entity)
-        *opts.severity = g_strdup (entity_text (severity_entity));
       pw_warn_entity = entity_child (entity, "password_warning");
       if (pw_warn_entity)
         *(opts.pw_warning) = g_strdup (entity_text (pw_warn_entity));
@@ -508,7 +505,7 @@ gmp_authenticate_info_ext_c (gvm_connection_t *connection,
   first = status[0];
   if (first == '2')
     {
-      entity_t timezone_entity, role_entity, severity_entity;
+      entity_t timezone_entity, role_entity;
       /* Get the extra info. */
       timezone_entity = entity_child (entity, "timezone");
       if (timezone_entity && opts.timezone)
@@ -516,9 +513,6 @@ gmp_authenticate_info_ext_c (gvm_connection_t *connection,
       role_entity = entity_child (entity, "role");
       if (role_entity && opts.role)
         *opts.role = g_strdup (entity_text (role_entity));
-      severity_entity = entity_child (entity, "severity");
-      if (severity_entity && opts.severity)
-        *opts.severity = g_strdup (entity_text (severity_entity));
       if (opts.pw_warning)
         {
           entity_t pw_warn_entity;

--- a/gmp/gmp.h
+++ b/gmp/gmp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2019 Greenbone Networks GmbH
+/* Copyright (C) 2009-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -43,7 +43,6 @@ typedef struct
   const char *username; ///< Password.
   const char *password; ///< Username.
   char **role;          ///< [out] Role.
-  char **severity;      ///< [out] Severity class setting.
   char **timezone;      ///< [out] Timezone if any, else NULL.
   char **pw_warning;    ///< [out] Password warning, NULL if password is okay.
 } gmp_authenticate_info_opts_t;
@@ -52,7 +51,7 @@ typedef struct
  * @brief Sensible default values for gmp_authenticate_info_opts_t
  */
 static const gmp_authenticate_info_opts_t gmp_authenticate_info_opts_defaults =
-  {0, NULL, NULL, NULL, NULL, NULL, NULL};
+  {0, NULL, NULL, NULL, NULL, NULL};
 
 /**
  * @brief Struct holding options for gmp get_report command.


### PR DESCRIPTION
This is not required anymore and can be removed
after https://github.com/greenbone/gsa/pull/2448
is applied as well as a backport of that PR to the
gsa master branch.

**Checklist**:

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
