### PR TITLE
Add file access tests using effective UID/GID (20.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add function to get duplicated hosts from the hosts list. [#387](https://github.com/greenbone/gvm-libs/pull/387)
+- Add file access tests using effective UID/GID [#422](https://github.com/greenbone/gvm-libs/pull/422)
 
 ### Changed
 - Reduce ping timeout when using test_alive_hosts_only feature. [#400](https://github.com/greenbone/gvm-libs/pull/400)

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -64,6 +64,60 @@ gvm_file_check_is_dir (const char *name)
 }
 
 /**
+ * @brief Checks whether a file or directory exists.
+ *
+ * Unlike g_file_test this checks the permissions based on the effective
+ *  UID and GID instead of the real one.
+ *
+ * Symbolic links are followed.
+ *
+ * @param[in]  name  Name of file or directory.
+ *
+ * @return 1 if file exists, 0 if it is not.
+ */
+int
+gvm_file_exists (const char *name)
+{
+  return eaccess (name, F_OK) == 0;
+}
+
+/**
+ * @brief Checks whether a file or directory exists and is executable.
+ *
+ * Unlike g_file_test this checks the permissions based on the effective
+ *  UID and GID instead of the real one.
+ *
+ * Symbolic links are followed.
+ *
+ * @param[in]  name  Name of file or directory.
+ *
+ * @return 1 if file is executable, 0 if it is not.
+ */
+int
+gvm_file_is_executable (const char *name)
+{
+  return eaccess (name, X_OK) == 0;
+}
+
+/**
+ * @brief Checks whether a file or directory exists and is readable.
+ *
+ * Unlike g_file_test this checks the permissions based on the effective
+ *  UID and GID instead of the real one.
+ *
+ * Symbolic links are followed.
+ *
+ * @param[in]  name  Name of file or directory.
+ *
+ * @return 1 if file is readable, 0 if it is not.
+ */
+int
+gvm_file_is_readable (const char *name)
+{
+  return eaccess (name, R_OK) == 0;
+}
+
+/**
  * @brief Recursively removes files and directories.
  *
  * This function will recursively call itself to delete a path and any

--- a/util/fileutils.h
+++ b/util/fileutils.h
@@ -30,6 +30,15 @@
 #include <glib.h>
 
 int
+gvm_file_exists (const char *name);
+
+int
+gvm_file_is_executable (const char *name);
+
+int
+gvm_file_is_readable (const char *name);
+
+int
 gvm_file_check_is_dir (const char *name);
 
 int


### PR DESCRIPTION
**What**:
The new functions gvm_file_exists, gvm_file_is_executable and
gvm_file_is_readable are added as an alternative to g_file_test that
tests the file access according to the effective user and group ID
instead of the real one.

**Why**:
The change is required for gvmd to work properly with the file flags
to set the UID and GID

**How**:
I tested the functions with a small test program like this:
```c
#define _GNU_SOURCE

#include <stdio.h>
#include <unistd.h>
#include <gvm/util/fileutils.h>

int main ()
{
  const char *fname = "./test.txt";
  printf ("File: %s\n", fname);
  printf (" - exists: %d\n", gvm_file_exists (fname));
  printf (" - readable: %d\n", gvm_file_is_readable (fname));
  printf (" - executable: %d\n", gvm_file_is_executable (fname));
  printf ("eUID: %d, eGID: %d\n", geteuid(), getegid());
}
```
The cases I checked were:
* the file `test.txt` not existing
* the user running the test executable (without any special flags), owning the text file
* the user running the *not* having any permissions for text file
* running the executable as a user that normally has no permissions for the text file
 but setting the setuid and setgid flags of the executable so it is run as a user with
 access to the file.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
