### PR TITLE
Change: Use new trigger-workflow action to update dependent images (stable)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -57,24 +57,17 @@ jobs:
   trigger-related-projects:
     needs: production
     if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        repository: ["greenbone/openvas-scanner", "greenbone/gvmd", "greenbone/gsad"]
     name: Trigger update container images in related projects
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger main openvas-scanner container image build
-        run: |
-          curl -X POST https://api.github.com/repos/greenbone/openvas-scanner/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u greenbonebot:${{ secrets.GREENBONE_BOT_TOKEN }} \
-          --data '{"event_type": "update-main-images"}'
-      - name: Trigger main gvmd container image build
-        run: |
-          curl -X POST https://api.github.com/repos/greenbone/gvmd/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u greenbonebot:${{ secrets.GREENBONE_BOT_TOKEN }} \
-          --data '{"event_type": "update-main-images"}'
-      - name: Trigger main gsad container image build
-        run: |
-          curl -X POST https://api.github.com/repos/greenbone/gsad/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u greenbonebot:${{ secrets.GREENBONE_BOT_TOKEN }} \
-          --data '{"event_type": "update-main-images"}'
+      - name: Trigger stable ${{ matrix.repository }} container image build
+        uses: greenbone/actions/trigger-workflow@v2
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: ${{ matrix.repository }}
+          workflow: container.yml
+          ref: stable


### PR DESCRIPTION
**What**:

Use new trigger-workflow action to update dependent images

**Why**:

When the gvm-libs container has re-build all dependent images should be re-build too.

DEVOPS-404

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
