### PR TITLE
Always init logger mutex before use

### DIFF
--- a/base/logging.c
+++ b/base/logging.c
@@ -368,6 +368,9 @@ gvm_log_lock_init (void)
 void
 gvm_log_lock (void)
 {
+  /* Initialize logger lock if not done already. */
+  gvm_log_lock_init ();
+
   g_mutex_lock (logger_mutex);
 }
 
@@ -419,9 +422,6 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
   channel = NULL;
   gchar *syslog_facility = "local0";
   gchar *syslog_ident = NULL;
-
-  /* Initialize logger lock if not done. */
-  gvm_log_lock_init ();
 
   /* Let's load the default configuration file directives from the
    * linked list. Scanning the link list twice is inefficient but


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Make sure to always init logger mutex before use.
Previously it could be the case that the mutex was not yet inited when openvas-scanner calls `gvm_log_lock` in `create_process`.
See https://github.com/greenbone/openvas-scanner/issues/960.
Jira: SC-468

**Why**: 

<!-- Why are these changes necessary? -->
Prevent segfault.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
