### PR TITLE
Correct g_hash_table_remove arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Set source address correctly and do not try to send ARP to unreachable destination. [#401](https://github.com/greenbone/gvm-libs/pull/401)
 - Increase minimum gpgme version [#405](https://github.com/greenbone/gvm-libs/pull/405)
 - Always NULL check ifaddrs->ifa_addr [#416](https://github.com/greenbone/gvm-libs/pull/416)
+- Correct g_hash_table_remove arg [#419](https://github.com/greenbone/gvm-libs/pull/419)
 
 [20.8.1]: https://github.com/greenbone/gvm-libs/compare/v20.8.0...gvm-libs-20.08
 

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -1384,7 +1384,7 @@ osp_credential_set_auth_data (osp_credential_t *credential, const char *name,
         g_hash_table_replace (credential->auth_data, g_strdup (name),
                               g_strdup (value));
       else
-        g_hash_table_remove (credential->auth_data, value);
+        g_hash_table_remove (credential->auth_data, name);
     }
   else
     {


### PR DESCRIPTION
**What**:

Pass name instead of value to g_has_table_remove.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Function expects key name.  Was causing a segfault on scans with credentials where the credential could not be decoded.

<!-- Why are these changes necessary? -->

**How**:

Run gvmd with --disable-encrypted-credentials.  Create a target with an SSH credential.  Run a task using the target.  Task should run.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
