### PR TITLE
Initialize reallocated memory in gvm_hosts_add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Adding initialization to struct scanner in `boreas/util_tests.c`. [#438](https://github.com/greenbone/gvm-libs/pull/438)
 - Fix warnings about uninitialized variables. [#448](https://github.com/greenbone/gvm-libs/pull/448)
 - Split the log message into smaller pieces when syslog is the log destination.  [#455](https://github.com/greenbone/gvm-libs/pull/455)
+- Initialize reallocated memory in gvm_hosts_add [#520](https://github.com/greenbone/gvm-libs/pull/520)
 
 ### Removed
 

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -957,7 +957,7 @@ gvm_hosts_add (gvm_hosts_t *hosts, gvm_host_t *host)
       hosts->max_size *= 4;
       hosts->hosts =
         g_realloc_n (hosts->hosts, hosts->max_size, sizeof (*hosts->hosts));
-      memset (hosts->hosts + (hosts->count * sizeof (gvm_host_t*)), '\0',
+      memset (hosts->hosts + hosts->count, '\0',
               (hosts->max_size - hosts->count) * sizeof (gvm_host_t*));
     }
   hosts->hosts[hosts->count] = host;

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -957,6 +957,9 @@ gvm_hosts_add (gvm_hosts_t *hosts, gvm_host_t *host)
       hosts->max_size *= 4;
       hosts->hosts =
         g_realloc_n (hosts->hosts, hosts->max_size, sizeof (*hosts->hosts));
+      memset (hosts->hosts + (hosts->count * sizeof (gvm_host_t*)),
+              '\0',
+              (hosts->max_size - hosts->count) * sizeof (gvm_host_t*));
     }
   hosts->hosts[hosts->count] = host;
   hosts->count++;

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -957,8 +957,7 @@ gvm_hosts_add (gvm_hosts_t *hosts, gvm_host_t *host)
       hosts->max_size *= 4;
       hosts->hosts =
         g_realloc_n (hosts->hosts, hosts->max_size, sizeof (*hosts->hosts));
-      memset (hosts->hosts + (hosts->count * sizeof (gvm_host_t*)),
-              '\0',
+      memset (hosts->hosts + (hosts->count * sizeof (gvm_host_t*)), '\0',
               (hosts->max_size - hosts->count) * sizeof (gvm_host_t*));
     }
   hosts->hosts[hosts->count] = host;


### PR DESCRIPTION
**What**:
If the array memory for the hosts is reallocated, the new memory is
initialized with all \0 bytes.

**Why**:
This ensures the array is correctly terminated when gvm_hosts_fill_gaps
is called when excluding hosts.

**How**:
By creating multiple targets with very large host ranges (> 2 million hosts) and adding excluded hosts to at least one of them.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
