### PR TITLE
Add: Boreas timeout option

### DIFF
--- a/base/prefs.c
+++ b/base/prefs.c
@@ -80,6 +80,7 @@ prefs_init (void)
   prefs_set ("report_host_details", "yes");
   prefs_set ("vendor_version", "\0");
   prefs_set ("test_alive_hosts_only", "yes");
+  prefs_set ("test_alive_wait_timeout", "3");
   prefs_set ("debug_tls", "0");
   prefs_set ("allow_simultaneous_ips", "yes");
 }

--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -69,7 +69,6 @@ scanner_t scanner;
 static int
 scan (alive_test_t alive_test)
 {
-  const int max_wait_rounds = 3;
   int number_of_targets;
   int number_of_dead_hosts;
   pthread_t sniffer_thread_id;
@@ -231,12 +230,12 @@ scan (alive_test_t alive_test)
         "%s: all ping packets have been sent, wait a bit for rest of replies.",
         __func__);
 
-      for (int i = 0; i < max_wait_rounds; i++)
+      for (unsigned int i = 0; i < get_alive_test_wait_timeout (); i++)
         {
           if (number_of_targets
               == (int) g_hash_table_size (scanner.hosts_data->alivehosts))
             break;
-          sleep (WAIT_FOR_REPLIES_TIMEOUT);
+          sleep (1); // 1 second is the minimum wait time
         }
       stop_sniffer_thread (&scanner, sniffer_thread_id);
     }

--- a/boreas/alivedetection.h
+++ b/boreas/alivedetection.h
@@ -30,8 +30,6 @@
 #define BURST 100
 /* how long (in microseconds) to wait until new BURST of packets is send */
 #define BURST_TIMEOUT 100000
-/* how tong (in sec) to wait for replies after last packet was sent */
-#define WAIT_FOR_REPLIES_TIMEOUT 1
 /* Src port of outgoing TCP pings. Used for filtering incoming packets. */
 #define FILTER_PORT 9910
 

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -32,6 +32,9 @@
  */
 #define G_LOG_DOMAIN "libgvm boreas"
 
+/* how long (in sec) to wait for replies after last packet was sent */
+#define WAIT_FOR_REPLIES_TIMEOUT 3
+
 scan_restrictions_t scan_restrictions;
 
 /**

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -504,3 +504,26 @@ get_alive_test_ports (void)
     return prefs_get ("alive_test_ports");
   return prefs_get ("ALIVE_TEST_PORTS");
 }
+
+/**
+ * @brief Get the max time in seconds that boreas waits for replies.
+ * Minimum is 1 second. Max is 20. If a given value is invalid or greather
+ * than 20, it is set to WAIT_FOR_REPLIES_TIMEOUT
+ *
+ * @return unsigned integer for the time in seconds.
+ */
+unsigned int
+get_alive_test_wait_timeout (void)
+{
+  unsigned int timeout = -1;
+  const gchar *str_timeout = NULL;
+
+  str_timeout = prefs_get ("test_alive_wait_timeout");
+  if (str_timeout != NULL)
+    timeout = atoi (str_timeout);
+
+  if (timeout > 0 && timeout <= 20)
+    return timeout;
+
+  return WAIT_FOR_REPLIES_TIMEOUT;
+}

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -56,6 +56,9 @@ get_alive_test_methods (alive_test_t *);
 const gchar *
 get_alive_test_ports (void);
 
+unsigned int
+get_alive_test_wait_timeout (void);
+
 int
 get_alive_hosts_count (void);
 

--- a/boreas/cli.c
+++ b/boreas/cli.c
@@ -37,6 +37,8 @@
  */
 #define G_LOG_DOMAIN "libgvm boreas"
 
+static unsigned int wait_timeout = 0;
+
 static boreas_error_t
 init_cli (scanner_t *scanner, gvm_hosts_t *hosts, alive_test_t alive_test,
           const gchar *port_list, const int print_results)
@@ -154,7 +156,10 @@ run_cli_scan (scanner_t *scanner, alive_test_t alive_test)
       usleep (500000);
     }
 
-  sleep (get_alive_test_wait_timeout ());
+  if (wait_timeout > 0 && wait_timeout <= 20)
+    sleep (wait_timeout);
+  else
+    sleep (get_alive_test_wait_timeout ());
 
   stop_sniffer_thread (scanner, sniffer_thread_id);
 
@@ -170,13 +175,16 @@ run_cli_scan (scanner_t *scanner, alive_test_t alive_test)
 }
 
 boreas_error_t
-run_cli (gvm_hosts_t *hosts, alive_test_t alive_test, const gchar *port_list)
+run_cli (gvm_hosts_t *hosts, alive_test_t alive_test, const gchar *port_list,
+         const unsigned int timeout)
 {
   scanner_t scanner = {0};
   boreas_error_t init_err;
   boreas_error_t run_err;
   boreas_error_t free_err;
   int print_results = 1;
+
+  wait_timeout = timeout;
 
   init_err = init_cli (&scanner, hosts, alive_test, port_list, print_results);
   if (init_err)

--- a/boreas/cli.c
+++ b/boreas/cli.c
@@ -175,8 +175,14 @@ run_cli_scan (scanner_t *scanner, alive_test_t alive_test)
 }
 
 boreas_error_t
-run_cli (gvm_hosts_t *hosts, alive_test_t alive_test, const gchar *port_list,
-         const unsigned int timeout)
+run_cli (gvm_hosts_t *hosts, alive_test_t alive_test, const gchar *port_list)
+{
+  return run_cli_extended (hosts, alive_test, port_list, 3);
+}
+
+boreas_error_t
+run_cli_extended (gvm_hosts_t *hosts, alive_test_t alive_test,
+                  const gchar *port_list, const unsigned int timeout)
 {
   scanner_t scanner = {0};
   boreas_error_t init_err;

--- a/boreas/cli.c
+++ b/boreas/cli.c
@@ -154,7 +154,7 @@ run_cli_scan (scanner_t *scanner, alive_test_t alive_test)
       usleep (500000);
     }
 
-  sleep (WAIT_FOR_REPLIES_TIMEOUT);
+  sleep (get_alive_test_wait_timeout ());
 
   stop_sniffer_thread (scanner, sniffer_thread_id);
 

--- a/boreas/cli.h
+++ b/boreas/cli.h
@@ -24,7 +24,11 @@
 #include "boreas_error.h"
 
 boreas_error_t
-run_cli (gvm_hosts_t *, alive_test_t, const gchar *, const unsigned int);
+run_cli_extended (gvm_hosts_t *, alive_test_t, const gchar *,
+                  const unsigned int);
+
+boreas_error_t
+run_cli (gvm_hosts_t *, alive_test_t, const gchar *);
 
 boreas_error_t
 is_host_alive (const char *, int *);

--- a/boreas/cli.h
+++ b/boreas/cli.h
@@ -24,7 +24,7 @@
 #include "boreas_error.h"
 
 boreas_error_t
-run_cli (gvm_hosts_t *, alive_test_t, const gchar *);
+run_cli (gvm_hosts_t *, alive_test_t, const gchar *, const unsigned int);
 
 boreas_error_t
 is_host_alive (const char *, int *);


### PR DESCRIPTION
**What**:
Make optional the waiting for replies timeout. This doesn't change the original behavior if not set. 
Setting this in the openvas.conf, change the default value system wide.

Jira: SC-680
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Some deveices or networks are too slow, and replies are not get in time, and therefore the target considered dead.
<!-- Why are these changes necessary? -->

**How**:
Set the scanner preference (in GSA in the scan config, or in the openvas.conf configuration file). Run a scan against dead hosts and see the logs, how long  it takes to finished the alive scan.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
