### PR TITLE
Fix: instead of setting strlen of argc just assume _POSIX_PATH_MAX 256 

### DIFF
--- a/base/proctitle.c
+++ b/base/proctitle.c
@@ -42,7 +42,6 @@ extern const char *__progname;
 #ifndef __FreeBSD__
 extern const char *__progname_full;
 #endif
-static int argv_len;
 static char **old_argv;
 extern char **environ;
 void *current_environ = NULL;
@@ -63,6 +62,7 @@ proctitle_init (int argc, char **argv)
 #else
   char *new_progname;
 #endif
+  (void) argc;
 
   if (argv == NULL)
     return;
@@ -84,11 +84,6 @@ proctitle_init (int argc, char **argv)
   environ[i] = NULL;
 
   old_argv = argv;
-  if (i > 0)
-    argv_len = envp[i - 1] + strlen (envp[i - 1]) - old_argv[0];
-  else
-    argv_len = old_argv[argc - 1] + strlen (old_argv[argc - 1]) - old_argv[0];
-
   /* Seems like these are in the moved environment, so reset them.  Idea from
    * proctitle.cpp in KDE libs.  */
   __progname = new_progname;
@@ -106,7 +101,6 @@ proctitle_init (int argc, char **argv)
 static void
 proctitle_set_args (const char *new_title, va_list args)
 {
-  int i;
   char *formatted;
 
   if (old_argv == NULL)
@@ -115,15 +109,11 @@ proctitle_set_args (const char *new_title, va_list args)
 
   formatted = g_strdup_vprintf (new_title, args);
 
-  i = strlen (formatted);
-  if (i > argv_len - 2)
-    {
-      i = argv_len - 2;
-      formatted[i] = '\0';
-    }
-  bzero (old_argv[0], argv_len);
-  memcpy (old_argv[0], formatted, argv_len);
-  old_argv[1] = NULL;
+  // _POSIX_PATH_MAX is conservatively defined as 256 so we just assume that
+  // max size in order to not run into segmentation faults or having to malloc
+  memset (old_argv[0], 0, 256);
+  // we ommit one to be 0 terminated
+  memcpy (old_argv[0], formatted, 255);
   g_free (formatted);
 }
 

--- a/base/proctitle.c
+++ b/base/proctitle.c
@@ -112,7 +112,7 @@ proctitle_set_args (const char *new_title, va_list args)
   // _POSIX_PATH_MAX is conservatively defined as 256 so we just assume that
   // max size in order to not run into segmentation faults or having to malloc
   memset (old_argv[0], 0, 256);
-  // we ommit one to be 0 terminated
+  // we omit one to be 0 terminated
   memcpy (old_argv[0], formatted, 255);
   g_free (formatted);
 }

--- a/base/pwpolicy.c
+++ b/base/pwpolicy.c
@@ -137,19 +137,27 @@ policy_checking_failed (void)
 static char *
 is_keyword (char *string, const char *keyword)
 {
-  int n = strlen (keyword);
+  int idx, slen;
+  char *tmp;
+  idx = strlen (keyword);
+  slen = strlen (string);
 
-  if (!strncmp (string, keyword, n))
+  if (!strncmp (string, keyword, idx))
     {
-      if (string[n] == ':') /* Skip the optional colon. */
-        n++;
-      if (!string[n] || g_ascii_isspace (string[n]))
+      tmp = string + idx;
+      if (tmp - string >= slen)
+        return NULL;
+      // skip optional:
+      if (*tmp == ':')
+        tmp++;
+
+      for (; tmp - string < slen && g_ascii_isspace (*tmp); tmp++)
         {
-          string += n;
-          while (g_ascii_isspace (*string))
-            string++;
-          return string;
+          // skip whitespace
         }
+      // double check
+      if (tmp - string < slen)
+        return tmp;
     }
   return NULL;
 }


### PR DESCRIPTION
In some scans it can happen that the program name will go over 256 may
resulting in segmentation faults. To counter that we set the maximal
program name to 256 to avoid malloc or segmentation faults.