### PR TITLE
Change: set initialized to false on mqtt_reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Refactor MQTT handling [#562](https://github.com/greenbone/gvm-libs/pull/562)
 - Handle script timeout as script preference with ID 0 [#578](https://github.com/greenbone/gvm-libs/pull/578)
+- Set initialized to false on reset [585](https://github.com/greenbone/gvm-libs/pull/585)
 
 ### Fixed
 - Fix prototypes in mqtt.h. [#584](https://github.com/greenbone/gvm-libs/pull/584)

--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -201,6 +201,7 @@ mqtt_reset ()
   mqtt_client_data_destroy (&mqtt);
 
   mqtt_set_global_client (NULL);
+  mqtt_set_initialized_status (FALSE);
 
   g_debug ("%s: end", __func__);
   return;


### PR DESCRIPTION
On mqtt_reset the mqtt client gets ddestroyed and niled but the value
for initialized is still true; this could trick dependening libraries to
believe that mqtt is still initialized.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
