### PR TITLE
Unify GLib log domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Changed
 ### Fixed
+- Unify GLib log domains [#479](https://github.com/greenbone/gvm-libs/pull/479)
+
 ### Removed
 
 [21.04.1]: https://github.com/greenbone/gvm-libs/compare/v21.4.0...gvm-libs-21.04

--- a/base/array.c
+++ b/base/array.c
@@ -24,6 +24,12 @@
 
 #include "array.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /**
  * @brief Make a global array.
  *

--- a/base/credentials.c
+++ b/base/credentials.c
@@ -28,6 +28,12 @@
 
 #include <string.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /**
  * @brief Free credentials.
  *

--- a/base/cvss.c
+++ b/base/cvss.c
@@ -80,6 +80,12 @@
 #include <math.h>
 #include <string.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /* Static Headers. */
 
 static double

--- a/base/drop_privileges.c
+++ b/base/drop_privileges.c
@@ -29,6 +29,12 @@
 #include <sys/types.h>
 #include <unistd.h> /* for geteuid, setgid, setuid */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /**
  * @brief Sets an error and return \p errorcode
  *

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -46,7 +46,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "base hosts"
+#define G_LOG_DOMAIN "libgvm base"
 
 /* Static variables */
 

--- a/base/logging.c
+++ b/base/logging.c
@@ -40,6 +40,12 @@
 #include <time.h>   /* for localtime, time, time_t */
 #include <unistd.h> /* for getpid */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /**
  * @struct gvm_logging_t
  * @brief Logging stores the parameters loaded from a log configuration

--- a/base/networking.c
+++ b/base/networking.c
@@ -46,7 +46,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "base networking"
+#define G_LOG_DOMAIN "libgvm base"
 
 /* Global variables */
 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -55,7 +55,10 @@
 #include <time.h>    // for strptime
 
 #undef G_LOG_DOMAIN
-#define G_LOG_DOMAIN "lib  nvti"
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
 
 /* VT references */
 

--- a/base/pidfile.c
+++ b/base/pidfile.c
@@ -32,11 +32,11 @@
 #include <string.h>      /* for strerror */
 #include <unistd.h>      /* for getpid */
 
+#undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.
  */
-#undef G_LOG_DOMAIN
-#define G_LOG_DOMAIN "base pidfile"
+#define G_LOG_DOMAIN "libgvm base"
 
 /**
  * @brief Create a PID-file.

--- a/base/prefs.c
+++ b/base/prefs.c
@@ -32,6 +32,12 @@
 #include <stdlib.h> /* for atoi() */
 #include <string.h> /* for strlen() */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 static GHashTable *global_prefs = NULL;
 
 void

--- a/base/proctitle.c
+++ b/base/proctitle.c
@@ -29,6 +29,12 @@
 #include <string.h> /* for strlen, strdup, bzero, strncpy */
 #include <sys/param.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /**
  * @brief Access to the executable's name.
  */

--- a/base/pwpolicy.c
+++ b/base/pwpolicy.c
@@ -42,7 +42,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "base plcy"
+#define G_LOG_DOMAIN "libgvm base"
 
 /**
  * @brief The name of the pattern file

--- a/base/settings.c
+++ b/base/settings.c
@@ -27,6 +27,12 @@
 #include <stdio.h>
 #include <string.h> /* for strlen */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /**
  * @brief Initialise a settings struct from a file.
  *

--- a/base/strings.c
+++ b/base/strings.c
@@ -27,6 +27,12 @@
 #include <assert.h> /* for assert */
 #include <glib.h>   /* for g_free, g_strconcat, gchar, g_strdup, g_strndup */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 /**
  * @brief Append a string to a string variable.
  *

--- a/base/version.c
+++ b/base/version.c
@@ -19,6 +19,12 @@
 
 #include "version.h"
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "libgvm base"
+
 const char *
 gvm_libs_version (void)
 {

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -52,7 +52,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 struct scanner scanner;
 

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -56,7 +56,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 static libnet_t *libnet = 0;
 

--- a/boreas/boreas_error.c
+++ b/boreas/boreas_error.c
@@ -25,7 +25,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 /**
  * @brief Transform Boreas error code into human readable error message.

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -30,7 +30,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 scan_restrictions_t scan_restrictions;
 

--- a/boreas/cli.c
+++ b/boreas/cli.c
@@ -34,7 +34,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 static boreas_error_t
 init_cli (struct scanner *scanner, gvm_hosts_t *hosts, alive_test_t alive_test,

--- a/boreas/ping.c
+++ b/boreas/ping.c
@@ -43,7 +43,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 struct v6pseudohdr
 {

--- a/boreas/sniffer.c
+++ b/boreas/sniffer.c
@@ -35,7 +35,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 /* for using int value in #defined string */
 #define STR(X) #X

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -38,7 +38,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "alive scan"
+#define G_LOG_DOMAIN "libgvm boreas"
 
 static boreas_error_t
 set_socket (socket_type_t, int *);

--- a/gmp/gmp.c
+++ b/gmp/gmp.c
@@ -39,7 +39,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "lib   gmp"
+#define G_LOG_DOMAIN "libgvm gmp"
 
 #define GMP_FMT_BOOL_ATTRIB(var, attrib) \
   (var.attrib == 0 ? " " #attrib "=\"0\"" : " " #attrib "=\"1\"")

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -41,7 +41,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "lib  osp"
+#define G_LOG_DOMAIN "libgvm osp"
 
 /**
  * @brief Struct holding options for OSP connection.

--- a/util/authutils.c
+++ b/util/authutils.c
@@ -31,7 +31,7 @@
 /**
  * @brief GLib logging domain.
  */
-#define G_LOG_DOMAIN "lib  auth"
+#define G_LOG_DOMAIN "libgvm util"
 
 /**
  * @brief Array of string representations of the supported authentication

--- a/util/compressutils.c
+++ b/util/compressutils.c
@@ -34,6 +34,12 @@
 #include <glib.h> /* for g_free, g_malloc0 */
 #include <zlib.h> /* for z_stream, Z_NULL, Z_OK, Z_BUF_ERROR, Z_STREAM_END */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "libgvm util"
+
 /**
  * @brief Compresses data in src buffer.
  *

--- a/util/fileutils.c
+++ b/util/fileutils.c
@@ -35,6 +35,12 @@
 #include <sys/stat.h>    /* for stat, S_ISDIR */
 #include <time.h>        /* for tm, strptime, localtime, time, time_t */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "libgvm util"
+
 /**
  * @brief Checks whether a file is a directory or not.
  *

--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -36,9 +36,9 @@
 
 #undef G_LOG_DOMAIN
 /**
- * @brief GLib log domain.
+ * @brief GLib logging domain.
  */
-#define G_LOG_DOMAIN "util gpgme"
+#define G_LOG_DOMAIN "libgvm util"
 
 /**
  * @brief Log function with extra gpg-error style output

--- a/util/kb.c
+++ b/util/kb.c
@@ -35,7 +35,10 @@
 #include <string.h> /* for strlen, strerror, strncpy, memset */
 
 #undef G_LOG_DOMAIN
-#define G_LOG_DOMAIN "lib  kb"
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "libgvm util"
 
 /**
  * @file kb.c

--- a/util/ldaputils.c
+++ b/util/ldaputils.c
@@ -38,7 +38,7 @@
 /**
  * @brief GLib logging domain.
  */
-#define G_LOG_DOMAIN "lib  ldap"
+#define G_LOG_DOMAIN "libgvm util"
 
 #define KEY_LDAP_HOST "ldaphost"
 #define KEY_LDAP_DN_AUTH "authdn"

--- a/util/nvticache.c
+++ b/util/nvticache.c
@@ -42,9 +42,9 @@
 
 #undef G_LOG_DOMAIN
 /**
- * @brief GLib log domain.
+ * @brief GLib logging domain.
  */
-#define G_LOG_DOMAIN "lib  nvticache"
+#define G_LOG_DOMAIN "libgvm util"
 
 char *src_path = NULL; /**< The directory of the source files. */
 kb_t cache_kb = NULL;  /**< Cache KB handler. */

--- a/util/radiusutils.c
+++ b/util/radiusutils.c
@@ -46,6 +46,12 @@
 
 #include <glib.h> /* for g_warning */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "libgvm util"
+
 #ifndef PW_MAX_MSG_SIZE
 #define PW_MAX_MSG_SIZE 4096
 #endif

--- a/util/serverutils.c
+++ b/util/serverutils.c
@@ -47,9 +47,9 @@
 
 #undef G_LOG_DOMAIN
 /**
- * @brief GLib log domain.
+ * @brief GLib logging domain.
  */
-#define G_LOG_DOMAIN "lib  serv"
+#define G_LOG_DOMAIN "libgvm util"
 
 /**
  * @brief Server address.

--- a/util/sshutils.c
+++ b/util/sshutils.c
@@ -30,6 +30,12 @@
 #include <libssh/libssh.h> /* for ssh_key_free, ssh_key_type, ssh_key_type_... */
 #include <string.h>        /* for strcmp, strlen */
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "libgvm util"
+
 /**
  * @brief Decrypts a base64 encrypted ssh private key.
  *

--- a/util/uuidutils.c
+++ b/util/uuidutils.c
@@ -28,6 +28,12 @@
 #include <stdlib.h>
 #include <uuid/uuid.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "libgvm util"
+
 /**
  * @brief Make a new universal identifier.
  *

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -41,9 +41,9 @@
 
 #undef G_LOG_DOMAIN
 /**
- * @brief GLib log domain.
+ * @brief GLib logging domain.
  */
-#define G_LOG_DOMAIN "lib   xml"
+#define G_LOG_DOMAIN "libgvm util"
 
 /**
  * @brief Size of the buffer for reading from the manager.


### PR DESCRIPTION
**What**:
The GLib log domains are changed to "libgvm " followed by the name of the library, e.g. "libgvm base" and added to the .c files where they were missing.

**Why**:
To make the log domains simpler to handle in the config files by making the names more consistent and reducing their number.

**How**:
-

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
