### PR TITLE
Fixing clang compiler warning, because of double parentheses

### DIFF
--- a/base/networking.c
+++ b/base/networking.c
@@ -651,7 +651,7 @@ port_range_ranges (const char *port_range)
 
       if (element_strlen >= 2)
         {
-          if ((element[0] == 'T'))
+          if (element[0] == 'T')
             {
               element++;
               while (*element && isblank (*element))
@@ -662,7 +662,7 @@ port_range_ranges (const char *port_range)
                   tcp = 1;
                 }
             }
-          else if ((element[0] == 'U'))
+          else if (element[0] == 'U')
             {
               element++;
               while (*element && isblank (*element))


### PR DESCRIPTION
**What**:

* Fixing the warning in #434 .
* tested with clang-7 and gcc-8

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
