### PR TITLE
Consider the alive_test_ports scanner preference in lowercase.

### DIFF
--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -497,5 +497,7 @@ get_alive_test_methods (alive_test_t *alive_test)
 const gchar *
 get_alive_test_ports (void)
 {
+  if (prefs_get ("alive_test_ports"))
+    return prefs_get ("alive_test_ports");
   return prefs_get ("ALIVE_TEST_PORTS");
 }


### PR DESCRIPTION
**What**:
Consider the alive_test_ports scanner preference in lowercase. 
Jira: SC-689
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The option is now visible in the GUI and gvmd shows this option in lower case as scanner preference, which is not handle by ospd-openvas and stored in redis directly.
This doesn't change the previous behaviour and both preferences (upper and lower case) are supported. 
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
