### PR TITLE
Create pid file by specifying full path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,10 +177,6 @@ if (NOT GVM_RUN_DIR)
   set (GVM_RUN_DIR  "/run/gvm")
 endif (NOT GVM_RUN_DIR)
 
-if (NOT GVM_PID_DIR)
-  set (GVM_PID_DIR "${GVM_RUN_DIR}")
-endif (NOT GVM_PID_DIR)
-
 if (NOT GVM_SYSCONF_DIR)
   set (GVM_SYSCONF_DIR "${SYSCONFDIR}/gvm")
 endif (NOT GVM_SYSCONF_DIR)

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -61,10 +61,6 @@ set (LIBGVM_BASE_NAME
      ${LIBGVM_BASE_NAME}
      PARENT_SCOPE)
 
-if (GVM_PID_DIR)
-  add_definitions (-DGVM_PID_DIR="${GVM_PID_DIR}")
-endif (GVM_PID_DIR)
-
 if (GVM_SYSCONF_DIR)
   add_definitions (-DGVM_SYSCONF_DIR="${GVM_SYSCONF_DIR}")
 endif (GVM_SYSCONF_DIR)
@@ -143,7 +139,7 @@ endif (BUILD_TESTS)
 
 configure_file (libgvm_base.pc.in ${CMAKE_BINARY_DIR}/libgvm_base.pc @ONLY)
 
-install (DIRECTORY DESTINATION ${GVM_PID_DIR})
+install (DIRECTORY DESTINATION ${GVM_RUN_DIR})
 
 install (FILES ${CMAKE_BINARY_DIR}/libgvm_base.pc
          DESTINATION ${LIBDIR}/pkgconfig)

--- a/base/pidfile.c
+++ b/base/pidfile.c
@@ -25,7 +25,7 @@
 #include "pidfile.h"
 
 #include <errno.h>       /* for errno */
-#include <glib.h>        /* for g_free, gchar, g_build_filename, g_strconcat */
+#include <glib.h>        /* for g_free, gchar */
 #include <glib/gstdio.h> /* for g_unlink, g_fopen */
 #include <stdio.h>       /* for fclose, FILE */
 #include <stdlib.h>      /* for atoi */
@@ -42,20 +42,17 @@
  * @brief Create a PID-file.
  *
  * A standard PID file will be created for the
- * given daemon name.
+ * given path.
  *
- * @param[in]  daemon_name The name of the daemon
+ * @param[in]  pid_file_path The full path of the pid file. E.g.
+ * "/tmp/service1.pid"
  *
  * @return 0 for success, anything else indicates an error.
  */
 int
-pidfile_create (gchar *daemon_name)
+pidfile_create (gchar *pid_file_path)
 {
-  gchar *name_pid = g_strconcat (daemon_name, ".pid", NULL);
-  gchar *pidfile_name = g_build_filename (GVM_PID_DIR, name_pid, NULL);
-  FILE *pidfile = g_fopen (pidfile_name, "w");
-
-  g_free (name_pid);
+  FILE *pidfile = g_fopen (pid_file_path, "w");
 
   if (pidfile == NULL)
     {
@@ -67,7 +64,6 @@ pidfile_create (gchar *daemon_name)
     {
       g_fprintf (pidfile, "%d\n", getpid ());
       fclose (pidfile);
-      g_free (pidfile_name);
     }
   return 0;
 }
@@ -75,27 +71,22 @@ pidfile_create (gchar *daemon_name)
 /**
  * @brief Remove PID file.
  *
- * @param[in]  daemon_name The name of the daemon
+ * @param[in]  pid_file_path The full path of the pid file. E.g.
+ * "/tmp/service1.pid"
  */
 void
-pidfile_remove (gchar *daemon_name)
+pidfile_remove (gchar *pid_file_path)
 {
-  gchar *name_pid = g_strconcat (daemon_name, ".pid", NULL);
-  gchar *pidfile_name = g_build_filename (GVM_PID_DIR, name_pid, NULL);
   gchar *pidfile_contents;
 
-  g_free (name_pid);
-
-  if (g_file_get_contents (pidfile_name, &pidfile_contents, NULL, NULL))
+  if (g_file_get_contents (pid_file_path, &pidfile_contents, NULL, NULL))
     {
       int pid = atoi (pidfile_contents);
 
       if (pid == getpid ())
         {
-          g_unlink (pidfile_name);
+          g_unlink (pid_file_path);
         }
       g_free (pidfile_contents);
     }
-
-  g_free (pidfile_name);
 }


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Delete GVM_PID_DIR define.
Change pid file functions to receive the full path to the pid file instead of just the name and using GVM_PID_DIR.

Jira: AP-1789

**Why**:

<!-- Why are these changes necessary? -->

Makes defining pid file more flexible.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

```C
#include <glib.h>
#include <gvm/base/pidfile.h>
#include <unistd.h>

void
main(int argc, char **argv)
{
  gchar *pid_file_path = "/tmp/test1.pid"; 
  pidfile_create (pid_file);
  sleep(20);
  pidfile_remove (pid_file);
}
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
