### PR TITLE
Fix various typos.

### DIFF
--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -390,7 +390,7 @@ alive_detection_init (gvm_hosts_t *hosts, alive_test_t alive_test)
       if (pref_value > 0)
         max_scan_hosts = pref_value;
       else
-        g_debug ("%s: Invalid max_scan_hosts value. It must be an interger "
+        g_debug ("%s: Invalid max_scan_hosts value. It must be an integer "
                  "greater than zero.",
                  __func__);
     }

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -255,7 +255,7 @@ finish_signal_on_queue (kb_t main_kb)
   if (fin_msg_already_on_queue)
     return 1;
 
-  /* Check if it was already set throught the whole items under the key.
+  /* Check if it was already set through the whole items under the key.
      If so, set the static variable to avoid querying redis unnecessarily. */
   queue_items = kb_item_get_all (main_kb, ALIVE_DETECTION_QUEUE);
   if (queue_items)

--- a/util/kb.c
+++ b/util/kb.c
@@ -447,7 +447,7 @@ redis_new (kb_t *kb, const char *kb_path)
 
   /* Try to make unused memory available for the OS again. */
   if (redis_memory_purge (*kb))
-    g_warning ("%s: Memory purge was not successfull", __func__);
+    g_warning ("%s: Memory purge was not successful", __func__);
 
   return rc;
 }

--- a/util/passwordbasedauthentication.c
+++ b/util/passwordbasedauthentication.c
@@ -86,7 +86,7 @@ exit:
  * is a NULL pointer, random data will be retrieved from the operating system
  * if possible.
  *
- * Teh generated setting string is written to OUTPUT, which is OUTPUT_SIZE long.
+ * The generated setting string is written to OUTPUT, which is OUTPUT_SIZE long.
  * OUTPUT_SIZE must be at least CRYPT_GENSALT_OUTPUT_SIZE.
  *
  * */
@@ -204,7 +204,7 @@ pba_hash (struct PBASettings *setting, const char *password)
   result = malloc (CRYPT_OUTPUT_SIZE);
   strncpy(result, rslt, CRYPT_OUTPUT_SIZE);
   // remove pepper, by jumping to begin of applied pepper within result
-  // and overridding it.
+  // and overriding it.
   tmp = result + (tmp - settings);
   for (i = 0; i < MAX_PEPPER_SIZE; i++)
     {


### PR DESCRIPTION
Found with codespell:

```
./util/kb.c:450: successfull ==> successful
./util/passwordbasedauthentication.c:89: Teh ==> The
./util/passwordbasedauthentication.c:207: overridding ==> overriding
./boreas/boreas_io.c:258: throught ==> thought, through, throughout
./boreas/alivedetection.c:393: interger ==> integer
```