### PR TITLE
Fix various typos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#410](https://github.com/greenbone/gvm-libs/pull/410)
 - Add multiple severities for nvti [#317](https://github.com/greenbone/gvm-libs/pull/317)
 - Add support for new OSP element for defining alive test methods via separate subelements. [#409](https://github.com/greenbone/gvm-libs/pull/409)
-- Add v3 handling to get_cvss_score_from_base_metrics [#411](https://github.com/greenbone/gvm-libs/pull/411)
+- Add v3 handling to get_cvss_score_from_base_metrics. [#411](https://github.com/greenbone/gvm-libs/pull/411)
 - Add severity_date tag in epoch time format. [#412](https://github.com/greenbone/gvm-libs/pull/412)
 - Make more scanner preferences available to openvas-nasl. [#413](https://github.com/greenbone/gvm-libs/pull/413)
 
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)
-- Continuously send dead hosts to ospd-openvas to enable a smooth progess bar if only ICMP is chosen as alive test.  [#389](https://github.com/greenbone/gvm-libs/pull/389)
+- Continuously send dead hosts to ospd-openvas to enable a smooth progress bar if only ICMP is chosen as alive test. [#389](https://github.com/greenbone/gvm-libs/pull/389)
 - Retry if response via tls1.3 is still not received. [#394](https://github.com/greenbone/gvm-libs/pull/394)
 - Replace current implementation of alive test arp ping with version using libnet. [#423](https://github.com/greenbone/gvm-libs/pull/423)
 - Let setup_log_handlers return an error if it does not have write access to some log file or log dir instead of aborting immediately. [#447](https://github.com/greenbone/gvm-libs/pull/447)

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -127,13 +127,13 @@ scan (alive_test_t alive_test)
 
               /* If the max_scan_hosts limit was reached we can not tell ospd
                * the true number of dead hosts. The number of alive hosts which
-               * are above the max_scan_hosts limit are not to be substracted
+               * are above the max_scan_hosts limit are not to be subtracted
                * form the dead hosts to send. They are considered as dead hosts
                * for the progress bar.*/
               if (scanner.scan_restrictions->max_scan_hosts_reached)
                 {
                   /* Handle the case where we reach the max_scan_hosts for the
-                   * first time. We may have to considere some of the new alive
+                   * first time. We may have to consider some of the new alive
                    * hosts as dead because of the restriction. E.g
                    * curr_alive=110 prev_alive=90 max_scan_hosts=100 batch=100.
                    * Normally we would send 80 as dead in this batch (20 new
@@ -229,7 +229,7 @@ scan (alive_test_t alive_test)
 
   stop_sniffer_thread (&scanner, sniffer_thread_id);
 
-  /* If only ICMP was specified we continously sent updates about dead hosts to
+  /* If only ICMP was specified we continuously send updates about dead hosts to
    * ospd while checking the hosts. We now only have to send the dead hosts of
    * the last batch. This is done here to catch the last alive hosts which may
    * have arrived after all packets were already sent.

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -63,7 +63,7 @@ static libnet_t *libnet = 0;
 static uint32_t dstip;           /* target IP */
 static uint8_t dstmac[ETH_ALEN]; /* ethxmas */
 
-/* autodetected, overriden by gvm_source_addr if openvas source_iface was set*/
+/* autodetected, overridden by gvm_source_addr if openvas source_iface was set*/
 static uint32_t srcip;
 static uint8_t srcmac[ETH_ALEN]; /* autodetected */
 
@@ -359,7 +359,7 @@ send_arp_v4 (const char *dst_str)
         }
     }
 
-  /* Make sure dstip and dst_str like eachother */
+  /* Make sure dstip and dst_str like each other */
   if (!xresolve (libnet, dst_str, LIBNET_DONT_RESOLVE, &dstip))
     {
       g_warning ("%s: Can't resolve %s. No ARP ping done for this addr.",


### PR DESCRIPTION
From codespell:

```
./CHANGELOG.md:22: progess ==> progress
./boreas/alivedetection.c:130: substracted ==> subtracted
./boreas/alivedetection.c:136: considere ==> considered
./boreas/alivedetection.c:232: continously ==> continuously
./boreas/arp.c:66: overriden ==> overridden
./boreas/arp.c:362: eachother ==> each other
```

Seems these typos doesn't exist in the gvm-libs-20.08 branch so i have created the PR against master.