### PR TITLE
Allow to re allocate the finish flag in the hosts queue for alive tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Use dedicated port list for alive detection (Boreas only) if supplied via OSP. [#391](https://github.com/greenbone/gvm-libs/pull/391)
+- Allow to re allocate the finish flag in the host queue for alive tests. [#407](https://github.com/greenbone/gvm-libs/pull/407)
 
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -928,7 +928,7 @@ gvm_host_new ()
  *
  * @param[in] host  Host to free.
  */
-static void
+void
 gvm_host_free (gpointer host)
 {
   gvm_host_t *h = host;

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -180,6 +180,9 @@ gvm_host_get_addr6 (const gvm_host_t *, struct in6_addr *);
 void
 gvm_host_add_reverse_lookup (gvm_host_t *);
 
+void
+gvm_host_free (gpointer);
+
 /* Miscellaneous functions */
 
 gvm_vhost_t *

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -180,8 +180,7 @@ gvm_host_get_addr6 (const gvm_host_t *, struct in6_addr *);
 void
 gvm_host_add_reverse_lookup (gvm_host_t *);
 
-void
-gvm_host_free (gpointer);
+void gvm_host_free (gpointer);
 
 /* Miscellaneous functions */
 

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -239,8 +239,7 @@ put_host_on_queue (kb_t kb, char *addr_str)
 }
 
 /**
- * @brief Checks if the finish signal is at the end of alive detection
- * queue.
+ * @brief Checks if the finish signal is already set as last item in the queue.
  *
  * @param main_kb  kb to use
  * @return 1 if it is already set. 0 otherwise.
@@ -262,8 +261,10 @@ finish_signal_on_queue (kb_t main_kb)
   kb_item_free (last_queue_item);
   return ret;
 }
+
 /**
- * @brief Reallocate finish signal at the end of alive detection queue.
+ * @brief Reallocate finish signal in last position of the alive detection
+ * queue.
  *
  * @param main_kb  kb to use
  */
@@ -272,7 +273,10 @@ realloc_finish_signal_on_queue (kb_t main_kb)
 {
   int kb_item_push_str_err, pos;
 
-  pos = 1; // Append the item at the end of the queue.
+  /* The alive test queue is a FIFO queue. Alive hosts are taken from the
+   * right side of the queue. Therefore the finish signal is put in the
+   * left end of queue, being the last item to be fetch.*/
+  pos = 1;
   kb_item_push_str_err = kb_item_add_str_unique (
     main_kb, ALIVE_DETECTION_QUEUE, ALIVE_DETECTION_FINISHED, 0, pos);
   if (kb_item_push_str_err)

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -239,12 +239,37 @@ put_host_on_queue (kb_t kb, char *addr_str)
 }
 
 /**
+ * @brief Checks if the finish signal is at the end of alive detection
+ * queue.
+ *
+ * @param main_kb  kb to use
+ * @return 1 if it is already set. 0 otherwise.
+ */
+int
+finish_signal_on_queue(kb_t main_kb)
+{
+  struct kb_item *last_queue_item;
+  int ret;
+
+  ret = 0;
+  last_queue_item = kb_item_get_single (
+    main_kb, ALIVE_DETECTION_QUEUE, KB_TYPE_STR);
+
+  if (last_queue_item
+      && (last_queue_item->type == KB_TYPE_STR)
+      && (!strcmp (last_queue_item->v_str, ALIVE_DETECTION_FINISHED)))
+    ret = 1;
+
+  kb_item_free (last_queue_item);
+  return ret;
+}
+/**
  * @brief Reallocate finish signal at the end of alive detection queue.
  *
  * @param main_kb  kb to use
  */
 void
-realloc_finish_signal_on_queue(kb_t main_kb)
+realloc_finish_signal_on_queue (kb_t main_kb)
 {
   int kb_item_push_str_err, pos;
 

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -246,17 +246,16 @@ put_host_on_queue (kb_t kb, char *addr_str)
  * @return 1 if it is already set. 0 otherwise.
  */
 int
-finish_signal_on_queue(kb_t main_kb)
+finish_signal_on_queue (kb_t main_kb)
 {
   struct kb_item *last_queue_item;
   int ret;
 
   ret = 0;
-  last_queue_item = kb_item_get_single (
-    main_kb, ALIVE_DETECTION_QUEUE, KB_TYPE_STR);
+  last_queue_item =
+    kb_item_get_single (main_kb, ALIVE_DETECTION_QUEUE, KB_TYPE_STR);
 
-  if (last_queue_item
-      && (last_queue_item->type == KB_TYPE_STR)
+  if (last_queue_item && (last_queue_item->type == KB_TYPE_STR)
       && (!strcmp (last_queue_item->v_str, ALIVE_DETECTION_FINISHED)))
     ret = 1;
 
@@ -274,10 +273,8 @@ realloc_finish_signal_on_queue (kb_t main_kb)
   int kb_item_push_str_err, pos;
 
   pos = 1; // Append the item at the end of the queue.
-  kb_item_push_str_err = kb_item_add_str_unique (main_kb,
-                                                  ALIVE_DETECTION_QUEUE,
-                                                  ALIVE_DETECTION_FINISHED,
-                                                  0, pos);
+  kb_item_push_str_err = kb_item_add_str_unique (
+    main_kb, ALIVE_DETECTION_QUEUE, ALIVE_DETECTION_FINISHED, 0, pos);
   if (kb_item_push_str_err)
     g_debug ("%s: Could not push the Boreas finish signal on the alive "
              "detection Queue.",

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -256,7 +256,7 @@ finish_signal_on_queue (kb_t main_kb)
     kb_item_get_single (main_kb, ALIVE_DETECTION_QUEUE, KB_TYPE_STR);
 
   if (last_queue_item && (last_queue_item->type == KB_TYPE_STR)
-      && (!strcmp (last_queue_item->v_str, ALIVE_DETECTION_FINISHED)))
+      && (!g_strcmp0 (last_queue_item->v_str, ALIVE_DETECTION_FINISHED)))
     ret = 1;
 
   kb_item_free (last_queue_item);

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -239,6 +239,27 @@ put_host_on_queue (kb_t kb, char *addr_str)
 }
 
 /**
+ * @brief Reallocate finish signal at the end of alive detection queue.
+ *
+ * @param main_kb  kb to use
+ */
+void
+realloc_finish_signal_on_queue(kb_t main_kb)
+{
+  int kb_item_push_str_err, pos;
+
+  pos = 1; // Append the item at the end of the queue.
+  kb_item_push_str_err = kb_item_add_str_unique (main_kb,
+                                                  ALIVE_DETECTION_QUEUE,
+                                                  ALIVE_DETECTION_FINISHED,
+                                                  0, pos);
+  if (kb_item_push_str_err)
+    g_debug ("%s: Could not push the Boreas finish signal on the alive "
+             "detection Queue.",
+             __func__);
+}
+
+/**
  * @brief Put finish signal on alive detection queue.
  *
  * If the finish signal (a string) was already put on the queue it is not put on

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -221,7 +221,7 @@ get_host_from_queue (kb_t alive_hosts_kb, gboolean *alive_deteciton_finished)
  * @param kb KB to use.
  * @param addr_str IP addr in str representation to put on queue.
  */
-static void
+void
 put_host_on_queue (kb_t kb, char *addr_str)
 {
   /* Print host on command line if no kb is available. No kb available could

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -34,11 +34,9 @@ put_host_on_queue (kb_t, char *);
 void
 put_finish_signal_on_queue (void *);
 
-void
-realloc_finish_signal_on_queue(kb_t);
+void realloc_finish_signal_on_queue (kb_t);
 
-int
-finish_signal_on_queue(kb_t);
+int finish_signal_on_queue (kb_t);
 
 void
 send_dead_hosts_to_ospd_openvas (int);

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -35,6 +35,9 @@ void
 put_finish_signal_on_queue (void *);
 
 void
+realloc_finish_signal_on_queue(kb_t);
+
+void
 send_dead_hosts_to_ospd_openvas (int);
 
 void

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -29,6 +29,9 @@ gvm_host_t *
 get_host_from_queue (kb_t, gboolean *);
 
 void
+put_host_on_queue (kb_t, char *);
+
+void
 put_finish_signal_on_queue (void *);
 
 void

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -37,6 +37,9 @@ put_finish_signal_on_queue (void *);
 void
 realloc_finish_signal_on_queue(kb_t);
 
+int
+finish_signal_on_queue(kb_t);
+
 void
 send_dead_hosts_to_ospd_openvas (int);
 

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -34,9 +34,11 @@ put_host_on_queue (kb_t, char *);
 void
 put_finish_signal_on_queue (void *);
 
-void realloc_finish_signal_on_queue (kb_t);
+void
+realloc_finish_signal_on_queue (kb_t);
 
-int finish_signal_on_queue (kb_t);
+int
+finish_signal_on_queue (kb_t);
 
 void
 send_dead_hosts_to_ospd_openvas (int);

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -308,7 +308,6 @@ fill_ports_array (gpointer range, gpointer ports_array)
     }
   else
     {
-
       for (i = range_start; i <= range_end; i++)
         {
           port_sized = (uint16_t) i;

--- a/util/kb.c
+++ b/util/kb.c
@@ -1112,11 +1112,13 @@ redis_del_items (kb_t kb, const char *name)
  * @param[in] name  Item name.
  * @param[in] str  Item value.
  * @param[in] len  Value length. Used for blobs.
+ * @param[in] pos  Which position the value is appended to. 0 for right,
+ *                 1 for left position in the list.
  *
  * @return 0 on success, non-null on error.
  */
 static int
-redis_add_str_unique (kb_t kb, const char *name, const char *str, size_t len)
+redis_add_str_unique (kb_t kb, const char *name, const char *str, size_t len, int pos)
 {
   struct kb_redis *kbr;
   redisReply *rep = NULL;
@@ -1135,7 +1137,7 @@ redis_add_str_unique (kb_t kb, const char *name, const char *str, size_t len)
   if (len == 0)
     {
       redisAppendCommand (ctx, "LREM %s 1 %s", name, str);
-      redisAppendCommand (ctx, "RPUSH %s %s", name, str);
+      redisAppendCommand (ctx, "%s %s %s", pos ? "LPUSH" : "RPUSH", name, str);
       redisGetReply (ctx, (void **) &rep);
       if (rep && rep->type == REDIS_REPLY_INTEGER && rep->integer == 1)
         g_debug ("Key '%s' already contained value '%s'", name, str);
@@ -1145,7 +1147,7 @@ redis_add_str_unique (kb_t kb, const char *name, const char *str, size_t len)
   else
     {
       redisAppendCommand (ctx, "LREM %s 1 %b", name, str, len);
-      redisAppendCommand (ctx, "RPUSH %s %b", name, str, len);
+      redisAppendCommand (ctx, "%s %s %b", pos ? "LPUSH" : "RPUSH", name, str, len);
       redisGetReply (ctx, (void **) &rep);
       if (rep && rep->type == REDIS_REPLY_INTEGER && rep->integer == 1)
         g_debug ("Key '%s' already contained string '%s'", name, str);

--- a/util/kb.c
+++ b/util/kb.c
@@ -1118,7 +1118,8 @@ redis_del_items (kb_t kb, const char *name)
  * @return 0 on success, non-null on error.
  */
 static int
-redis_add_str_unique (kb_t kb, const char *name, const char *str, size_t len, int pos)
+redis_add_str_unique (kb_t kb, const char *name, const char *str, size_t len,
+                      int pos)
 {
   struct kb_redis *kbr;
   redisReply *rep = NULL;
@@ -1147,7 +1148,8 @@ redis_add_str_unique (kb_t kb, const char *name, const char *str, size_t len, in
   else
     {
       redisAppendCommand (ctx, "LREM %s 1 %b", name, str, len);
-      redisAppendCommand (ctx, "%s %s %b", pos ? "LPUSH" : "RPUSH", name, str, len);
+      redisAppendCommand (ctx, "%s %s %b", pos ? "LPUSH" : "RPUSH", name, str,
+                          len);
       redisGetReply (ctx, (void **) &rep);
       if (rep && rep->type == REDIS_REPLY_INTEGER && rep->integer == 1)
         g_debug ("Key '%s' already contained string '%s'", name, str);

--- a/util/kb.h
+++ b/util/kb.h
@@ -183,7 +183,7 @@ struct kb_operations
    * Function provided by an implementation to insert (append) a new
    * unique entry under a given name.
    */
-  int (*kb_add_str_unique) (kb_t, const char *, const char *, size_t);
+  int (*kb_add_str_unique) (kb_t, const char *, const char *, size_t, int);
   /**
    * Function provided by an implementation to get (replace) a new entry
    * under a given name.
@@ -458,16 +458,18 @@ kb_item_add_str (kb_t kb, const char *name, const char *str, size_t len)
  * @param[in] name  Item name.
  * @param[in] str  Item value.
  * @param[in] len  Value length. Used for blobs.
+ * @param[in] pos  Which position the value is appended to. 0 for right,
+ *                 1 for left position in the list.
  * @return 0 on success, non-null on error.
  */
 static inline int
-kb_item_add_str_unique (kb_t kb, const char *name, const char *str, size_t len)
+kb_item_add_str_unique (kb_t kb, const char *name, const char *str, size_t len, int pos)
 {
   assert (kb);
   assert (kb->kb_ops);
   assert (kb->kb_ops->kb_add_str_unique);
 
-  return kb->kb_ops->kb_add_str_unique (kb, name, str, len);
+  return kb->kb_ops->kb_add_str_unique (kb, name, str, len, pos);
 }
 
 /**

--- a/util/kb.h
+++ b/util/kb.h
@@ -463,7 +463,8 @@ kb_item_add_str (kb_t kb, const char *name, const char *str, size_t len)
  * @return 0 on success, non-null on error.
  */
 static inline int
-kb_item_add_str_unique (kb_t kb, const char *name, const char *str, size_t len, int pos)
+kb_item_add_str_unique (kb_t kb, const char *name, const char *str, size_t len,
+                        int pos)
 {
   assert (kb);
   assert (kb->kb_ops);

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -615,12 +615,13 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
               else if ((timeout == 0) && (count == GNUTLS_E_AGAIN))
                 {
                   /* Server still busy, try read again.
-                     If there is no timeout set and the server is still not ready,
-                     it will try up to 10 times before closing the socket.*/
+                     If there is no timeout set and the server is still not
+                     ready, it will try up to 10 times before closing the
+                     socket.*/
                   if (retries > 0)
                     {
-                     retries = retries - 1;
-                     continue;
+                      retries = retries - 1;
+                      continue;
                     }
                 }
 


### PR DESCRIPTION
**What**:
If the flag to indicate that the alive test has finished has been already set at the end of the list, with these changes it is possible to add/move a host and then re allocate the flag at the end again.
**Why**:
In some cases a host can be added/moved in the alive host list.

**How**:


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
