### PR TITLE
Refactor: add changelog.toml

### DIFF
--- a/changelog.toml
+++ b/changelog.toml
@@ -1,0 +1,8 @@
+commit_types = [
+    { message = "^add", group = "Added"},
+    { message = "^remove", group = "Removed"},
+    { message = "^change", group = "Changed"},
+    { message = "^fix", group = "Bug Fixes"},
+]
+
+changelog_dir = "changelog"


### PR DESCRIPTION
To be able to create a changelog from conventional commits we need to
define which commits should be parsed within a changelog.toml.
