### PR TITLE
Install libcgreen unit test library via Debian

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
     libldap2-dev \
     libradcli-dev \
     libpaho-mqtt-dev \
+    libcgreen1-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gcc/g++ compiler

--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
     libradcli-dev \
     libpaho-mqtt-dev \
     libcgreen1-dev \
+    lcov \
     && rm -rf /var/lib/apt/lists/*
 
 # Install gcc/g++ compiler

--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -29,17 +29,6 @@ jobs:
           - greenbone/gvm-libs-gcc-build:main
     container: ${{ matrix.container }}
     steps:
-      - name: Clone cgreen
-        uses: actions/checkout@v2
-        with:
-          repository: cgreen-devs/cgreen
-          ref: 1.4.0
-      - name: Install cgreen
-        run: |
-          make
-          make test
-          make install
-          ldconfig
       - uses: actions/checkout@v2
       - name: Configure and Compile gvm-libs
         run: |


### PR DESCRIPTION
**What**:

With using Debian stable (Bullseye) a package of libcgreen is available
and it isn't required to build it ourselfs.


**Why**:

We use Debian Bullseye for the container images which provides a package for libcgreen.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
