### PR TITLE
Accept underscore as valid char in hostname strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Increase minimum gpgme version [#405](https://github.com/greenbone/gvm-libs/pull/405)
 - Always NULL check ifaddrs->ifa_addr [#416](https://github.com/greenbone/gvm-libs/pull/416)
 - Correct g_hash_table_remove arg [#419](https://github.com/greenbone/gvm-libs/pull/419)
+- Accept underscore as valid char in hostname strings [#429](https://github.com/greenbone/gvm-libs/pull/429)
 
 [20.8.1]: https://github.com/greenbone/gvm-libs/compare/v20.8.0...gvm-libs-20.08
 

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -454,7 +454,7 @@ is_hostname (const char *str)
 
   point = split;
   while (*point)
-    if (g_regex_match_simple ("^(?!-)[a-z0-9-]{1,63}(?<!-)$", *point,
+    if (g_regex_match_simple ("^(?!-)[a-z0-9_-]{1,63}(?<!-)$", *point,
                               G_REGEX_CASELESS, 0)
         == 0)
       {

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -65,6 +65,10 @@ Ensure (hosts, gvm_get_host_type_returns_host_type_hostname)
 {
   assert_that (gvm_get_host_type ("www.greenbone.net"),
                is_equal_to (HOST_TYPE_NAME));
+  assert_that (gvm_get_host_type ("www.example_underscore.net"),
+               is_equal_to (HOST_TYPE_NAME));
+  assert_that (gvm_get_host_type ("www.example-dash.net"),
+               is_equal_to (HOST_TYPE_NAME));
   assert_that (gvm_get_host_type ("greenbone.net"),
                is_equal_to (HOST_TYPE_NAME));
   assert_that (gvm_get_host_type ("g"), is_equal_to (HOST_TYPE_NAME));


### PR DESCRIPTION
**What**:
Accept underscore as valid char in hostname strings
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Underscore is allowed for domain names, but not for hostnames. Despite it is not recommended at all, it can be desirable to use it. Under the premise "the scanner must do the best it can" it is now allowed.
RFC for hostnames: https://tools.ietf.org/html/rfc819
RFC for domain name syntax https://tools.ietf.org/html/rfc2181

<!-- Why are these changes necessary? -->

**How**:
Scan a target which includes a host with an underscore in the name
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
