### PR TITLE
Fix: limit proctitle to argv space

### DIFF
--- a/base/proctitle.c
+++ b/base/proctitle.c
@@ -43,6 +43,7 @@ extern const char *__progname;
 extern const char *__progname_full;
 #endif
 static char **old_argv;
+static int old_argc;
 extern char **environ;
 void *current_environ = NULL;
 
@@ -62,7 +63,7 @@ proctitle_init (int argc, char **argv)
 #else
   char *new_progname;
 #endif
-  (void) argc;
+  old_argc = argc;
 
   if (argv == NULL)
     return;
@@ -115,6 +116,9 @@ proctitle_set_args (const char *new_title, va_list args)
   // we omit one to be 0 terminated
   memcpy (old_argv[0], formatted, 255);
   g_free (formatted);
+  // omit previous additional parameter
+  if (old_argc > 1)
+    old_argv[1] = NULL;
 }
 
 /**

--- a/base/pwpolicy.c
+++ b/base/pwpolicy.c
@@ -145,19 +145,19 @@ is_keyword (char *string, const char *keyword)
   if (!strncmp (string, keyword, idx))
     {
       tmp = string + idx;
-      if (tmp - string >= slen)
+      if (tmp - string > slen)
         return NULL;
       // skip optional:
       if (*tmp == ':')
         tmp++;
+      if (tmp - string > slen)
+        return NULL;
 
       for (; tmp - string < slen && g_ascii_isspace (*tmp); tmp++)
         {
           // skip whitespace
         }
-      // double check
-      if (tmp - string < slen)
-        return tmp;
+      return tmp;
     }
   return NULL;
 }


### PR DESCRIPTION
According to C99:
```
The parameters argc and argv and the strings pointed to by the argv array shall
be modifiable by the program, and retain their last-stored v alues between program
startup and program termination.
```

This means that only the data in argv is guaranteed to be writeable; everything else is not specified and may be different depending on the execution context and machine.

The previvous solution used the space `environ` by allocating a new environ block and move the memory. This however is also not guaranteed and has lead to segmentation faults and is according to `man 7 environ` in BUGS:

```
There  is also the risk of name space pollution.  
Programs like make and autoconf allow overriding of default utility names from the environment with similarly named variables in all caps.
...
Such usage is considered mistaken, and to be avoided in new programs.
```

which indicates that using environ to accumulate more space for a display name is based on a misuse.