### PR TITLE
Fix: return with error code when mqtt connect fails

### DIFF
--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -346,7 +346,13 @@ mqtt_init (const char *server_uri)
   g_server_uri = mqtt_get_global_server_uri ();
   if (g_server_uri == NULL)
     mqtt_set_global_server_uri (server_uri);
-  mqtt_connect (mqtt, server_uri);
+  if (mqtt_connect (mqtt, server_uri))
+    {
+      g_warning ("%s: Unable to connect to MQTT broker.", __func__);
+      g_free (mqtt);
+      mqtt = NULL;
+      return -1;
+    }
 
   mqtt_set_global_client (mqtt);
   mqtt_set_initialized_status (TRUE);


### PR DESCRIPTION
**What**:
Handle error of `mqtt_connect`
SC-566

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When `mqtt_connect` failed, no error was returned and openvas thought the MQTT connection was successful even when it was not.

<!-- Why are these changes necessary? -->

**How**:
Start a scan without a broker. Compare before patch and after. Before yout get these messages:
```
libgvm util:CRITICAL:2022-03-23 09h26.41 utc:4416: mqtt_connect: mqtt connection error to tcp://127.0.0.1:1883: Failure
sd   main:MESSAGE:2022-03-23 09h26.41 utc:4416: attack_network_init: INIT MQTT: SUCCESS 
```
after the patch you get
```
sd   main:MESSAGE:2022-03-23 10h34.47 utc:21180: Running LSC via Notus for 127.0.0.1
libgvm util:CRITICAL:2022-03-23 10h34.47 utc:21180: mqtt_connect: mqtt connection error to tcp://127.0.0.1:1883: Failure
libgvm util:WARNING:2022-03-23 10h34.47 utc:21180: mqtt_init: Unable to connect to MQTT broker.
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
