### PR TITLE
Use memory purge redis command when initializing new kb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add v3 handling to get_cvss_score_from_base_metrics. [#411](https://github.com/greenbone/gvm-libs/pull/411)
 - Add severity_date tag in epoch time format. [#412](https://github.com/greenbone/gvm-libs/pull/412)
 - Make more scanner preferences available to openvas-nasl. [#413](https://github.com/greenbone/gvm-libs/pull/413)
+- Use memory purge redis command when initializing new kb. [#452](https://github.com/greenbone/gvm-libs/pull/452)
 
 ### Changed
 - Add separators for a new (ip address) field in ERRMSG and DEADHOST messages. [#376](https://github.com/greenbone/gvm-libs/pull/376)

--- a/util/kb.c
+++ b/util/kb.c
@@ -381,6 +381,33 @@ redis_get_kb_index (kb_t kb)
 }
 
 /**
+ * @brief Attempt to purge dirty pages.
+ *
+ * Attempt to purge dirty pages so these can be reclaimed by the allocator.
+ * This command only works when using jemalloc as an allocator, and evaluates
+ * to a benign NOOP for all others. Command is applied to complete redis
+ * instance and not only single db.
+ *
+ * @param[in] kb KB handle where to run the command.
+ *
+ * @return 0 on success, non-null on error.
+ */
+static int
+redis_memory_purge (kb_t kb)
+{
+  redisReply *rep;
+  int rc = 0;
+
+  rep = redis_cmd (redis_kb (kb), "MEMORY PURGE");
+  if (!rep || rep->type == REDIS_REPLY_ERROR)
+    rc = -1;
+  if (rep)
+    freeReplyObject (rep);
+
+  return rc;
+}
+
+/**
  * @brief Initialize a new Knowledge Base object.
  *
  * @param[in] kb  Reference to a kb_t to initialize.

--- a/util/kb.c
+++ b/util/kb.c
@@ -440,6 +440,11 @@ redis_new (kb_t *kb, const char *kb_path)
     }
 
   *kb = (kb_t) kbr;
+
+  /* Try to make unused memory available for the OS again. */
+  if (redis_memory_purge (*kb))
+    g_warning ("%s: Memory purge was not successfull", __func__);
+
   return rc;
 }
 


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Use memory purge redis command when initializing new kb.

**Why**:

<!-- Why are these changes necessary? -->

Handle issue of redis memory not being released to the OS again.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Running the following script with a target of 5 hosts with ospd-openvas. Redis will use about 800M memory. 

```C
if(description) {
  script_oid("1.3.6.1.4.1.25623.1.0.999999");
  script_version("2019-09-09T06:03:58+0000");
  script_name("test redis memory");
  script_category(ACT_SCANNER);
  script_family("Port scanners");
  script_copyright("This script is Copyright (C) 2009 Greenbone Networks GmbH");
  script_tag(name:"last_modification", value:"2019-09-09 06:03:58 +0000 (Mon, 09 Sep 2019)");
  script_tag(name:"creation_date", value:"2009-10-26 10:02:32 +0100 (Mon, 26 Oct 2009)");
  script_tag(name:"cvss_base", value:"0.0");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_tag(name:"summary", value:"some value");
  exit(0);
}

include("misc_func.inc"); # for rand_str()

i = 0;
key  = "key";
value = rand_str(length: 1000);

a = rand();
b = rand();
for (; i<100000; i++ ) {
    set_kb_item(name: key+i+a+b, value:value+b+a);
}

```

Check the memory via e.g. `redis-cli -s /run/redis-openvas/redis.sock info memory | grep used_memory_rss`.
Run some other script which does not use much memory. The memory will probably not decrease to the baseline again.

With the PR the memory will imiidiately decrease to the baseline again if a script was started which does not use much memory after the initial script was called.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
