### PR TITLE
Use double for scores in vtseverity_t and helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow to re allocate the finish flag in the host queue for alive tests.
   [#407](https://github.com/greenbone/gvm-libs/pull/407)
   [#410](https://github.com/greenbone/gvm-libs/pull/410)
-- Add multiple severities for nvti [#317](https://github.com/greenbone/gvm-libs/pull/317)
+- Add multiple severities for nvti [#317](https://github.com/greenbone/gvm-libs/pull/317) [#472](https://github.com/greenbone/gvm-libs/pull/472)
 - Add support for new OSP element for defining alive test methods via separate subelements. [#409](https://github.com/greenbone/gvm-libs/pull/409)
 - Add v3 handling to get_cvss_score_from_base_metrics. [#411](https://github.com/greenbone/gvm-libs/pull/411)
 - Add severity_date tag in epoch time format. [#412](https://github.com/greenbone/gvm-libs/pull/412)

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -172,25 +172,25 @@ typedef struct vtseverity
   gchar *origin; ///< Optional: Where does the severity come from
                  ///< ("CVE-2018-1234", "Greenbone Research")
   int date; ///< Timestamp in seconds since epoch, defaults to VT creation date.
-  int score;    ///< The score derived from the value in range [0-100]
+  double score; ///< The score derived from the value in range [0.0-10.0]
   gchar *value; ///< The value which corresponds to the type.
 } vtseverity_t;
 
 /**
  * @brief Create a new vtseverity structure filled with the given values.
  *
- * @param type The severity type to be set.
- *
- * @param origin The origin reference to be set, can be NULL.
- *
- * @param value The value corresponding to the type.
+ * @param[in]  type   The severity type to be set.
+ * @param[in]  origin The origin reference to be set, can be NULL.
+ * @param[in]  date   The date to be set.
+ * @param[in]  score  The score to be set.
+ * @param[in]  value  The value corresponding to the type.
  *
  * @return NULL in case the memory could not be allocated.
  *         Else a vtref structure which needs to be
  *         released using @ref vtref_free .
  */
 vtseverity_t *
-vtseverity_new (const gchar *type, const gchar *origin, int date, int score,
+vtseverity_new (const gchar *type, const gchar *origin, int date, double score,
                 const gchar *value)
 {
   vtseverity_t *s = g_malloc0 (sizeof (vtseverity_t));
@@ -288,7 +288,7 @@ vtseverity_date (const vtseverity_t *s)
  *
  * @return The score.
  */
-int
+double
 vtseverity_score (const vtseverity_t *s)
 {
   return s->score;
@@ -915,11 +915,11 @@ nvti_vtseverity (const nvti_t *n, guint p)
  *
  * @return The severity score, -1 indicates an error.
  */
-int
+double
 nvti_severity_score (const nvti_t *n)
 {
   unsigned int i;
-  int score = -1;
+  double score = -1.0;
 
   for (i = 0; i < nvti_vtseverities_len (n); i++)
     {

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -76,7 +76,7 @@ const gchar *
 vtref_text (const vtref_t *);
 
 vtseverity_t *
-vtseverity_new (const gchar *, const gchar *, int, int, const gchar *);
+vtseverity_new (const gchar *, const gchar *, int, double, const gchar *);
 void
 vtseverity_free (vtseverity_t *);
 const gchar *
@@ -87,7 +87,7 @@ const gchar *
 vtseverity_value (const vtseverity_t *);
 int
 vtseverity_date (const vtseverity_t *);
-int
+double
 vtseverity_score (const vtseverity_t *);
 
 int
@@ -103,7 +103,7 @@ guint
 nvti_vtseverities_len (const nvti_t *);
 vtseverity_t *
 nvti_vtseverity (const nvti_t *, guint);
-int
+double
 nvti_severity_score (const nvti_t *);
 
 nvti_t *


### PR DESCRIPTION
**What**:
The typedef and the functions nvti_severity_score, vtseverity_new and
vtseverity_new now use double to be able to handle CVSS scores.

**Why**:
The score handling in gvmd will use CVSS scores instead of integer ones.

**How**:
Tested by running gvmd --rebuild in an updated gvmd that uses CVSS scores and checking that scores are not truncated to integers.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
