### PR TITLE
Make test_alive_hosts_only (Boreas) feature the new default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add function to find and return a host from a host list. [490](https://github.com/greenbone/gvm-libs/pull/490)
 
 ### Changed
+- Make test_alive_hosts_only (Boreas) feature the new default. [503](https://github.com/greenbone/gvm-libs/pull/503)
+
 ### Fixed
 - Unify GLib log domains [#479](https://github.com/greenbone/gvm-libs/pull/479)
 - Fix double free. [#499](https://github.com/greenbone/gvm-libs/pull/499)

--- a/base/prefs.c
+++ b/base/prefs.c
@@ -77,7 +77,7 @@ prefs_init (void)
   prefs_set ("drop_privileges", "no");
   prefs_set ("report_host_details", "yes");
   prefs_set ("vendor_version", "\0");
-  prefs_set ("test_alive_hosts_only", "no");
+  prefs_set ("test_alive_hosts_only", "yes");
   prefs_set ("debug_tls", "0");
   prefs_set ("allow_simultaneous_ips", "yes");
 }


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Make test_alive_hosts_only (Boreas) feature the new default.

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
