### PR TITLE
Add function to move a host to the end of the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Use dedicated port list for alive detection (Boreas only) if supplied via OSP. [#391](https://github.com/greenbone/gvm-libs/pull/391)
-- Allow to re allocate the finish flag in the host queue for alive tests. [#407](https://github.com/greenbone/gvm-libs/pull/407)
+- Allow to re allocate the finish flag in the host queue for alive tests.
+  [#407](https://github.com/greenbone/gvm-libs/pull/407)
+  [#410](https://github.com/greenbone/gvm-libs/pull/410)
 
 ### Added
 - Add multiple severities for nvti [#317](https://github.com/greenbone/gvm-libs/pull/317)

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1301,6 +1301,39 @@ gvm_hosts_next (gvm_hosts_t *hosts)
 }
 
 /**
+ * @brief Move the current gvm_host_t from a gvm_hosts_t structure to
+ * the end of the hosts list.
+ *
+ * @param[in/out]   hosts     gvm_hosts_t structure which hosts must be
+ * rearange. The hosts->current index points to the last used hosts and
+ * gvm_hosts_next() must be called to get the next host in the list.
+ *
+ */
+void
+gvm_hosts_move_current_host_to_end (gvm_hosts_t *hosts)
+{
+  void *host_tmp;
+  size_t i;
+
+  if (!hosts)
+    return;
+
+  if (hosts->current == hosts->count)
+    {
+      hosts->current -= 1;
+      return;
+    }
+
+  hosts->current -= 1;
+  host_tmp = hosts->hosts[hosts->current];
+
+  for (i = hosts->current; i < hosts->count; i++)
+    hosts->hosts[i - 1] = hosts->hosts[i];
+
+  hosts->hosts[hosts->count - 1] = host_tmp;
+}
+
+/**
  * @brief Frees memory occupied by an gvm_hosts_t structure.
  *
  * @param[in] hosts The hosts collection to free.

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -112,6 +112,9 @@ gvm_host_t *
 gvm_hosts_next (gvm_hosts_t *);
 
 void
+gvm_hosts_move_current_host_to_end (gvm_hosts_t *);
+
+void
 gvm_hosts_free (gvm_hosts_t *);
 
 void

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -212,6 +212,42 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
   assert_that (gvm_hosts_new_with_max ("127.0.0.1|127.0.0.2", 2), is_null);
 }
 
+Ensure (hosts, gvm_hosts_move_host_to_end)
+{
+  gvm_hosts_t *hosts = NULL;
+  gvm_host_t *host = NULL;
+  int totalhosts;
+  size_t current;
+
+  hosts = gvm_hosts_new ("192.168.0.0/28");
+
+  // Get first host
+  host = gvm_hosts_next (hosts);
+
+  totalhosts = gvm_hosts_count (hosts);
+  assert_that (totalhosts, is_equal_to (14));
+
+  while (g_strcmp0 (gvm_host_value_str (host), "192.168.0.9"))
+    {
+      host = gvm_hosts_next (hosts);
+    }
+  assert_that (g_strcmp0 (gvm_host_value_str (host), "192.168.0.9"),
+               is_equal_to (0));
+
+  current = hosts->current;
+  gvm_hosts_move_current_host_to_end (hosts);
+  assert_that (hosts->current, is_equal_to (current - 1));
+
+  host = gvm_hosts_next (hosts);
+  assert_that (g_strcmp0 (gvm_host_value_str (host), "192.168.0.10"),
+               is_equal_to (0));
+  assert_that (g_strcmp0 (gvm_host_value_str (hosts->hosts[totalhosts - 1]),
+                          "192.168.0.9"),
+               is_equal_to (0));
+
+  gvm_hosts_free (hosts);
+}
+
 /* Test suite. */
 
 int
@@ -244,6 +280,8 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, hosts, gvm_hosts_new_with_max_returns_error);
   add_test_with_context (suite, hosts, gvm_hosts_new_with_max_returns_success);
+
+  add_test_with_context (suite, hosts, gvm_hosts_move_host_to_end);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION

**What**:
Allows to put a host in the hosts structure at the end
of the host list without reset the iterator.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It was need to move the host to the end without resetting the iterator. 
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
