### PR TITLE
Fix include dirs for Sentry and fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for volatile keys. [#460](https://github.com/greenbone/gvm-libs/pull/460)
 - Possibility to use lcrypt with `$6$` (sha512) for authentication [484](https://github.com/greenbone/gvm-libs/pull/484)
 - Add function to perform an alive test and get the amount of alive hosts. [495](https://github.com/greenbone/gvm-libs/pull/495)
-- Add functions for sentry integration. [#502](https://github.com/greenbone/gvm-libs/pull/502)
+- Add functions for sentry integration. [#502](https://github.com/greenbone/gvm-libs/pull/502) [#506](https://github.com/greenbone/gvm-libs/pull/506)
 
 ### Changed
 ### Fixed

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -30,14 +30,15 @@ pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 if ($ENV{BUILD_SENTRY})
   find_package (SENTRY REQUIRED)
   if (${SENTRY_FOUND})
-    message ("Bulding with Sentry integration")
+    message ("Building with Sentry integration")
     set (SENTRY_LDFLAGS "-lsentry")
-    set (SENTRY_CFLAGS "-I${CMAKE_INSTALL_PREFIX}/include")
+    set (SENTRY_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
+    set (SENTRY_CFLAGS "-I${SENTRY_INCLUDE_DIR}")
     add_definitions (-DHAVE_SENTRY=1)
   endif (${SENTRY_FOUND})
 endif ($ENV{BUILD_SENTRY})
 
-include_directories (${GLIB_INCLUDE_DIRS})
+include_directories (${GLIB_INCLUDE_DIRS} ${SENTRY_INCLUDE_DIR})
 
 set (FILES array.c credentials.c cvss.c drop_privileges.c hosts.c logging.c
            networking.c nvti.c pidfile.c prefs.c proctitle.c pwpolicy.c


### PR DESCRIPTION
**What**:
The directory for Sentry was missing in the include_directories in
CMakeLists.txt.
A typo has been fixed in the "Building with Sentry integration" message.

**Why**:

<!-- Why are these changes necessary? -->

**How**:
By running CMake with `BUILD_SENTRY=1` and then trying to build gvm-libs.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
