### PR TITLE
Check if kb_path is NULL before kb_redis init

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -414,13 +414,17 @@ redis_memory_purge (kb_t kb)
  * @param[in] kb  Reference to a kb_t to initialize.
  * @param[in] kb_path   Path to KB.
  *
- * @return 0 on success, -1 on connection error, -2 when no DB is available.
+ * @return 0 on success, -1 on connection error, -2 when no DB is available, -3
+ * when given kb_path was NULL.
  */
 static int
 redis_new (kb_t *kb, const char *kb_path)
 {
   struct kb_redis *kbr;
   int rc = 0;
+
+  if (kb_path == NULL)
+    return -3;
 
   kbr = g_malloc0 (sizeof (struct kb_redis));
   kbr->kb.kb_ops = &KBRedisOperations;
@@ -466,6 +470,9 @@ redis_direct_conn (const char *kb_path, const int kb_index)
   struct kb_redis *kbr;
   redisReply *rep;
 
+  if (kb_path == NULL)
+    return NULL;
+
   kbr = g_malloc0 (sizeof (struct kb_redis));
   kbr->kb.kb_ops = &KBRedisOperations;
   kbr->path = g_strdup (kb_path);
@@ -510,6 +517,9 @@ redis_find (const char *kb_path, const char *key)
 {
   struct kb_redis *kbr;
   unsigned int i = 1;
+
+  if (kb_path == NULL)
+    return NULL;
 
   kbr = g_malloc0 (sizeof (struct kb_redis));
   kbr->kb.kb_ops = &KBRedisOperations;


### PR DESCRIPTION

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

If in struct kb_redis the path is set to NULL later calls to hiredis functions may result in segfault. Therefore check path for NULL before setting it.

Jira: SC-498

**Why**:

<!-- Why are these changes necessary? -->

Prevent potential segfault when not setting a valid path.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
