### PR TITLE
Ensure that new kb taken by the scanner are always clean.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add function ldap_enable_debug () [#453](https://github.com/greenbone/gvm-libs/pull/453)
+- Ensure that new kb taken by the scanner are always clean. [#469](https://github.com/greenbone/gvm-libs/pull/469)
 
 ### Changed
 Use a char pointer instead of an zero-lenght array as kb_redis struct member. [443](https://github.com/greenbone/gvm-libs/pull/443)

--- a/util/kb.c
+++ b/util/kb.c
@@ -1570,7 +1570,8 @@ redis_delete_all (struct kb_redis *kbr)
   if (sigaction (SIGPIPE, &new_action, &original_action))
     return -1;
 
-  g_debug ("%s: deleting all elements from KB #%u", __func__, kbr->db);
+  if (kbr)
+    g_debug ("%s: deleting all elements from KB #%u", __func__, kbr->db);
   rep = redis_cmd (kbr, "FLUSHDB");
   if (rep == NULL || rep->type != REDIS_REPLY_STATUS)
     {

--- a/util/kb.c
+++ b/util/kb.c
@@ -412,6 +412,9 @@ redis_new (kb_t *kb, const char *kb_path)
       rc = -1;
     }
 
+  /* Ensure that the new kb is clean */
+  redis_delete_all (kbr);
+
   *kb = (kb_t) kbr;
   return rc;
 }


### PR DESCRIPTION
**What**:
Ensure that new kb taken by the scanner are always clean.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To ensure that new kbs taken by the scanner are always clean.
<!-- Why are these changes necessary? -->

**How**:
Enter to redis-cli and check that the only kb set "in used" is the kb 1, which contains the VTs cache
```
$ redis-cli -s /run/redis-openvas/redis.sock 
redis /run/redis-openvas/redis.sock> keys *
1) "GVM.__GlobalDBIndex"
redis /run/redis-openvas/redis.sock> HGETALL GVM.__GlobalDBIndex
1) "1"
2) "1"
```

Add some items to the the KB 2 and KB 3
```
redis /run/redis-openvas/redis.sock> SELECT 2
OK
redis /run/redis-openvas/redis.sock[2]> LPUSH a 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[2]> LPUSH b 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[2]> LPUSH b 123 1231 11222
(integer) 6
redis /run/redis-openvas/redis.sock[2]> LPUSH x 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[2]> LPUSH c 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[2]> LPUSH v 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[2]> LPUSH w 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[2]> keys *
1) "a"
2) "w"
3) "b"
4) "v"
5) "x"
6) "c"
redis /run/redis-openvas/redis.sock[2]> SELECT 3
OK
redis /run/redis-openvas/redis.sock[3]> LPUSH w 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH v 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH b 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH x 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH a 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH as 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asd 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asdf 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asdgf 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asdvdsgf 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asd23vdsgf 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asd23htvdsgf 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asd23htvjdsgf 123 1231 11222
(integer) 3
redis /run/redis-openvas/redis.sock[3]> LPUSH asd23htvdjdsgf 123 1231 11222
(integer) 3

redis /run/redis-openvas/redis.sock> info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0
db1:keys=179237,expires=0,avg_ttl=0
db2:keys=6,expires=0,avg_ttl=0
db3:keys=14,expires=0,avg_ttl=0
```


Run a scan. As the only kb set as "in used" is the kb 1, kb 2 and kb 3 will be taken for the task.
Once the openvas started and scans the host, check in the kb 2 and kb 3 if the items you added above were deleted (kb clean)

```
redis /run/redis-openvas/redis.sock[2]> SELECT 2
OK
redis /run/redis-openvas/redis.sock[2]> keys *
1) "internal/scanid"
2) "internal/7f24d936-8879-41b4-83ef-195a55129345/scanprefs"
3) "internal/ec2f19c9-32dd-4fde-b9b4-7d6f07a7a53c/globalscanid"
4) "internal/7f24d936-8879-41b4-83ef-195a55129345"

redis /run/redis-openvas/redis.sock[2]> SELECT 3
OK
redis /run/redis-openvas/redis.sock[3]> keys as*
(empty list or set)
redis /run/redis-openvas/redis.sock[3]> info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0
db1:keys=179237,expires=0,avg_ttl=0
db2:keys=5,expires=0,avg_ttl=0
db3:keys=71,expires=0,avg_ttl=0
```


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
