### PR TITLE
Get vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Reintroduction after Rebase
   [#538](https://github.com/greenbone/gvm-libs/pull/538)
 - Add function for mqtt init status [#567](https://github.com/greenbone/gvm-libs/pull/567)
+- Add function to get the severity_vector, otherwise the cvss_base_vector. [#568](https://github.com/greenbone/gvm-libs/pull/568)
 
 ### Changed
 

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -937,6 +937,36 @@ nvti_severity_score (const nvti_t *n)
 }
 
 /**
+ * @brief Get the severity score
+ *
+ * Extended severity was introduced but still not all
+ * vts are using it. Therefore it must be check if
+ * we can calculate the score from the severity_vector tag
+ * or we have to calculate it from the deprecated
+ * cvss_base_vector tag.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @return The severity_vector if present or cvss_base_vector otherwise.
+ * NULL indicates an error. Must be free()'d by the caller.
+ */
+gchar *
+nvti_severity_vector_from_tag (const nvti_t *n)
+{
+  gchar *vector;
+
+  /* Currently, only one severity_vector can be stored as tag.
+   * Therfore we just check this one. */
+  vector = nvti_get_tag (n, "severity_vector");
+  if (vector)
+    return vector;
+
+  vector = nvti_get_tag (n, "cvss_base_vector");
+
+  return vector;
+}
+
+/**
  * @brief Get the solution.
  *
  * @param n The NVT Info structure of which the solution should

--- a/base/nvti.c
+++ b/base/nvti.c
@@ -940,9 +940,9 @@ nvti_severity_score (const nvti_t *n)
  * @brief Get the severity score
  *
  * Extended severity was introduced but still not all
- * vts are using it. Therefore it must be check if
+ * vts are using it. Therefore it must be checked if
  * we can calculate the score from the severity_vector tag
- * or we have to calculate it from the deprecated
+ * or if we have to calculate it from the deprecated
  * cvss_base_vector tag.
  *
  * @param n The NVT Info structure.

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -105,6 +105,8 @@ vtseverity_t *
 nvti_vtseverity (const nvti_t *, guint);
 double
 nvti_severity_score (const nvti_t *);
+gchar *
+nvti_severity_vector_from_tag (const nvti_t *);
 
 nvti_t *
 nvti_new (void);

--- a/base/nvti_tests.c
+++ b/base/nvti_tests.c
@@ -141,6 +141,48 @@ Ensure (nvti, nvtis_add_does_not_use_oid_as_key)
   assert_that (nvtis_lookup (nvtis, "2"), is_null);
 }
 
+/* nvti severity vector */
+
+Ensure (nvti, nvti_get_severity_vector_both)
+{
+  nvti_t *nvti;
+
+  nvti = nvti_new ();
+  nvti_set_tag (nvti, "cvss_base_vector=DEF");
+  nvti_set_tag (nvti, "severity_vector=ABC");
+
+  assert_that (nvti_severity_vector_from_tag (nvti),
+               is_equal_to_string ("ABC"));
+
+  nvti_free (nvti);
+}
+
+Ensure (nvti, nvti_get_severity_vector_no_cvss_base)
+{
+  nvti_t *nvti;
+
+  nvti = nvti_new ();
+  nvti_set_tag (nvti, "severity_vector=ABC");
+
+  assert_that (nvti_severity_vector_from_tag (nvti),
+               is_equal_to_string ("ABC"));
+
+  nvti_free (nvti);
+}
+
+Ensure (nvti, nvti_get_severity_vector_no_severity_vector)
+{
+  nvti_t *nvti;
+
+  nvti = nvti_new ();
+  nvti_set_tag (nvti, "cvss_base_vector=DEF");
+
+  assert_that (nvti_severity_vector_from_tag (nvti),
+               is_equal_to_string ("DEF"));
+
+  nvti_free (nvti);
+}
+
 /* Test suite. */
 
 int
@@ -162,6 +204,11 @@ main (int argc, char **argv)
   add_test_with_context (suite, nvti, nvti_set_solution_method_correct);
 
   add_test_with_context (suite, nvti, nvtis_add_does_not_use_oid_as_key);
+
+  add_test_with_context (suite, nvti, nvti_get_severity_vector_both);
+  add_test_with_context (suite, nvti,
+                         nvti_get_severity_vector_no_severity_vector);
+  add_test_with_context (suite, nvti, nvti_get_severity_vector_no_cvss_base);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
**What**:
Add function to get the severity_vector, otherwise the cvss_base_vector.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Extended severity was introduced and there are new tags to hold severity information. severity_vector is the tag name.
Some VTs doesn't have the new tag, but the old one cvss_base_vector. This function returns the vector severity_vector, or the cvss_base_vector if the vt does not have the new tag.

<!-- Why are these changes necessary? -->

**How**:
Test added
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
