### PR TITLE
Improve boreas retry functionality SC 434

### DIFF
--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -81,7 +81,6 @@ scan (alive_test_t alive_test)
   /* Following variables are only relevant if only ICMP was chosen. */
   int remaining_batch = 0;
   int prev_alive = 0;
-  int i;
   gboolean limit_reached_handled = FALSE; /* Scan restrictions related. */
 
   gettimeofday (&start_time, NULL);
@@ -232,10 +231,7 @@ scan (alive_test_t alive_test)
         "%s: all ping packets have been sent, wait a bit for rest of replies.",
         __func__);
 
-      /* If all targets are already identified as alive we do not need to wait
-       * for replies anymore.*/
-
-      for (i = 0; i < max_wait_rounds; i++)
+      for (int i = 0; i < max_wait_rounds; i++)
         {
           if (number_of_targets
               == (int) g_hash_table_size (scanner.hosts_data->alivehosts))

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -69,6 +69,7 @@ scanner_t scanner;
 static int
 scan (alive_test_t alive_test)
 {
+  const int max_wait_rounds = 3;
   int number_of_targets;
   int number_of_dead_hosts;
   pthread_t sniffer_thread_id;
@@ -80,6 +81,7 @@ scan (alive_test_t alive_test)
   /* Following variables are only relevant if only ICMP was chosen. */
   int remaining_batch = 0;
   int prev_alive = 0;
+  int i;
   gboolean limit_reached_handled = FALSE; /* Scan restrictions related. */
 
   gettimeofday (&start_time, NULL);
@@ -232,10 +234,14 @@ scan (alive_test_t alive_test)
 
       /* If all targets are already identified as alive we do not need to wait
        * for replies anymore.*/
-      if (number_of_targets
-          != (int) g_hash_table_size (scanner.hosts_data->alivehosts))
-        sleep (WAIT_FOR_REPLIES_TIMEOUT);
 
+      for (i = 0; i < max_wait_rounds; i++)
+        {
+          if (number_of_targets
+              == (int) g_hash_table_size (scanner.hosts_data->alivehosts))
+            break;
+          sleep (WAIT_FOR_REPLIES_TIMEOUT);
+        }
       stop_sniffer_thread (&scanner, sniffer_thread_id);
     }
 

--- a/boreas/ping.c
+++ b/boreas/ping.c
@@ -258,7 +258,7 @@ send_icmp (gpointer key, gpointer value, gpointer scanner_p)
 
   scanner = (scanner_t *) scanner_p;
 
-  // we send multiple icmp message to reduce to chance of unwanted drops
+  // we send multiple icmp messages to reduce the chance of unwanted drops
   for (i = 0; i < icmp_retries; i++)
     {
       if (g_hash_table_contains (scanner->hosts_data->alivehosts, key))

--- a/boreas/ping.c
+++ b/boreas/ping.c
@@ -257,12 +257,12 @@ send_icmp (gpointer key, gpointer value, gpointer scanner_p)
   int icmp_retries, grace_period = 0;
   const char *tmp;
   if ((icmp_retries =
-         (tmp = prefs_get ("ICMP_RETRIES")) != NULL ? atoi (tmp) : 1)
+         (tmp = prefs_get ("icmp_retries")) != NULL ? atoi (tmp) : 1)
       <= 0)
     icmp_retries = 1;
   else if (icmp_retries > 1)
     grace_period =
-      (tmp = prefs_get ("ICMP_GRACE_PERIOD")) != NULL ? atoi (tmp) : 0;
+      (tmp = prefs_get ("icmp_grace_period")) != NULL ? atoi (tmp) : 0;
 
   scanner = (scanner_t *) scanner_p;
 

--- a/boreas/sniffer.c
+++ b/boreas/sniffer.c
@@ -26,7 +26,6 @@
 #include <errno.h>
 #include <glib.h>
 #include <net/if_arp.h>
-#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <stdlib.h>
 #include <string.h>

--- a/boreas/sniffer.c
+++ b/boreas/sniffer.c
@@ -23,7 +23,6 @@
 #include "boreas_io.h"
 
 #include <arpa/inet.h>
-#include <asm-generic/errno-base.h>
 #include <errno.h>
 #include <glib.h>
 #include <net/if_arp.h>

--- a/boreas/sniffer.c
+++ b/boreas/sniffer.c
@@ -239,9 +239,9 @@ sniffer_thread (void *scanner_p)
 int
 stop_sniffer_thread (scanner_t *scanner, pthread_t sniffer_thread_id)
 {
-  // wait period for grace
+  // wait period for grace in microseconds
   const int wait = 5000;
-  // maximum grace period
+  // maximum grace period in microseconds
   const int max_grace = 2 * 1000 * 1000;
   int err, waited;
   void *retval;


### PR DESCRIPTION
To reduce the chances of having hosts wrongfully identified as dead via ICMP the amount of sent icmp packets got enhanced by 10 and the wait overall grace period got increased by 3 to reduce the chances on slower networks.
