### PR TITLE
Do not send unnecessary message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix info msg when 0 alive hosts are left to scan and max_scan_hosts limit is reached. No message will be generated for that case anymore. [#561](https://github.com/greenbone/gvm-libs/pull/561)
 
 [Unreleased]: https://github.com/greenbone/gvm-libs/compare/v20.8.2...HEAD
 

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -185,7 +185,10 @@ get_host_from_queue (kb_t alive_hosts_kb, gboolean *alive_deteciton_finished)
 
               num_not_scanned_hosts =
                 get_alive_hosts_count () - get_max_scan_hosts ();
-              send_limit_msg (num_not_scanned_hosts);
+              if (0 != num_not_scanned_hosts)
+                {
+                  send_limit_msg (num_not_scanned_hosts);
+                }
             }
           g_debug ("%s: Boreas already finished scanning and we reached the "
                    "end of the Queue of alive hosts.",


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Do not send unnecessary message anymore.
When 0 alive hosts are left to scan and max_scan_hosts limit is reached no message will be generated for that case anymore.

**Why**:

SC-298

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
Start a scan with 1 host and `max_scan_hosts = 1` and `test_alive_hosts_only = yes`. Before PR a Error Message message about 0 left alive hosts is generated. After PR no message in generated anymore.


**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
