### PR TITLE
Add function ldap_enable_debug ()

### DIFF
--- a/util/ldaputils.c
+++ b/util/ldaputils.c
@@ -51,6 +51,45 @@
  */
 
 /**
+ * @brief Wrapper function to use glib logging for LDAP debug logging.
+ */
+static void
+ldap_log (const char *message)
+{
+  g_debug ("OpenLDAP: %s", message);
+}
+
+/**
+ * @brief Enable OpenLDAP debug logging.
+ *
+ * @return 0 success, -1 error.
+ */
+int
+ldap_enable_debug ()
+{
+  int ret;
+  static int debug_level = 65535;
+
+  ret = ber_set_option (NULL, LBER_OPT_LOG_PRINT_FN, ldap_log);
+  if (ret != LBER_OPT_SUCCESS)
+    {
+      g_warning ("%s: Failed to set LDAP debug print function: %s",
+                 __func__, ldap_err2string (ret));
+      return -1;
+    }
+
+  ret = ldap_set_option (NULL, LDAP_OPT_DEBUG_LEVEL, &debug_level);
+  if (ret != LDAP_OPT_SUCCESS)
+    {
+      g_warning ("%s: Failed to set LDAP debug level: %s",
+                 __func__, ldap_err2string (ret));
+      return -1;
+    }
+
+  return 0;
+}
+
+/**
  * @brief Authenticate against an ldap directory server.
  *
  * @param[in] info      Schema and address to use.
@@ -454,6 +493,18 @@ ldap_auth_dn_is_good (const gchar *authdn)
 }
 
 #else
+
+/**
+ * @brief Dummy function for enabling LDAP debugging for manager.
+ *
+ * @return Always -1 for failure.
+ */
+int
+ldap_enable_debug ()
+{
+  g_warning ("%s: GVM-libs compiled without LDAP", __func__);
+  return -1;
+}
 
 /**
  * @brief Dummy function for manager.

--- a/util/ldaputils.h
+++ b/util/ldaputils.h
@@ -44,6 +44,9 @@ struct ldap_auth_info
 };
 
 int
+ldap_enable_debug ();
+
+int
 ldap_connect_authenticate (const gchar *, const gchar *,
                            /* ldap_auth_info_t */ void *, const gchar *);
 


### PR DESCRIPTION
**What**:
This function enables LDAP debug logging via the glib logging, which can
be used for debugging LDAP connection issues, for example.

**Why**:
To help users with LDAP connection issues.

**How**:
Tested by using the function in gvmd and checking the log output after attempting an LDAP authentication.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
