### PR TITLE
Fix free host segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#538](https://github.com/greenbone/gvm-libs/pull/538)
 - Add function for mqtt init status [#567](https://github.com/greenbone/gvm-libs/pull/567)
 - Add function to get the severity_vector, otherwise the cvss_base_vector. [#568](https://github.com/greenbone/gvm-libs/pull/568)
+- Add function to duplicate host and vhost objects [#590](https://github.com/greenbone/gvm-libs/pull/590)
 
 ### Changed
 

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -909,6 +909,28 @@ gvm_vhost_free (gpointer vhost)
 }
 
 /**
+ * @brief Creates a deep copy of a gvm_vhost_t object.
+ *
+ * @param vhost source vhost
+ * @param data dummy for g_slist_copy_deep
+ * @return gpointer copy of vhost
+ */
+gpointer
+gvm_duplicate_vhost (gconstpointer vhost, gpointer data)
+{
+  (void) (data);
+  gvm_vhost_t *ret = NULL;
+
+  if (!vhost)
+    return NULL;
+
+  ret = gvm_vhost_new (g_strdup (((gvm_vhost_t *) vhost)->value),
+                       g_strdup (((gvm_vhost_t *) vhost)->source));
+
+  return ret;
+}
+
+/**
  * @brief Creates a new gvm_host_t object.
  *
  * @return Pointer to new host object, NULL if creation fails.
@@ -1984,6 +2006,43 @@ gvm_host_find_in_hosts (const gvm_host_t *host, const struct in6_addr *addr,
 
   g_free (host_str);
   return NULL;
+}
+
+/**
+ * @brief Creates a deep copy of a host. gvm_host_free has to be called on it.
+ *
+ * @param host source host
+ * @return gvm_host_t* copy of host
+ */
+gvm_host_t *
+gvm_duplicate_host (gvm_host_t *host)
+{
+  gvm_host_t *ret = NULL;
+
+  if (host == NULL)
+    return NULL;
+
+  ret = gvm_host_new ();
+
+  ret->type = host->type;
+  switch (host->type)
+    {
+    case HOST_TYPE_NAME:
+      ret->name = g_strdup (host->name);
+      break;
+    case HOST_TYPE_IPV4:
+      ret->addr.s_addr = host->addr.s_addr;
+      break;
+    case HOST_TYPE_IPV6:
+      ret->addr6.__in6_u = host->addr6.__in6_u;
+      break;
+    default:
+      g_free (ret);
+      return NULL;
+    }
+  ret->vhosts = g_slist_copy_deep (host->vhosts, gvm_duplicate_vhost, NULL);
+
+  return ret;
 }
 
 /**

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -189,6 +189,11 @@ gvm_host_add_reverse_lookup (gvm_host_t *);
 
 void gvm_host_free (gpointer);
 
+gpointer gvm_duplicate_vhost (gconstpointer, gpointer);
+
+gvm_host_t *
+gvm_duplicate_host (gvm_host_t *);
+
 /* Miscellaneous functions */
 
 gvm_vhost_t *


### PR DESCRIPTION
**What**:
Added a duplicate function for host and vhost.
https://github.com/greenbone/openvas-scanner/pull/888 depends on this PR

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In some cases a Segmentation Fault appears when freeing the hosts and vhosts of hosts and alive_hosts_list.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-libs/blob/master/CHANGELOG.md) Entry
