### PR TITLE
Use deprecation as warning for `g_memdup`

### DIFF
--- a/base/networking.c
+++ b/base/networking.c
@@ -365,13 +365,19 @@ gvm_resolve_list (const char *name)
         {
           struct sockaddr_in *addrin = (struct sockaddr_in *) p->ai_addr;
           ipv4_as_ipv6 (&(addrin->sin_addr), &dst);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
           list = g_slist_prepend (list, g_memdup (&dst, sizeof (dst)));
+#pragma GCC diagnostic pop
         }
       else if (p->ai_family == AF_INET6)
         {
           struct sockaddr_in6 *addrin = (struct sockaddr_in6 *) p->ai_addr;
           memcpy (&dst, &(addrin->sin6_addr), sizeof (struct in6_addr));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
           list = g_slist_prepend (list, g_memdup (&dst, sizeof (dst)));
+#pragma GCC diagnostic pop
         }
       p = p->ai_next;
     }

--- a/util/kb.c
+++ b/util/kb.c
@@ -629,7 +629,10 @@ redis2kbitem_single (const char *name, const redisReply *elt, int force_int)
   else
     {
       item->type = KB_TYPE_STR;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
       item->v_str = g_memdup (elt->str, elt->len + 1);
+#pragma GCC diagnostic pop
       item->len = elt->len;
     }
 


### PR DESCRIPTION
**What**:

* set warning to deprecation for `g_memdup`.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* glib is<2.68 in debian buster and … bullseye, so we need to relay on g_memdup for backwarts compatibility.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
