### PR TITLE
Add: Log warning when Redis tcp connection is used

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -277,6 +277,7 @@ connect_redis (const char *addr, int len)
   int port, host_len;
   char *tmp, *host;
   redisContext *result;
+  static int warn_flag = 0;
 
   if (len < tcp_indicator_len + 1)
     goto unix_connect;
@@ -293,6 +294,13 @@ connect_redis (const char *addr, int len)
   host = calloc (1, host_len);
   memmove (host, addr + tcp_indicator_len, host_len);
   result = redisConnect (host, port);
+  if (warn_flag == 0)
+    {
+      g_warning ("A Redis TCP connection is being used. This feature is "
+                 "experimental and insecure, since it is not an encrypted "
+                 "channel. We discourage its usage in production environments");
+      warn_flag = 1;
+    }
   free (host);
   return result;
 unix_connect:


### PR DESCRIPTION
**What**:
Log warning when Redis tcp connection is used
Jira: SC-550

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Redis TCP connection is not encrypted
<!-- Why are these changes necessary? -->

**How**:
Set redis and openvas to use a tcp connection and check the logs.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
