### PR TITLE
Fixed small spelling mistake (PL-52)

### DIFF
--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -500,7 +500,7 @@ start_alive_detection (void *hosts_to_test)
   /* Free memory, close sockets and connections. */
   pthread_cleanup_pop (1);
   if (free_err)
-    g_warning ("%s: %s. Exit Boreas thread none the less.", __func__,
+    g_warning ("%s: %s. Exit Boreas thread nonetheless.", __func__,
                str_boreas_error (free_err));
 
   pthread_exit (0);


### PR DESCRIPTION

**What**:

  Fixed small spelling mistake.

**Why**:
The mistake caused some warnings at build-time in GOS (Closes: GOS-52).

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
