### PR TITLE
Use matrix to trigger dependent image builds in parallel

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -58,26 +58,16 @@ jobs:
     needs: production
     if: github.event_name != 'pull_request'
     name: Trigger update container images in related projects
+    strategy:
+      fail-fast: false
+      matrix:
+        repository: ["greenbone/openvas-scanner", "greenbone/gvmd", "greenbone/gsad"]
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger main openvas-scanner container image build
+      - name: Trigger main ${{ matrix.repository }} container image build
         uses: greenbone/actions/trigger-workflow@v2
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-          repository: greenbone/openvas-scanner
-          workflow: container.yml
-          ref: main
-      - name: Trigger main gvmd container image build
-        uses: greenbone/actions/trigger-workflow@v2
-        with:
-          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-          repository: greenbone/gvmd
-          workflow: container.yml
-          ref: main
-      - name: Trigger main gsad container image build
-        uses: greenbone/actions/trigger-workflow@v2
-        with:
-          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-          repository: greenbone/gsad
+          repository: ${{ matrix.repository }}
           workflow: container.yml
           ref: main


### PR DESCRIPTION
**What**:

Use matrix to trigger dependent image builds in parallel

DEVOPS-404

**Why**:

Simplify triggering dependent container image builds by using a workflow matrix.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
