### PR TITLE
Add functions osp_check_feed and osp_get_vts_feed_info

### DIFF
--- a/osp/osp.c
+++ b/osp/osp.c
@@ -251,6 +251,9 @@ osp_connection_close (osp_connection_t *connection)
 /**
  * @brief Gets additional status info about the feed.
  *
+ * The lockfile_in_use and self_test_exit_error fields will be set to -1 if
+ * the corresponding elements are missing.
+ *
  * @param[in]   connection            Connection to an OSP server.
  * @param[out]  lockfile_in_use       Whether the lockfile is in use.
  * @param[out]  self_test_exit_error  Whether the sync script self check failed.
@@ -304,7 +307,7 @@ osp_check_feed (osp_connection_t *connection, int *lockfile_in_use,
       else
         {
           g_warning ("%s: element LOCKFILE_IN_USE missing.", __func__);
-          *lockfile_in_use = 0;
+          *lockfile_in_use = -1;
         }
     }
 
@@ -315,7 +318,7 @@ osp_check_feed (osp_connection_t *connection, int *lockfile_in_use,
       else
         {
           g_warning ("%s: element SELF_TEST_EXIT_ERROR missing.", __func__);
-          *self_test_exit_error = 0;
+          *self_test_exit_error = -1;
         }
     }
 

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -95,6 +95,9 @@ osp_connection_close (osp_connection_t *);
 
 /* OSP commands */
 int
+osp_check_feed (osp_connection_t *, int *, int *, char **, char **);
+
+int
 osp_get_version (osp_connection_t *, char **, char **, char **, char **,
                  char **, char **);
 

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -102,6 +102,10 @@ int
 osp_get_vts_version (osp_connection_t *, char **, char **error);
 
 int
+osp_get_vts_feed_info (osp_connection_t *, char **, char **, char **, char **,
+                       char **);
+
+int
 osp_get_vts (osp_connection_t *, entity_t *);
 
 typedef struct


### PR DESCRIPTION
**What**:
This adds new functions to get extended information about the NVTs feed via OSP.

**Why**:
So gvmd can get the info from the scanner instead of calling greenbone-nvt-sync directly.
(AP-1845)

**How**:
By running the `<get_feeds/>` GMP command with the changes from greenbone/gvmd/pull/1769.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
