### PR TITLE
Split the log message into smaller pieces when syslog is the log destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Use a char pointer instead of an zero-lenght array as kb_redis struct member. [443](https://github.com/greenbone/gvm-libs/pull/443)
 
 ### Fixed
-* Fixing [#434](https://github.com/greenbone/gvm-libs/pull/434) by removing the extra parentheses in `base/networking.c` [#437](https://github.com/greenbone/gvm-libs/pull/437)
-* Adding initialization to struct scanner in `boreas/util_tests.c`. [#438](https://github.com/greenbone/gvm-libs/pull/438)
-* Fix warnings about uninitialized variables. [#448](https://github.com/greenbone/gvm-libs/pull/448)
+- Fixing [#434](https://github.com/greenbone/gvm-libs/pull/434) by removing the extra parentheses in `base/networking.c` [#437](https://github.com/greenbone/gvm-libs/pull/437)
+- Adding initialization to struct scanner in `boreas/util_tests.c`. [#438](https://github.com/greenbone/gvm-libs/pull/438)
+- Fix warnings about uninitialized variables. [#448](https://github.com/greenbone/gvm-libs/pull/448)
+- Split the log message into smaller pieces when syslog is the log destination.  [#455](https://github.com/greenbone/gvm-libs/pull/455)
 
 ### Removed
 


### PR DESCRIPTION
**What**:
Split the log message into smaller pieces when syslog is the log destination
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Syslog doesn't support messages longer than 1kb. The overflow data
will not be logged or will be shown in the hypervisor console
if it runs on a virtual machine.

<!-- Why are these changes necessary? -->

**How**:
- Set max-ips-per-target to 70000 in gvmd
- Create a target with 70000 hosts
- Set the syslog as log facility
- Run the task and check that the 70000 host are logged in different messages.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
