### PR TITLE
Do not abort when log file not accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Continuously send dead hosts to ospd-openvas to enable a smooth progess bar if only ICMP is chosen as alive test.  [#389](https://github.com/greenbone/gvm-libs/pull/389)
 - Retry if response via tls1.3 is still not received. [#394](https://github.com/greenbone/gvm-libs/pull/394)
 - Replace current implementation of alive test arp ping with version using libnet. [#423](https://github.com/greenbone/gvm-libs/pull/423)
+* Let setup_log_handlers return an error if it does not have write access to some log file or log dir instead of aborting immediately. [#447](https://github.com/greenbone/gvm-libs/pull/447)
 
 ### Removed
 - Remove handling of severity class from auth [#402](https://github.com/greenbone/gvm-libs/pull/402)

--- a/base/logging.c
+++ b/base/logging.c
@@ -791,11 +791,17 @@ check_log_file (gvm_logging_t *log_domain_entry)
  * Iterates over the link list and adds the groups to the handler.
  *
  * @param gvm_log_config_list A pointer to the configuration linked list.
+ *
+ * @return 0 on success, -1 if not able to create log file directory or open log
+ * file for some domain.
  */
-void
+int
 setup_log_handlers (GSList *gvm_log_config_list)
 {
   GSList *log_domain_list_tmp;
+  int err;
+  int ret = 0;
+
   if (gvm_log_config_list != NULL)
     {
       /* Go to the head of the list. */
@@ -807,6 +813,15 @@ setup_log_handlers (GSList *gvm_log_config_list)
 
           /* Get the list data which is an gvm_logging_t struct. */
           log_domain_entry = log_domain_list_tmp->data;
+
+          err = check_log_file (log_domain_entry);
+          if (err)
+            {
+              ret = -1;
+              /* Go to the next item. */
+              log_domain_list_tmp = g_slist_next (log_domain_list_tmp);
+              continue;
+            }
 
           GLogFunc logfunc =
 #if 0
@@ -841,4 +856,6 @@ setup_log_handlers (GSList *gvm_log_config_list)
                       | G_LOG_LEVEL_ERROR | G_LOG_FLAG_FATAL
                       | G_LOG_FLAG_RECURSION),
     (GLogFunc) gvm_log_func, gvm_log_config_list);
+
+  return ret;
 }

--- a/base/logging.h
+++ b/base/logging.h
@@ -44,7 +44,7 @@ gvm_log_func (const char *, GLogLevelFlags, const char *, gpointer);
 void
 log_func_for_gnutls (int, const char *);
 
-void
+int
 setup_log_handlers (GSList *);
 
 void


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Do not abort when trying to log to log file with wrong permissions.

If the error reported by setup_log_handlers is not handled the log domains with log files which can not be accessed will be ignored and some default is used instead.

Related to: https://github.com/greenbone/openvas-scanner/pull/661 

**Why**:

<!-- Why are these changes necessary? -->
Fix https://github.com/greenbone/openvas-scanner/issues/415.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
