### PR TITLE
Fix find_library call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Possibility to use lcrypt with `$6$` (sha512) for authentication [484](https://github.com/greenbone/gvm-libs/pull/484)
 - Add function to perform an alive test and get the amount of alive hosts. [495](https://github.com/greenbone/gvm-libs/pull/495)
 - Add functions for sentry integration. [#502](https://github.com/greenbone/gvm-libs/pull/502) [#506](https://github.com/greenbone/gvm-libs/pull/506)
-- Add basic support for mqtt. [505](https://github.com/greenbone/gvm-libs/pull/505)
+- Add basic support for mqtt.
+  [#505](https://github.com/greenbone/gvm-libs/pull/505)
+  [#511](https://github.com/greenbone/gvm-libs/pull/511)
 
 ### Changed
 ### Fixed

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -52,8 +52,8 @@ pkg_check_modules (LIBXML2 REQUIRED libxml-2.0>=2.0)
 
 # for mqtt
 # Optional for now because lib is currently not in debian buster stable.
-find_library(LIBPAHO lpaho)
-message (STATUS "Looking for lpaho... ${LIBPAHO}")
+find_library(LIBPAHO paho-mqtt3c)
+message (STATUS "Looking for paho-mqtt3c ... ${LIBPAHO}")
 if (NOT LIBPAHO)
   message (STATUS "libpaho-mqtt3c is required for MQTTv5 support.")
 else (LIBPAHO)

--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -88,7 +88,7 @@ mqtt_connect (const char *server_uri)
   mqtt_t *mqtt = NULL;
   MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer5;
   MQTTProperties connect_properties = MQTTProperties_initializer;
-  MQTTResponse resp = MQTTResponse_initializer;
+  MQTTResponse resp;
 
   uuid = gvm_uuid_make ();
   client = mqtt_create (server_uri, uuid);
@@ -139,7 +139,7 @@ mqtt_publish (mqtt_t *mqtt, const char *topic, const char *msg)
   MQTTClient client;
   MQTTClient_message pubmsg = MQTTClient_message_initializer;
   MQTTClient_deliveryToken token;
-  MQTTResponse resp = MQTTResponse_initializer;
+  MQTTResponse resp;
   int rc;
 
   client = mqtt->client;


### PR DESCRIPTION
**What**:

Search for paho-mqtt3c instead of lpaho.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->
Does not install with MQTT support otherwise.


**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
Install gvm-libs.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
