### PR TITLE
Dont free the kb_path twice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 ### Fixed
 - Unify GLib log domains [#479](https://github.com/greenbone/gvm-libs/pull/479)
+- Fix double free. [#499](https://github.com/greenbone/gvm-libs/pull/499)
 
 ### Removed
 

--- a/util/kb.c
+++ b/util/kb.c
@@ -279,7 +279,6 @@ get_redis_ctx (struct kb_redis *kbr)
              kbr->rctx ? kbr->rctx->errstr : strerror (ENOMEM));
       redisFree (kbr->rctx);
       kbr->rctx = NULL;
-      g_free (kbr->path);
       return -1;
     }
 
@@ -289,7 +288,6 @@ get_redis_ctx (struct kb_redis *kbr)
       g_log (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL, "No redis DB available");
       redisFree (kbr->rctx);
       kbr->rctx = NULL;
-      g_free (kbr->path);
       return -2;
     }
 


### PR DESCRIPTION
**What**:
Dont free the kb_path twice.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The functions calling g_strdup (kb_path) already take care of free()'ing the string, as well as delete once the kb is deleted.

<!-- Why are these changes necessary? -->

**How**:
Kill redis and call openvas in the console. 

```
$ openvas
(process:26189): GLib-WARNING (recursed) **: Invalid UTF-8 passed to g_io_channel_write_chars().Aborted
```

You can run `valgrind openvas ` and check it.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
