### PR TITLE
Restructure LDAP / RADIUS install instructions. Fix typo.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ Install prerequisites on Debian GNU/Linux 'Buster' 10:
 Prerequisites for Optional Features
 -----------------------------------
 
-Certain features of gvm-libs are optional and requires the following:
+Certain features of gvm-libs are optional and require the following:
 
 Prerequisites for LDAP authentication:
 * libldap2 library >= 2.4.44 (util) (Debian package: libldap2-dev)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,13 +24,9 @@ Specific development libraries:
 * libgnutls >= 3.2.15 (util)
 * libuuid >= 2.25.0 (util)
 * libssh >= 0.6.0 (util)
-* libldap2 >= 2.4.44 (util)
 * libhiredis >= 0.10.1 (util)
 * libxml2 >= 2.0 (util)
 * libpcap
-
-Optional development libraries:
-* libradcli-dev >= 1.2.6 (util)
 
 Prerequisites for building documentation:
 * doxygen
@@ -49,11 +45,28 @@ Install prerequisites on Debian GNU/Linux 'Buster' 10:
     libgnutls28-dev \
     uuid-dev \
     libssh-gcrypt-dev \
-    libldap2-dev \
     libhiredis-dev \
     libxml2-dev \
-    libradcli-dev \
     libpcap-dev
+
+
+Prerequisites for Optional Features
+-----------------------------------
+
+Certain features of gvm-libs are optional and requires the following:
+
+Prerequisites for LDAP authentication:
+* libldap2 library >= 2.4.44 (util) (Debian package: libldap2-dev)
+
+Prerequisites for RADIUS authentication:
+* libradcli4 library >= 1.2.6 (util) (Debian package: libradcli-dev)
+* Alternative: libfreeradius3 library (util) (Debian package: libfreeradius-dev)
+
+Install prerequisites for optional features on Debian GNU/Linux 'Buster' 10:
+
+    apt-get install \
+    libldap2-dev \
+    libradcli-dev
 
 
 Compiling gvm-libs

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -98,7 +98,7 @@ option (BUILD_WITH_RADIUS "Try to build with Radius support" ON)
 option (BUILD_WITH_LDAP "Try to build with LDAP support" ON)
 
 if (BUILD_WITH_RADIUS)
-  #for radiusutils we need freerdius-client library
+  #for radiusutils we need freeradius-client library
   message (STATUS "Looking for freeradius-client library...")
   find_library (LIBFREERADIUS freeradius-client)
   if (NOT LIBFREERADIUS)


### PR DESCRIPTION
LDAP and RADIUS auth are both optional features:

https://github.com/bjoernricks/gvm-libs/blob/b0e1f5ef9916062a2b48b84004dc2922c2ef5a08/util/CMakeLists.txt#L94-L132

so we should document / mention them separately.

This can also help with questions like https://github.com/Atomicorp/gvm/issues/36

Part of https://github.com/greenbone/templates/issues/17