### PR TITLE
Convert "severity_date" value to seconds since epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#410](https://github.com/greenbone/gvm-libs/pull/410)
 - Add multiple severities for nvti [#317](https://github.com/greenbone/gvm-libs/pull/317)
 - Add support for new OSP element for defining alive test methods via separate subelements. [#409](https://github.com/greenbone/gvm-libs/pull/409)
+- Add severity_date tag in epoch time format. [#412](https://github.com/greenbone/gvm-libs/pull/412)
 
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -1497,7 +1497,7 @@ nvti_add_tag (nvti_t *n, const gchar *name, const gchar *value)
       newvalue = g_strdup_printf ("%i", (int) nvti_creation_time (n));
     }
   else if (!strcmp (name, "severity_date"))
-      newvalue = g_strdup_printf ("%i", (int) parse_nvt_timestamp (value));
+    newvalue = g_strdup_printf ("%i", (int) parse_nvt_timestamp (value));
   else if (!strcmp (name, "cvss_base"))
     {
       /* Ignore this tag because it is not being used.

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -1458,10 +1458,10 @@ nvti_set_solution_method (nvti_t *n, const gchar *solution_method)
 
 /**
  * @brief Add a tag to the NVT tags.
- *        The tag names "last_modification" and "creation_date" are
- *        treated special: The value is expected to be a timestamp
- *        and it is being converted to seconds since epoch before
- *        added as a tag value.
+ *        The tag names "severity_date", "last_modification" and
+ *        "creation_date" are treated special: The value is expected
+ *        to be a timestamp  and it is being converted to seconds
+ *        since epoch before added as a tag value.
  *        The tag name "cvss_base" will be ignored and not added.
  *
  * @param n     The NVT Info structure.
@@ -1496,6 +1496,8 @@ nvti_add_tag (nvti_t *n, const gchar *name, const gchar *value)
       nvti_set_creation_time (n, parse_nvt_timestamp (value));
       newvalue = g_strdup_printf ("%i", (int) nvti_creation_time (n));
     }
+  else if (!strcmp (name, "severity_date"))
+      newvalue = g_strdup_printf ("%i", (int) parse_nvt_timestamp (value));
   else if (!strcmp (name, "cvss_base"))
     {
       /* Ignore this tag because it is not being used.


### PR DESCRIPTION
**What**:
 The tag names "severity_date" is treated special
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
For consistency, the severity_date  date format value is the same as for creation_date and last_modification. Internally is expected to be a seconds since epoch value.

<!-- Why are these changes necessary? -->

**How**:
Add the following tags to a script
```
  script_tag(name:"severity_vector", value:"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L");
  script_tag(name:"severity_origin", value:"greenbone");
  script_tag(name:"severity_date", value:"2009-03-26 19:23:59 +0100 (Thu, 26 Mar 2009)");
```
Check in redis cache, that the severity date for the modified script is seconds since epoch.

```
redis /tmp/redis.sock[1]> lrange nvt:1.3.6.1.4.1.25623.1.0.100081 0 -1
 1) "auth_enabled.nasl"
 2) ""
 3) ""
 4) ""
 5) ""
 6) "Services/auth, 113"
 7) "find_service.nasl"
 8) "last_modification=1549632112|creation_date=1238091839|cvss_base_vector=AV:N/AC:L/Au:N/C:P/I:N/A:N|severity_vector=CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L|severity_origin=greenbone|severity_date=1238091839|summary=The remote host is running an ident daemon.\n\n  The Ident Protocol is designed to work as a server daemon, on a user's\n  comp
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
