### PR TITLE
When hash or password are NULL return INVALID rather then ERR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 Use a char pointer instead of an zero-lenght array as kb_redis struct member. [443](https://github.com/greenbone/gvm-libs/pull/443)
+- pba verify returns INVALID instead of ERR when hash or password are null [496](https://github.com/greenbone/gvm-libs/pull/496)
 
 ### Fixed
 - Fixing [#434](https://github.com/greenbone/gvm-libs/pull/434) by removing the extra parentheses in `base/networking.c` [#437](https://github.com/greenbone/gvm-libs/pull/437)

--- a/util/passwordbasedauthentication_tests.c
+++ b/util/passwordbasedauthentication_tests.c
@@ -33,7 +33,6 @@ AfterEach (PBA)
 
 Ensure (PBA, returns_false_on_not_phc_compliant_setting)
 {
-    assert_false(pba_is_phc_compliant(NULL));
     assert_false(pba_is_phc_compliant("$"));
     assert_false(pba_is_phc_compliant("password"));
 }
@@ -75,6 +74,17 @@ Ensure (PBA, verify_hash)
     assert_equal(pba_verify_hash(&setting_wo_pepper, hash, "*password"), VALID);
     free(hash);
 }
+
+Ensure (PBA, verify_hash_returns_invalid_on_np_hash_np_password)
+{
+    struct PBASettings setting = { "4242" , 20000, "$6$"};
+    char *hash;
+    hash = pba_hash(&setting, "*password");
+    assert_not_equal(hash, NULL);
+    assert_equal(pba_verify_hash(&setting, NULL, "*password"), INVALID);
+    assert_equal(pba_verify_hash(&setting, hash, NULL), INVALID);
+}
+
 
 Ensure (PBA, defaults)
 {
@@ -131,6 +141,8 @@ main (int argc, char **argv)
                          unique_hash_without_adding_used_pepper);
   add_test_with_context (suite, PBA,
                          verify_hash);
+  add_test_with_context (suite, PBA,
+                         verify_hash_returns_invalid_on_np_hash_np_password);
   add_test_with_context (suite, PBA,
                          handle_md5_hash);
   add_test_with_context (suite, PBA,


### PR DESCRIPTION
To make it easier to handle hash or passqord unset cases for the caller
gvm-libs passwordbasedauthentication should not threat hash or password
is a nullpointer as an error case but rather as a invalid password.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
