### PR TITLE
 Make more scanner preferences available for openvas-nasl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for new OSP element for defining alive test methods via separate subelements. [#409](https://github.com/greenbone/gvm-libs/pull/409)
 - Add v3 handling to get_cvss_score_from_base_metrics [#411](https://github.com/greenbone/gvm-libs/pull/411)
 - Add severity_date tag in epoch time format. [#412](https://github.com/greenbone/gvm-libs/pull/412)
+- Make more scanner preferences available to openvas-nasl. [#413](https://github.com/greenbone/gvm-libs/pull/413)
 
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)

--- a/base/prefs.c
+++ b/base/prefs.c
@@ -60,6 +60,20 @@ prefs_init (void)
   prefs_set ("open_sock_max_attempts", "5");
   prefs_set ("time_between_request", "0");
   prefs_set ("nasl_no_signature_check", "yes");
+  prefs_set ("max_hosts", "30");
+  prefs_set ("max_checks", "10");
+  prefs_set ("log_whole_attack", "no");
+  prefs_set ("log_plugins_name_at_load", "no");
+  prefs_set ("optimize_test", "yes");
+  prefs_set ("non_simult_ports", "139, 445, 3389, Services/irc");
+  prefs_set ("safe_checks", "yes");
+  prefs_set ("auto_enable_dependencies", "yes");
+  prefs_set ("drop_privileges", "no");
+  prefs_set ("report_host_details", "yes");
+  prefs_set ("vendor_version", "\0");
+  prefs_set ("test_alive_hosts_only", "no");
+  prefs_set ("debug_tls", "0");
+  prefs_set ("allow_simult_ips_same_host", "yes");
 }
 
 /**


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Move all scanner settings/preferences which have defaults and are not dependent on CMake variables
to gvm-libs. This way they are available for openvas-nasl too.

Settings not moved to gvm-libs with reason

Defaults defined via CMake
  * scanner_plugins_timeout
  * plugins_timeout
  * db_address

Defined via openvas-nasl command line option
  * include_folders

Not needed by openvas-nasl
  * plugins_folder

Prerequisite to:
https://github.com/greenbone/openvas/pull/614

**Why**:

<!-- Why are these changes necessary? -->

To make the options available to scripts when run via openvas-nasl.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Dump the prefs (`prefs_dump ()`) with and without the PRs.

openvas-nasl: has the additional options now.
openvas: no difference in preference settings. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
