### PR TITLE
Fix finish_signal_on_queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#451](https://github.com/greenbone/gvm-libs/pull/451)
 - Fix openvas preference name. The option was rename to "allow_simultaneous_ips". [#461](https://github.com/greenbone/gvm-libs/pull/461)
 
+### Fixed
+- Fix finish_signal_on_queue for boreas. [#464](https://github.com/greenbone/gvm-libs/pull/464)
+
 ### Removed
 - Remove handling of severity class from auth [#402](https://github.com/greenbone/gvm-libs/pull/402)
 - Remove version from the nvticache name. [#386](https://github.com/greenbone/gvm-libs/pull/386)

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -240,7 +240,7 @@ put_host_on_queue (kb_t kb, char *addr_str)
 }
 
 /**
- * @brief Checks if the finish signal is already set as last item in the queue.
+ * @brief Checks if the finish signal is already set.
  *
  * @param main_kb  kb to use
  * @return 1 if it is already set. 0 otherwise.
@@ -248,18 +248,30 @@ put_host_on_queue (kb_t kb, char *addr_str)
 int
 finish_signal_on_queue (kb_t main_kb)
 {
-  struct kb_item *last_queue_item;
-  int ret;
+  static gboolean fin_msg_already_on_queue = FALSE;
+  struct kb_item *queue_items = NULL;
+  int ret = 0;
 
-  ret = 0;
-  last_queue_item =
-    kb_item_get_single (main_kb, ALIVE_DETECTION_QUEUE, KB_TYPE_STR);
+  if (fin_msg_already_on_queue)
+    return 1;
 
-  if (last_queue_item && (last_queue_item->type == KB_TYPE_STR)
-      && (!g_strcmp0 (last_queue_item->v_str, ALIVE_DETECTION_FINISHED)))
-    ret = 1;
-
-  kb_item_free (last_queue_item);
+  /* Check if it was already set throught the whole items under the key.
+     If so, set the static variable to avoid quering redis unnecessarily. */
+  queue_items =
+    kb_item_get_all (main_kb, ALIVE_DETECTION_QUEUE);
+  if (queue_items)
+    {
+      while (queue_items)
+        {
+          if (!g_strcmp0 (queue_items->v_str, ALIVE_DETECTION_FINISHED))
+            {
+              fin_msg_already_on_queue = TRUE;
+              ret = 1;
+            }
+          queue_items = queue_items->next;
+        }
+      kb_item_free (queue_items);
+    }
   return ret;
 }
 

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -256,7 +256,7 @@ finish_signal_on_queue (kb_t main_kb)
     return 1;
 
   /* Check if it was already set throught the whole items under the key.
-     If so, set the static variable to avoid quering redis unnecessarily. */
+     If so, set the static variable to avoid querying redis unnecessarily. */
   queue_items =
     kb_item_get_all (main_kb, ALIVE_DETECTION_QUEUE);
   if (queue_items)


### PR DESCRIPTION
**What**:
Fix finish_signal_on_queue. Check for the signal in the whole items under the key, instead of
just checking the the last item.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In some cases the `finished` was not reallocated causing interrupted scans
<!-- Why are these changes necessary? -->

**How**:
Run a scan with Boreas alive test, with `expand_vhosts` option enabled and `allow_simultaneous_ips` disabled. Check that the scan is not interrupted and all hosts are scanned.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
