### PR TITLE
Add throttle functionality for sending pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Increase minimum gpgme version [#405](https://github.com/greenbone/gvm-libs/pull/405)
 - Always NULL check ifaddrs->ifa_addr [#416](https://github.com/greenbone/gvm-libs/pull/416)
 - Correct g_hash_table_remove arg [#419](https://github.com/greenbone/gvm-libs/pull/419)
-- Accept underscore as valid char in hostname strings [#429](https://github.com/greenbone/gvm-libs/pull/429)
+- Accept underscore as valid char in hostname strings [#430](https://github.com/greenbone/gvm-libs/pull/430)
+- Add throttle for pinging with test_alive_hosts_only feature when socket buffer is full. [#429](https://github.com/greenbone/gvm-libs/pull/429)
 
 [20.8.1]: https://github.com/greenbone/gvm-libs/compare/v20.8.0...gvm-libs-20.08
 

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -94,6 +94,8 @@ scan (alive_test_t alive_test)
       g_debug ("%s: ICMP Ping", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_icmp,
                             &scanner);
+      wait_until_so_sndbuf_empty (scanner.icmpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner.icmpv6soc, 10);
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_TCP_SYN_SERVICE)
@@ -102,6 +104,8 @@ scan (alive_test_t alive_test)
       scanner.tcp_flag = TH_SYN; /* SYN */
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_tcp,
                             &scanner);
+      wait_until_so_sndbuf_empty (scanner.tcpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner.tcpv6soc, 10);
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_TCP_ACK_SERVICE)
@@ -110,6 +114,8 @@ scan (alive_test_t alive_test)
       scanner.tcp_flag = TH_ACK; /* ACK */
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_tcp,
                             &scanner);
+      wait_until_so_sndbuf_empty (scanner.tcpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner.tcpv6soc, 10);
       usleep (500000);
     }
   if (alive_test & ALIVE_TEST_ARP)
@@ -117,6 +123,8 @@ scan (alive_test_t alive_test)
       g_debug ("%s: ARP Ping", __func__);
       g_hash_table_foreach (scanner.hosts_data->targethosts, send_arp,
                             &scanner);
+      wait_until_so_sndbuf_empty (scanner.arpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner.arpv6soc, 10);
     }
   if (alive_test & ALIVE_TEST_CONSIDER_ALIVE)
     {

--- a/boreas/cli.c
+++ b/boreas/cli.c
@@ -120,6 +120,8 @@ run_cli_scan (struct scanner *scanner, alive_test_t alive_test)
     {
       g_hash_table_foreach (scanner->hosts_data->targethosts, send_icmp,
                             scanner);
+      wait_until_so_sndbuf_empty (scanner->icmpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner->icmpv6soc, 10);
       usleep (500000);
     }
   if (alive_test & (ALIVE_TEST_TCP_SYN_SERVICE))
@@ -127,6 +129,8 @@ run_cli_scan (struct scanner *scanner, alive_test_t alive_test)
       scanner->tcp_flag = 0x02; /* SYN */
       g_hash_table_foreach (scanner->hosts_data->targethosts, send_tcp,
                             scanner);
+      wait_until_so_sndbuf_empty (scanner->tcpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner->tcpv6soc, 10);
       usleep (500000);
     }
   if (alive_test & (ALIVE_TEST_TCP_ACK_SERVICE))
@@ -134,12 +138,17 @@ run_cli_scan (struct scanner *scanner, alive_test_t alive_test)
       scanner->tcp_flag = 0x10; /* ACK */
       g_hash_table_foreach (scanner->hosts_data->targethosts, send_tcp,
                             scanner);
+      wait_until_so_sndbuf_empty (scanner->tcpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner->tcpv6soc, 10);
       usleep (500000);
     }
   if (alive_test & (ALIVE_TEST_ARP))
     {
       g_hash_table_foreach (scanner->hosts_data->targethosts, send_arp,
                             scanner);
+      wait_until_so_sndbuf_empty (scanner->arpv4soc, 10);
+      wait_until_so_sndbuf_empty (scanner->arpv6soc, 10);
+      usleep (500000);
     }
 
   sleep (WAIT_FOR_REPLIES_TIMEOUT);

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -24,11 +24,13 @@
 #include <errno.h>
 #include <glib.h>
 #include <ifaddrs.h> /* for getifaddrs() */
+#include <linux/sockios.h>
 #include <net/ethernet.h>
 #include <net/if.h>           /* for if_nametoindex() */
 #include <netpacket/packet.h> /* for sockaddr_ll */
 #include <stdlib.h>
 #include <string.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -308,7 +310,6 @@ fill_ports_array (gpointer range, gpointer ports_array)
     }
   else
     {
-
       for (i = range_start; i <= range_end; i++)
         {
           port_sized = (uint16_t) i;
@@ -613,4 +614,46 @@ count_difference (GHashTable *hashtable_A, GHashTable *hashtable_B)
     }
 
   return count;
+}
+
+/**
+ * @brief Check if socket send buffer is empty.
+ *
+ * @param[in] soc Socket.
+ * @param[out] err Set to -1 on error.
+ *
+ * @return 1 if so_sndbug is empyt, else 0.
+ */
+static int
+so_sndbuf_empty (int soc, int *err)
+{
+  int cur_so_sendbuf = -1;
+  if (ioctl (soc, SIOCOUTQ, &cur_so_sendbuf) == -1)
+    {
+      g_warning ("%s: ioctl error: %s", __func__, strerror (errno));
+      *err = -1;
+      return 0;
+    }
+  return cur_so_sendbuf ? 0 : 1;
+}
+
+/**
+ * @brief Wait until socket send buffer empty or timeout reached.
+ *
+ * @param soc     Socket.
+ * @param timout  Timeout in seconds.
+ */
+void
+wait_until_so_sndbuf_empty (int soc, int timeout)
+{
+  int cnt = 0;
+  int err = 0;
+  int empty;
+
+  empty = so_sndbuf_empty (soc, &err);
+  for (; !empty && (err != -1) && (cnt / 10 != timeout);
+       empty = so_sndbuf_empty (soc, &err), cnt++)
+    {
+      usleep (100000);
+    }
 }

--- a/boreas/util.h
+++ b/boreas/util.h
@@ -45,6 +45,9 @@ set_all_needed_sockets (struct scanner *, alive_test_t);
 boreas_error_t
 close_all_needed_sockets (struct scanner *, alive_test_t);
 
+void
+wait_until_so_sndbuf_empty (int, int);
+
 /* Misc hashtable functions. */
 
 int


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Make sure that we do no try to send when the SO_SNDBUF is already full.

**Why**:

<!-- Why are these changes necessary? -->

Packets might not be sent if no buffer space is available.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Disabale rate limit by setting BURST_TIMEOUT to 0 (needs recompile) and use `tc` to limit bandwidth e.g. ``sudo tc qdisc add dev <iface> root tbf rate 500kbit burst 32kbit latency 400ms`` and use boreas (https://github.com/greenbone/boreas/) `sudo boreas --target "198.18.0.0/15,172.16.0.0/12,192.168.0.0/16" --icmp`.

Before the patch you would see a lot of `sendto(): No buffer space available`. After the patch they are gone.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
