### PR TITLE
Improve ARP ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)
 - Continuously send dead hosts to ospd-openvas to enable a smooth progess bar if only ICMP is chosen as alive test.  [#389](https://github.com/greenbone/gvm-libs/pull/389)
 - Retry if response via tls1.3 is still not received. [#394](https://github.com/greenbone/gvm-libs/pull/394)
+- Replace current implementation of alive test arp ping with version using libnet. [#423](https://github.com/greenbone/gvm-libs/pull/423)
 
 ### Removed
 - Remove handling of severity class from auth [#402](https://github.com/greenbone/gvm-libs/pull/402)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,7 @@ Specific development libraries:
 * libssh >= 0.6.0 (util)
 * libhiredis >= 0.10.1 (util)
 * libxml2 >= 2.0 (util)
+* libnet1 >= 1.1.2.1 (boreas)
 * libpcap
 * libgcrypt
 
@@ -48,7 +49,8 @@ Install prerequisites on Debian GNU/Linux 'Buster' 10:
     libssh-gcrypt-dev \
     libhiredis-dev \
     libxml2-dev \
-    libpcap-dev
+    libpcap-dev \
+    libnet1-dev
 
 
 Prerequisites for Optional Features

--- a/boreas/CMakeLists.txt
+++ b/boreas/CMakeLists.txt
@@ -113,7 +113,7 @@ set (LIBGVM_BOREAS_NAME
 
 add_executable (alivedetection-test
                 EXCLUDE_FROM_ALL
-                alivedetection_tests.c boreas_error.c boreas_io.c ping.c
+                alivedetection_tests.c arp.c boreas_error.c boreas_io.c ping.c
                 sniffer.c util.c)
 add_test (alivedetection-test alivedetection-test)
 target_include_directories (alivedetection-test PRIVATE ${CGREEN_INCLUDE_DIRS})
@@ -135,7 +135,7 @@ target_link_libraries (boreas_error-test
 
 add_executable (boreas_io-test
                 EXCLUDE_FROM_ALL
-                boreas_io_tests.c boreas_error.c alivedetection.c ping.c
+                arp.c boreas_io_tests.c boreas_error.c alivedetection.c ping.c
                 sniffer.c util.c)
 add_test (boreas_io-test boreas_io-test)
 target_include_directories (boreas_io-test PRIVATE ${CGREEN_INCLUDE_DIRS})
@@ -147,22 +147,22 @@ target_link_libraries (boreas_io-test gvm_base_shared gvm_util_shared
 
 add_executable (cli-test
                 EXCLUDE_FROM_ALL
-                cli_tests.c boreas_error.c boreas_io.c util.c)
+                arp.c cli_tests.c boreas_error.c boreas_io.c util.c)
 add_test (cli-test cli-test)
 target_include_directories (cli-test PRIVATE ${CGREEN_INCLUDE_DIRS})
 target_link_libraries (cli-test gvm_base_shared gvm_util_shared
                       ${CGREEN_LIBRARIES}
-                      ${GLIB_LDFLAGS}
+                      ${GLIB_LDFLAGS} ${PCAP_LDFLAGS} ${LIBNET_LDFLAGS}
                       ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable (ping-test
                 EXCLUDE_FROM_ALL
-                ping_tests.c util.c boreas_error.c)
+                ping_tests.c arp.c util.c boreas_error.c)
 add_test (ping-test ping-test)
 target_include_directories (ping-test PRIVATE ${CGREEN_INCLUDE_DIRS})
 target_link_libraries (ping-test gvm_base_shared
                        ${CGREEN_LIBRARIES}
-                       ${GLIB_LDFLAGS}
+                       ${GLIB_LDFLAGS} ${PCAP_LDFLAGS} ${LIBNET_LDFLAGS}
                        ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable (sniffer-test

--- a/boreas/CMakeLists.txt
+++ b/boreas/CMakeLists.txt
@@ -24,6 +24,29 @@ endif (NOT PKG_CONFIG_FOUND)
 
 ## Dependency checks
 
+message (STATUS "Looking for libnet...")
+find_library (NET net)
+message (STATUS "Looking for net... ${NET}")
+if (NOT NET)
+  message (SEND_ERROR "The net library is required.")
+endif (NOT NET)
+message (STATUS "Looking for libnet-config...")
+find_program (LIBNET_CONFIG libnet-config)
+
+if (LIBNET_CONFIG)
+  message (STATUS "Looking for libnet-config... ${LIBNET_CONFIG}")
+  execute_process (COMMAND libnet-config --libs
+    OUTPUT_VARIABLE LIBNET_LDFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process (COMMAND libnet-config --cflags
+    OUTPUT_VARIABLE LIBNET_CFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+else (LIBNET_CONFIG)
+  message (STATUS "libnet-config not found, using defaults...")
+  set (LIBNET_LDFLAGS "-L/usr/lib -lnet")
+  set (LIBNET_CFLAGS "-I/usr/include")
+endif (LIBNET_CONFIG)
+
 message (STATUS "Looking for pcap...")
 find_library (PCAP pcap)
 message (STATUS "Looking for pcap... ${PCAP}")
@@ -75,7 +98,11 @@ if (BUILD_SHARED)
   set_target_properties (gvm_boreas_shared PROPERTIES VERSION "${CPACK_PACKAGE_VERSION}")
   set_target_properties (gvm_boreas_shared PROPERTIES PUBLIC_HEADER "${HEADERS}")
 
-  target_link_libraries (gvm_boreas_shared LINK_PRIVATE ${GLIB_LDFLAGS} "-lnet" ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries (gvm_boreas_shared LINK_PRIVATE
+                         ${GLIB_LDFLAGS}
+                         ${LIBNET_LDFLAGS}
+                         ${LINKER_HARDENING_FLAGS}
+                         ${CMAKE_THREAD_LIBS_INIT})
 endif (BUILD_SHARED)
 
 set (LIBGVM_BOREAS_NAME
@@ -93,7 +120,7 @@ target_include_directories (alivedetection-test PRIVATE ${CGREEN_INCLUDE_DIRS})
 target_link_libraries (alivedetection-test gvm_base_shared gvm_util_shared
                        ${CGREEN_LIBRARIES}
                        ${GLIB_LDFLAGS}
-                       ${PCAP_LDFLAGS}
+                       ${PCAP_LDFLAGS} ${LIBNET_LDFLAGS}
                        ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable (boreas_error-test
@@ -113,7 +140,7 @@ add_executable (boreas_io-test
 add_test (boreas_io-test boreas_io-test)
 target_include_directories (boreas_io-test PRIVATE ${CGREEN_INCLUDE_DIRS})
 target_link_libraries (boreas_io-test gvm_base_shared gvm_util_shared
-                       ${PCAP_LDFLAGS}
+                       ${PCAP_LDFLAGS} ${LIBNET_LDFLAGS}
                        ${CGREEN_LIBRARIES}
                        ${GLIB_LDFLAGS}
                        ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
@@ -144,7 +171,7 @@ add_executable (sniffer-test
 add_test (sniffer-test sniffer-test)
 target_include_directories (sniffer-test PRIVATE ${CGREEN_INCLUDE_DIRS})
 target_link_libraries (sniffer-test gvm_base_shared gvm_util_shared
-                       ${PCAP_LDFLAGS}
+                       ${PCAP_LDFLAGS} ${LIBNET_LDFLAGS}
                        ${CGREEN_LIBRARIES}
                        ${GLIB_LDFLAGS}
                        ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})

--- a/boreas/CMakeLists.txt
+++ b/boreas/CMakeLists.txt
@@ -54,9 +54,9 @@ pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 
 include_directories (${GLIB_INCLUDE_DIRS})
 
-set (FILES alivedetection.c boreas_error.c boreas_io.c cli.c ping.c sniffer.c util.c)
+set (FILES alivedetection.c arp.c boreas_error.c boreas_io.c cli.c ping.c sniffer.c util.c)
 
-set (HEADERS alivedetection.h boreas_error.h boreas_io.h cli.h ping.h sniffer.h util.h)
+set (HEADERS alivedetection.h arp.h boreas_error.h boreas_io.h cli.h ping.h sniffer.h util.h)
 
 if (BUILD_STATIC)
   set (LIBGVM_BOREAS_NAME gvm_boreas_static)
@@ -75,7 +75,7 @@ if (BUILD_SHARED)
   set_target_properties (gvm_boreas_shared PROPERTIES VERSION "${CPACK_PACKAGE_VERSION}")
   set_target_properties (gvm_boreas_shared PROPERTIES PUBLIC_HEADER "${HEADERS}")
 
-  target_link_libraries (gvm_boreas_shared LINK_PRIVATE ${GLIB_LDFLAGS} ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries (gvm_boreas_shared LINK_PRIVATE ${GLIB_LDFLAGS} "-lnet" ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
 endif (BUILD_SHARED)
 
 set (LIBGVM_BOREAS_NAME

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -71,7 +71,7 @@ static const uint8_t ethnull[ETH_ALEN] = {0, 0, 0, 0, 0, 0};
 static const uint8_t ethxmas[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 static const char *ip_broadcast = "255.255.255.255";
 
-static const char *target = "Error";
+static char *target = "Error";
 
 /**
  * @brief Strip newline at end of string.
@@ -278,7 +278,7 @@ format_mac (const unsigned char *mac, char *buf, size_t bufsize)
 static void
 pingip_send ()
 {
-  static libnet_ptag_t arp = 0, eth = 0;
+  libnet_ptag_t arp = 0, eth = 0;
 
   // Padding size chosen fairly arbitrarily.
   // Without this padding some systems (e.g. Raspberry Pi 3
@@ -344,8 +344,7 @@ send_arp_v4 (const char *dst_str)
                  __func__, dst_str);
       return;
     }
-  dst_str = strdup (libnet_addr2name4 (dstip, 0));
-  target = dst_str;
+  target = g_strdup (libnet_addr2name4 (dstip, 0));
 
   /* Get some good iface. */
   if (!ifname)
@@ -417,4 +416,8 @@ send_arp_v4 (const char *dst_str)
   g_debug ("ARP PING %s", dst_str);
 
   pingip_send ();
+
+  g_free (target);
+  /* Set target to some error string again. */
+  target = "Error";
 }

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -241,9 +241,6 @@ arp_lookupdev (uint32_t dstip, char *ebuf)
     }
   else
     {
-      g_debug ("%s: Failed to find iface using"
-               " getifaddrs().",
-               __func__);
       snprintf (ebuf, LIBNET_ERRBUF_SIZE,
                 "No matching interface found using getifaddrs().");
     }
@@ -357,8 +354,8 @@ send_arp_v4 (const char *dst_str)
         {
           memcpy (ifname_default, alldevsp->name, IF_NAMESIZE);
           pcap_freealldevs (alldevsp);
-          g_warning ("%s: Set default interface via pcap_findalldevs(): %s",
-                     __func__, ifname_default);
+          g_debug ("%s: Set default interface via pcap_findalldevs(): %s",
+                   __func__, ifname_default);
         }
     }
 
@@ -378,20 +375,14 @@ send_arp_v4 (const char *dst_str)
       strip_newline (ebuf);
       if (!ifname)
         {
-          g_debug ("%s: lookup dev: %s", __func__, ebuf);
+          g_debug ("%s: %s Trying to use guessed interface instead.", __func__,
+                   ebuf);
         }
       if (!ifname)
         {
           /* Only set ifname if ifname_default str is not empty. */
           if (*ifname_default)
             ifname = ifname_default;
-
-          if (ifname)
-            {
-              g_debug ("%s: Unable to automatically find interface to use. "
-                       "Use Guessed default interface %s.",
-                       __func__, ifname);
-            }
         }
       if (!ifname)
         {
@@ -438,11 +429,9 @@ send_arp_v4 (const char *dst_str)
         }
     }
 
-  g_debug ("%s: This box: Interface: %s  IP: %s   MAC address: %s", __func__,
-           ifname, libnet_addr2name4 (libnet_get_ipaddr4 (libnet), 0),
+  g_debug ("%s: Ping %s   Interface: %s   Src IP: %s   Src MAC: %s", __func__,
+           dst_str, ifname, libnet_addr2name4 (libnet_get_ipaddr4 (libnet), 0),
            format_mac (srcmac, mac_debug_buf, sizeof (mac_debug_buf)));
-
-  g_debug ("ARP PING %s", dst_str);
 
   pingip_send ();
   libnet_clear_packet (libnet);

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -1,0 +1,419 @@
+/* Portions Copyright (C) 2021 Greenbone Networks GmbH
+ * Based on work Copyright (C) Thomas Habets <thomas@habets.se>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * @file
+ * @brief implementation of arp ping.
+ *
+ * Most of the functions are modified versions of functions found in 
+ * https://github.com/ThomasHabets/arping/tree/arping-2.19/src.
+ */
+
+#include "arp.h"
+
+#include "../base/networking.h" /* for gvm_source_addr() */
+
+#include <errno.h>
+#include <glib.h>
+#include <ifaddrs.h>
+#include <libnet.h>
+#include <limits.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <pcap.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
+#endif
+
+#ifndef IP_ALEN
+#define IP_ALEN 4
+#endif
+
+libnet_t *libnet = 0;
+
+uint32_t dstip;                  /* target IP */
+static uint8_t dstmac[ETH_ALEN]; /* ethxmas */
+
+/* autodetected, overriden by gvm_source_addr if openvas source_iface was set*/
+uint32_t srcip;
+static uint8_t srcmac[ETH_ALEN]; /* autodetected */
+
+static const uint8_t ethnull[ETH_ALEN] = {0, 0, 0, 0, 0, 0};
+static const uint8_t ethxmas[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+static const char *ip_broadcast = "255.255.255.255";
+
+static int send_reply = 0;  /* Send reply instead of request */
+static int unsolicited = 0; /* Use unsolicited ARP */
+
+static const char *target = "Error";
+
+/**
+ * @brief Strip newline at end of string.
+ *
+ * Some Libnet error messages end with a newline. Strip that in place.
+ *
+ * @param s String to strip newline from.
+ */
+static void
+strip_newline (char *s)
+{
+  size_t n;
+  for (n = strlen (s); n && (s[n - 1] == '\n'); --n)
+    {
+      s[n - 1] = 0;
+    }
+}
+
+/**
+ * @brief Init libnet.
+ *
+ * Init libnet with specified ifname. Destroy if already inited.
+ * If this function retries with different parameter it will preserve
+ * the original error message and print that.
+ * Call with recursive=0.
+ *
+ * @param ifname    Interface name to use
+ * @param recursive Only used inside do_libnet_init. Use 0.
+ *
+ * @return -1 on failure, 0 on success.
+ */
+static int
+do_libnet_init (const char *ifname, int recursive)
+{
+  char ebuf[LIBNET_ERRBUF_SIZE];
+  ebuf[0] = 0;
+  g_debug ("%s: libnet_init(%s)", __func__, ifname ? ifname : "<null>");
+  if (libnet)
+    {
+      /* Probably going to switch interface from temp to real. */
+      libnet_destroy (libnet);
+      libnet = 0;
+    }
+
+  /* Try libnet_init() even though we aren't root. We may have
+   * a capability or something. */
+  if (!(libnet = libnet_init (LIBNET_LINK, (char *) ifname, ebuf)))
+    {
+      strip_newline (ebuf);
+      if (!ifname)
+        {
+          /* Sometimes libnet guesses an interface that it then
+           * can't use. Work around that by attempting to
+           * use "lo". */
+          do_libnet_init ("lo", 1);
+          if (libnet != NULL)
+            {
+              return 0;
+            }
+        }
+      else if (recursive)
+        {
+          /* Continue original execution to get that
+           * error message. */
+          return 0;
+        }
+      g_debug ("%s: libnet_init(LIBNET_LINK, %s): %s", __func__,
+               ifname ? ifname : "<null>", ebuf);
+      if (getuid () && geteuid ())
+        {
+          g_warning ("%s: you may need to run as root", __func__);
+        }
+      return -1;
+    }
+  return 0;
+}
+
+/**
+ * @brief Resolve address.
+ *
+ * @param[in]   l     libnet_t.
+ * @param[in]   name  IP string or addr name.
+ * @param[out]  addr  Resolved ipv4 addr.
+ *
+ * @return 1 on success, 0 on failure.
+ */
+static int
+xresolve (libnet_t *l, const char *name, int r, uint32_t *addr)
+{
+  if (!strcmp (ip_broadcast, name))
+    {
+      *addr = 0xffffffff;
+      return 1;
+    }
+  *addr = libnet_name2addr4 (l, (char *) name, r);
+  return *addr != 0xffffffff;
+}
+
+/**
+ * @brief Find interface to use for a given destination.
+ *
+ * @param dstip   Destination IP.
+ * @param ebuf    Buffer to store error message in.
+ *
+ * @return Interface or NULL if no interface found.
+ */
+static const char *
+arping_lookupdev (uint32_t dstip, char *ebuf)
+{
+  struct ifaddrs *ifa = NULL;
+  struct ifaddrs *cur;
+  const char *ret = NULL;
+  int match_count = 0; /* Matching interfaces */
+
+  /* best match */
+  in_addr_t best_mask = 0;
+
+  /* Results */
+  static char ifname[IFNAMSIZ];
+
+  *ebuf = 0;
+
+  if (getifaddrs (&ifa))
+    {
+      g_debug ("%s: getifaddrs(): %s", __func__, strerror (errno));
+      snprintf (ebuf, LIBNET_ERRBUF_SIZE, "getifaddrs(): %s", strerror (errno));
+      goto out;
+    }
+  for (cur = ifa; cur; cur = cur->ifa_next)
+    {
+      in_addr_t addr, mask;
+
+      if (!(cur->ifa_flags & IFF_UP))
+        {
+          continue;
+        }
+      if (!cur->ifa_addr || !cur->ifa_netmask || !cur->ifa_name)
+        {
+          continue;
+        }
+      if (cur->ifa_addr->sa_family != AF_INET)
+        {
+          continue;
+        }
+      if (cur->ifa_flags & (IFF_LOOPBACK | IFF_POINTOPOINT))
+        {
+          continue;
+        }
+      addr = ((struct sockaddr_in *) cur->ifa_addr)->sin_addr.s_addr;
+      mask = ((struct sockaddr_in *) cur->ifa_netmask)->sin_addr.s_addr;
+      if ((addr & mask) != (dstip & mask))
+        {
+          continue;
+        }
+      match_count++;
+      if (ntohl (mask) > ntohl (best_mask))
+        {
+          memset (ifname, 0, sizeof (ifname));
+          strncpy (ifname, cur->ifa_name, sizeof (ifname) - 1);
+          best_mask = mask;
+        }
+    }
+  if (match_count)
+    {
+      ret = ifname;
+      g_debug ("%s: Autodetected interface %s", __func__, ret);
+    }
+  else
+    {
+      g_debug ("%s: Failed to find iface using"
+               " getifaddrs().",
+               __func__);
+      snprintf (ebuf, LIBNET_ERRBUF_SIZE,
+                "No matching interface found using getifaddrs().");
+    }
+out:
+  if (ifa)
+    {
+      freeifaddrs (ifa);
+    }
+  return ret;
+}
+
+/**
+ * @brief Format a MAC address to human readable format.
+ *
+ * @param[in] mac   MAC to format.
+ * @param[in] buf   Buffer to store formatted MAC in.
+ * @param[in] bufze Size of Buffer.
+ *
+ * @return Formatted MAC string stored in buf.
+ */
+static char *
+format_mac (const unsigned char *mac, char *buf, size_t bufsize)
+{
+  snprintf (buf, bufsize, "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x", mac[0], mac[1],
+            mac[2], mac[3], mac[4], mac[5]);
+  return buf;
+}
+
+/**
+ * @brief  Send ARP who-has.
+ */
+static void
+pingip_send ()
+{
+  static libnet_ptag_t arp = 0, eth = 0;
+
+  // Padding size chosen fairly arbitrarily.
+  // Without this padding some systems (e.g. Raspberry Pi 3
+  // wireless interface) failed. dmesg said:
+  //   arping: packet size is too short (42 <= 50)
+  const uint8_t padding[16] = {0};
+
+  if (-1
+      == (arp = libnet_build_arp (
+            ARPHRD_ETHER, ETHERTYPE_IP, ETH_ALEN, IP_ALEN,
+            send_reply ? ARPOP_REPLY : ARPOP_REQUEST, srcmac,
+            (uint8_t *) &srcip,
+            unsolicited ? (uint8_t *) ethxmas : (uint8_t *) ethnull,
+            (uint8_t *) &dstip, padding, sizeof padding, libnet, arp)))
+    {
+      g_warning ("%s: libnet_build_arp(): %s", __func__,
+                 libnet_geterror (libnet));
+    }
+
+  eth = libnet_build_ethernet (dstmac, srcmac, ETHERTYPE_ARP,
+                               NULL, // payload
+                               0,    // payload size
+                               libnet, eth);
+  if (-1 == eth)
+    {
+      g_warning ("%s: %s: %s", __func__, "libnet_build_ethernet()",
+                 libnet_geterror (libnet));
+    }
+  if (-1 == libnet_write (libnet))
+    {
+      g_warning ("%s: libnet_write(): %s", __func__, libnet_geterror (libnet));
+    }
+}
+
+/**
+ * @brief Send arp ping using libnet.
+ *
+ * @param dst Destination address as string.
+ *
+ */
+void
+send_arp_v4 (const char *dst_str)
+{
+  char ebuf[LIBNET_ERRBUF_SIZE + PCAP_ERRBUF_SIZE];
+  char *cp;
+  const char *ifname = NULL;
+
+  ebuf[0] = 0;
+
+  /* set globals */
+  srcip = 0;
+  dstip = 0xffffffff;
+  memcpy (dstmac, ethxmas, ETH_ALEN);
+
+  /* set src IP if we have global openvas src ip */
+  gvm_source_addr (&srcip);
+
+  /* libnet init */
+  do_libnet_init (ifname, 0);
+
+  /* Make sure dstip and dst_str like eachother */
+  if (!xresolve (libnet, dst_str, LIBNET_RESOLVE, &dstip))
+    {
+      g_warning ("%s: Can't resolve %s. No ARP ping done for this addr.",
+                 __func__, dst_str);
+      return;
+    }
+  dst_str = strdup (libnet_addr2name4 (dstip, 0));
+  target = dst_str;
+
+  /* Get some good iface. */
+  if (!ifname)
+    {
+      ifname = arping_lookupdev (dstip, ebuf);
+      strip_newline (ebuf);
+      if (!ifname)
+        {
+          g_warning ("%s: lookup dev: %s", __func__, ebuf);
+        }
+      if (!ifname)
+        {
+          ifname = pcap_lookupdev (ebuf);
+          strip_newline (ebuf);
+          if (ifname)
+            {
+              g_warning ("%s: Unable to automatically find "
+                         "interface to use."
+                         "Guessing interface %s.",
+                         __func__, ifname);
+            }
+        }
+      if (!ifname)
+        {
+          g_warning ("%s: Gave up looking for interface"
+                     " to use: %s. Address '%s' will be skipped.",
+                     __func__, ebuf, target);
+          return;
+        }
+      /* check for other probably-not interfaces */
+      if (!strcmp (ifname, "ipsec") || !strcmp (ifname, "lo"))
+        {
+          g_warning ("%s: %s looks like the wrong "
+                     "interface to use. Using it anyway this time.",
+                     __func__, ifname);
+        }
+    }
+
+  /*
+   * Init libnet again, because we now know the interface name.
+   * We should know it by know at least
+   */
+  do_libnet_init (ifname, 0);
+
+  if (!(cp = (char *) libnet_get_hwaddr (libnet)))
+    {
+      g_warning ("%s: libnet_get_hwaddr(): %s. Address '%s' will be skipped.",
+                 __func__, libnet_geterror (libnet), target);
+      return;
+    }
+  memcpy (srcmac, cp, ETH_ALEN);
+
+  if (srcip != INADDR_ANY)
+    {
+      if ((uint32_t) -1 == (srcip = libnet_get_ipaddr4 (libnet)))
+        {
+          g_warning ("%s: Unable to get the IPv4 address of "
+                     "interface %s: %s. Address '%s' will be skipped.",
+                     __func__, ifname, libnet_geterror (libnet), target);
+          return;
+        }
+    }
+
+  char buf[128];
+  g_debug ("%s: This box: Interface: %s  IP: %s   MAC address: %s", __func__,
+           ifname, libnet_addr2name4 (libnet_get_ipaddr4 (libnet), 0),
+           format_mac (srcmac, buf, sizeof (buf)));
+
+  g_debug ("ARP PING %s", dst_str);
+
+  pingip_send ();
+}

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -52,6 +52,12 @@
 #define IP_ALEN 4
 #endif
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "alive scan"
+
 libnet_t *libnet = 0;
 
 uint32_t dstip;                  /* target IP */
@@ -173,7 +179,7 @@ xresolve (libnet_t *l, const char *name, int r, uint32_t *addr)
  * @return Interface or NULL if no interface found.
  */
 static const char *
-arping_lookupdev (uint32_t dstip, char *ebuf)
+arp_lookupdev (uint32_t dstip, char *ebuf)
 {
   struct ifaddrs *ifa = NULL;
   struct ifaddrs *cur;
@@ -344,7 +350,7 @@ send_arp_v4 (const char *dst_str)
   /* Get some good iface. */
   if (!ifname)
     {
-      ifname = arping_lookupdev (dstip, ebuf);
+      ifname = arp_lookupdev (dstip, ebuf);
       strip_newline (ebuf);
       if (!ifname)
         {

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -22,7 +22,7 @@
  * @file
  * @brief implementation of arp ping.
  *
- * Most of the functions are modified versions of functions found in 
+ * Most of the functions are modified versions of functions found in
  * https://github.com/ThomasHabets/arping/tree/arping-2.19/src.
  */
 
@@ -64,9 +64,6 @@ static uint8_t srcmac[ETH_ALEN]; /* autodetected */
 static const uint8_t ethnull[ETH_ALEN] = {0, 0, 0, 0, 0, 0};
 static const uint8_t ethxmas[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 static const char *ip_broadcast = "255.255.255.255";
-
-static int send_reply = 0;  /* Send reply instead of request */
-static int unsolicited = 0; /* Use unsolicited ARP */
 
 static const char *target = "Error";
 
@@ -284,12 +281,10 @@ pingip_send ()
   const uint8_t padding[16] = {0};
 
   if (-1
-      == (arp = libnet_build_arp (
-            ARPHRD_ETHER, ETHERTYPE_IP, ETH_ALEN, IP_ALEN,
-            send_reply ? ARPOP_REPLY : ARPOP_REQUEST, srcmac,
-            (uint8_t *) &srcip,
-            unsolicited ? (uint8_t *) ethxmas : (uint8_t *) ethnull,
-            (uint8_t *) &dstip, padding, sizeof padding, libnet, arp)))
+      == (arp = libnet_build_arp (ARPHRD_ETHER, ETHERTYPE_IP, ETH_ALEN, IP_ALEN,
+                                  ARPOP_REQUEST, srcmac, (uint8_t *) &srcip,
+                                  (uint8_t *) ethnull, (uint8_t *) &dstip,
+                                  padding, sizeof padding, libnet, arp)))
     {
       g_warning ("%s: libnet_build_arp(): %s", __func__,
                  libnet_geterror (libnet));

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -425,6 +425,7 @@ send_arp_v4 (const char *dst_str)
   g_debug ("ARP PING %s", dst_str);
 
   pingip_send ();
+  libnet_clear_packet (libnet);
 
   g_free (target);
 }

--- a/boreas/arp.h
+++ b/boreas/arp.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2021 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef ARP_H
+#define ARP_H
+
+void
+send_arp_v4 (const char *parm);
+
+#endif /* not ARP_H */

--- a/boreas/arp.h
+++ b/boreas/arp.h
@@ -21,6 +21,6 @@
 #define ARP_H
 
 void
-send_arp_v4 (const char *parm);
+send_arp_v4 (const char *);
 
 #endif /* not ARP_H */

--- a/boreas/ping.c
+++ b/boreas/ping.c
@@ -19,21 +19,18 @@
 
 #include "ping.h"
 
-#include "../base/networking.h" /* for gvm_routethrough() */
+#include "arp.h"
 #include "util.h"
 
 #include <arpa/inet.h>
 #include <errno.h>
 #include <glib.h>
 #include <ifaddrs.h> /* for getifaddrs() */
-#include <net/ethernet.h>
-#include <net/if.h> /* for if_nametoindex() */
 #include <netinet/icmp6.h>
 #include <netinet/in.h>
 #include <netinet/ip6.h>
 #include <netinet/ip_icmp.h>
 #include <netinet/tcp.h>
-#include <netpacket/packet.h> /* for sockaddr_ll */
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -66,19 +63,6 @@ struct pseudohdr
   u_char protocol;
   u_short length;
   struct tcphdr tcpheader;
-};
-
-struct arp_hdr
-{
-  uint16_t htype;
-  uint16_t ptype;
-  uint8_t hlen;
-  uint8_t plen;
-  uint16_t opcode;
-  uint8_t sender_mac[6];
-  uint8_t sender_ip[4];
-  uint8_t target_mac[6];
-  uint8_t target_ip[4];
 };
 
 /**
@@ -437,125 +421,6 @@ send_tcp (gpointer key, gpointer value, gpointer scanner_p)
 }
 
 /**
- * @brief Send arp ping.
- *
- * @param soc Socket to use for sending.
- * @param dst Destination address to send to.
- */
-static void
-send_arp_v4 (int soc, struct in_addr *dst_p)
-{
-  struct sockaddr_ll soca;
-  struct arp_hdr arphdr;
-  int frame_length;
-  uint8_t *ether_frame;
-
-  static gboolean first_time_setup_done = FALSE;
-  static struct in_addr src;
-  static int ifaceindex;
-  static uint8_t src_mac[6];
-  static uint8_t dst_mac[6];
-
-  memset (&soca, 0, sizeof (soca));
-
-  /* Set up data which does not change between function calls. */
-  if (!first_time_setup_done)
-    {
-      struct sockaddr_storage storage_src;
-      struct sockaddr_storage storage_dst;
-      struct sockaddr_in sin_src;
-      struct sockaddr_in sin_dst;
-
-      memset (&sin_src, 0, sizeof (struct sockaddr_in));
-      memset (&sin_dst, 0, sizeof (struct sockaddr_in));
-      sin_src.sin_family = AF_INET;
-      sin_dst.sin_family = AF_INET;
-      sin_dst.sin_addr = *dst_p;
-      memcpy (&storage_dst, &sin_dst, sizeof (sin_dst));
-      memcpy (&storage_src, &sin_src, sizeof (sin_src));
-
-      /* Get interface and set src addr. */
-      g_debug ("%s: Destination addr: %s", __func__, inet_ntoa (*dst_p));
-      gchar *interface = gvm_routethrough (&storage_dst, &storage_src);
-      if (!interface)
-        {
-          g_warning ("%s: No appropriate interface was found. Network may be "
-                     "unreachable. No ARP ping send for host %s.",
-                     __func__, inet_ntoa (*dst_p));
-          return;
-        }
-      g_debug ("%s: interface to use: %s", __func__, interface);
-      memcpy (&src, &((struct sockaddr_in *) (&storage_src))->sin_addr,
-              sizeof (struct in_addr));
-      g_debug ("%s: Source addr: %s", __func__, inet_ntoa (src));
-
-      /* Get interface index for sockaddr_ll. */
-      if ((ifaceindex = if_nametoindex (interface)) == 0)
-        g_warning ("%s: if_nametoindex: %s", __func__, strerror (errno));
-
-      /* Set MAC addresses. */
-      memset (src_mac, 0, 6 * sizeof (uint8_t));
-      memset (dst_mac, 0xff, 6 * sizeof (uint8_t));
-      if (get_source_mac_addr (interface, (unsigned char *) src_mac) != 0)
-        g_warning ("%s: get_source_mac_addr() returned error", __func__);
-
-      g_debug ("%s: Source MAC address: %02x:%02x:%02x:%02x:%02x:%02x",
-               __func__, src_mac[0], src_mac[1], src_mac[2], src_mac[3],
-               src_mac[4], src_mac[5]);
-      g_debug ("%s: Destination mac address: %02x:%02x:%02x:%02x:%02x:%02x",
-               __func__, dst_mac[0], dst_mac[1], dst_mac[2], dst_mac[3],
-               dst_mac[4], dst_mac[5]);
-
-      first_time_setup_done = TRUE;
-    }
-
-  /* Fill in sockaddr_ll.*/
-  soca.sll_ifindex = ifaceindex;
-  soca.sll_family = AF_PACKET;
-  memcpy (soca.sll_addr, src_mac, 6 * sizeof (uint8_t));
-  soca.sll_halen = 6;
-
-  /* Fill ARP header.*/
-  /* IP addresses. */
-  memcpy (&arphdr.target_ip, dst_p, 4 * sizeof (uint8_t));
-  memcpy (&arphdr.sender_ip, &src, 4 * sizeof (uint8_t));
-  /* Hardware type ethernet.
-   * Protocol type IP.
-   * Hardware address length is MAC address length.
-   * Protocol address length is length of IPv4.
-   * OpCode is ARP request. */
-  arphdr.htype = htons (1);
-  arphdr.ptype = htons (ETH_P_IP);
-  arphdr.hlen = 6;
-  arphdr.plen = 4;
-  arphdr.opcode = htons (1);
-  memcpy (&arphdr.sender_mac, src_mac, 6 * sizeof (uint8_t));
-  memset (&arphdr.target_mac, 0, 6 * sizeof (uint8_t));
-
-  /* Ethernet frame to send. */
-  ether_frame = g_malloc0 (IP_MAXPACKET);
-  /* (MAC + MAC + ethernet type + ARP_HDRLEN) */
-  frame_length = 6 + 6 + 2 + 28;
-
-  memcpy (ether_frame, dst_mac, 6 * sizeof (uint8_t));
-  memcpy (ether_frame + 6, src_mac, 6 * sizeof (uint8_t));
-  /* ethernet type code */
-  ether_frame[12] = ETH_P_ARP / 256;
-  ether_frame[13] = ETH_P_ARP % 256;
-  /* ARP header.  ETH_HDRLEN = 14, ARP_HDRLEN = 28 */
-  memcpy (ether_frame + 14, &arphdr, 28 * sizeof (uint8_t));
-
-  if ((sendto (soc, ether_frame, frame_length, MSG_NOSIGNAL,
-               (struct sockaddr *) &soca, sizeof (soca)))
-      <= 0)
-    g_warning ("%s: sendto(): %s", __func__, strerror (errno));
-
-  g_free (ether_frame);
-
-  return;
-}
-
-/**
  * @brief Is called in g_hash_table_foreach(). Check if ipv6 or ipv4, get
  * correct socket and start appropriate ping function.
  *
@@ -569,8 +434,6 @@ send_arp (gpointer key, gpointer value, gpointer scanner_p)
   struct scanner *scanner;
   struct in6_addr dst6;
   struct in6_addr *dst6_p = &dst6;
-  struct in_addr dst4;
-  struct in_addr *dst4_p = &dst4;
   static int count = 0;
 
   scanner = (struct scanner *) scanner_p;
@@ -597,7 +460,6 @@ send_arp (gpointer key, gpointer value, gpointer scanner_p)
     }
   else
     {
-      dst4.s_addr = dst6_p->s6_addr32[3];
-      send_arp_v4 (scanner->arpv4soc, dst4_p);
+      send_arp_v4 (key);
     }
 }


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Use libnet for arp ping for alive detection.

**Why**:

<!-- Why are these changes necessary? -->

Robust implementation of arp ping as it was not stable before. The arp ping is part of the experimental (currently default off) alive detection feature.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Can be tested with cli front-end for the alive test https://github.com/greenbone/boreas/ and do some scans with it. 

`sudo boreas --target "0:0:0:0:0:ffff:c0a8:384b,192.168.42.42" --arp`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
