### PR TITLE
Fix typos.

### DIFF
--- a/boreas/ping.c
+++ b/boreas/ping.c
@@ -89,7 +89,7 @@ struct arp_hdr
  * @param[in]   soc         The socket to get the send buffer for.
  * @param[out]  so_sndbuf   The size of the send buffer.
  *
- * @return 0 on succes, -1 on error. so_sndbuf is set to -1 on error.
+ * @return 0 on success, -1 on error. so_sndbuf is set to -1 on error.
  */
 static int
 get_so_sndbuf (int soc, int *so_sndbuf)
@@ -129,7 +129,7 @@ throttle (int soc, int so_sndbuf)
     }
 
   /* If setting of so_sndbuf or cur_so_sendbuf failed we do not enter the
-   * throttling loop. Normally this should not occure but we really do not want
+   * throttling loop. Normally this should not occur but we really do not want
    * to get into an infinite loop here. */
   if (cur_so_sendbuf != -1 && so_sndbuf != -1)
     {

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -641,7 +641,7 @@ so_sndbuf_empty (int soc, int *err)
  * @brief Wait until socket send buffer empty or timeout reached.
  *
  * @param soc     Socket.
- * @param timout  Timeout in seconds.
+ * @param timeout Timeout in seconds.
  */
 void
 wait_until_so_sndbuf_empty (int soc, int timeout)


### PR DESCRIPTION
From codespell:

```
./boreas/util.c:644: timout ==> timeout
./boreas/ping.c:92: succes ==> success
./boreas/ping.c:132: occure ==> occur, occurred
```