### PR TITLE
Fix log file check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Continuously send dead hosts to ospd-openvas to enable a smooth progress bar if only ICMP is chosen as alive test. [#389](https://github.com/greenbone/gvm-libs/pull/389)
 - Retry if response via tls1.3 is still not received. [#394](https://github.com/greenbone/gvm-libs/pull/394)
 - Replace current implementation of alive test arp ping with version using libnet. [#423](https://github.com/greenbone/gvm-libs/pull/423)
-- Let setup_log_handlers return an error if it does not have write access to some log file or log dir instead of aborting immediately. [#447](https://github.com/greenbone/gvm-libs/pull/447)
+- Let setup_log_handlers return an error if it does not have write access to some log file or log dir instead of aborting immediately.
+  [#447](https://github.com/greenbone/gvm-libs/pull/447)
+  [#451](https://github.com/greenbone/gvm-libs/pull/451)
 
 ### Removed
 - Remove handling of severity class from auth [#402](https://github.com/greenbone/gvm-libs/pull/402)


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Adds missing handling of syslog logging and empty file string to https://github.com/greenbone/gvm-libs/pull/447 .

**Why**:

<!-- Why are these changes necessary? -->

Else not able to init openvas with some logging configs.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

add the following to the openvas_log.conf

```
[sd   main]
prepend=%t %s %p
separator=:
prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
file=syslog
syslog_facility=daemon
syslog_indent=openvas
level=127
```

Without the patch `openvas -s` will fail if openvas is started as other user (e.g. `sudo -u testuser openvas -s`). Same if `file=` is put into the config. With applied PR this is fixed.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
