### PR TITLE
Fix: Require libpaho for mqtt support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@ INSTALLATION INSTRUCTIONS FOR GVM-LIBS
 ======================================
 
 Please note: The reference system used by most of the developers is Debian
-GNU/Linux 'Buster' 10. The build might fail on any other system. Also, it is
+GNU/Linux 'Bullseye' 11. The build might fail on any other system. Also, it is
 necessary to install dependent development packages.
 
 Prerequisites for gvm-libs
@@ -29,6 +29,7 @@ Specific development libraries:
 * libnet1 >= 1.1.2.1 (boreas)
 * libpcap
 * libgcrypt
+* libpaho-mqtt >= 1.3.0 (utils)
 
 Prerequisites for building documentation:
 * doxygen
@@ -37,7 +38,7 @@ Prerequisites for building documentation:
 Prerequisites for building tests:
 * [Cgreen](https://cgreen-devs.github.io/#_installing_cgreen) (optional, for building tests)
 
-Install prerequisites on Debian GNU/Linux 'Buster' 10:
+Install prerequisites on Debian GNU/Linux 'Bullseye' 11:
 
     apt-get install \
     cmake \
@@ -50,7 +51,8 @@ Install prerequisites on Debian GNU/Linux 'Buster' 10:
     libhiredis-dev \
     libxml2-dev \
     libpcap-dev \
-    libnet1-dev
+    libnet1-dev \
+    libpaho-mqtt-dev
 
 
 Prerequisites for Optional Features
@@ -70,9 +72,6 @@ Install prerequisites for optional features on Debian GNU/Linux 'Buster' 10:
     apt-get install \
     libldap2-dev \
     libradcli-dev
-
-Prerequisites for MQTT support:
-* libpaho-mqtt-dev >= 1.3.8. This package is currently not available in debian buster stable. Could be installed from source, backports or unstable branch.
 
 Compiling gvm-libs
 ------------------

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -51,11 +51,10 @@ pkg_check_modules (REDIS REQUIRED hiredis>=0.10.1)
 pkg_check_modules (LIBXML2 REQUIRED libxml-2.0>=2.0)
 
 # for mqtt
-# Optional for now because lib is currently not in debian buster stable.
 find_library(LIBPAHO paho-mqtt3c)
 message (STATUS "Looking for paho-mqtt3c ... ${LIBPAHO}")
 if (NOT LIBPAHO)
-  message (STATUS "libpaho-mqtt3c is required for MQTTv5 support.")
+  message (SEND_ERROR "libpaho-mqtt3c is required for MQTTv5 support.")
 else (LIBPAHO)
   set (LIBPAHO_LDFLAGS "paho-mqtt3c")
   add_definitions (-DHAVE_MQTT=1)


### PR DESCRIPTION
**What**:

MQTT support is required for openvas-scanner. It would be possible to
just not build the mqtt support in gvm-libs but in that case it would
be required to check in openvas-scanner if gvm-libs has mqtt support.
Therefore it is easier to always build gvm-libs with mqtt support.

Closes #694

**Why**:

libpaho is already required see #694 and #632

**How**:

```sh
apt remove libpaho-mqtt-dev
mkdir build &&cd build
cmake ..
```
cmake configuration fails with an error.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
