### PR TITLE
Set LDAP version to 3 after initialization

### DIFF
--- a/util/ldaputils.c
+++ b/util/ldaputils.c
@@ -333,8 +333,29 @@ ldap_auth_bind (const gchar *host, const gchar *userdn, const gchar *password,
                   g_free (ldapuri);
                   goto fail;
                 }
+             // Set LDAP version to 3 after initialization
+              ldap_return = ldap_set_option (ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapv3);
+              if (ldap_return != LDAP_SUCCESS)
+                {
+                  g_warning ("Aborting, could not set ldap protocol version to 3: %s.",
+                             ldap_err2string (ldap_return));
+                  g_free (ldapuri);
+                  goto fail;
+                }
             }
         }
+      else
+        {
+         // Set LDAP version to 3 after initialization
+          ldap_return = ldap_set_option (ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapv3);
+          if (ldap_return != LDAP_SUCCESS)
+            {
+              g_warning ("Aborting, could not set ldap protocol version to 3: %s.",
+                         ldap_err2string (ldap_return));
+              g_free (ldapuri);
+              goto fail;
+            }
+       }
     }
   else
     g_debug ("LDAP StartTLS initialized.");

--- a/util/ldaputils.c
+++ b/util/ldaputils.c
@@ -333,12 +333,14 @@ ldap_auth_bind (const gchar *host, const gchar *userdn, const gchar *password,
                   g_free (ldapuri);
                   goto fail;
                 }
-             // Set LDAP version to 3 after initialization
-              ldap_return = ldap_set_option (ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapv3);
+              // Set LDAP version to 3 after initialization
+              ldap_return =
+                ldap_set_option (ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapv3);
               if (ldap_return != LDAP_SUCCESS)
                 {
-                  g_warning ("Aborting, could not set ldap protocol version to 3: %s.",
-                             ldap_err2string (ldap_return));
+                  g_warning (
+                    "Aborting, could not set ldap protocol version to 3: %s.",
+                    ldap_err2string (ldap_return));
                   g_free (ldapuri);
                   goto fail;
                 }
@@ -346,16 +348,18 @@ ldap_auth_bind (const gchar *host, const gchar *userdn, const gchar *password,
         }
       else
         {
-         // Set LDAP version to 3 after initialization
-          ldap_return = ldap_set_option (ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapv3);
+          // Set LDAP version to 3 after initialization
+          ldap_return =
+            ldap_set_option (ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapv3);
           if (ldap_return != LDAP_SUCCESS)
             {
-              g_warning ("Aborting, could not set ldap protocol version to 3: %s.",
-                         ldap_err2string (ldap_return));
+              g_warning (
+                "Aborting, could not set ldap protocol version to 3: %s.",
+                ldap_err2string (ldap_return));
               g_free (ldapuri);
               goto fail;
             }
-       }
+        }
     }
   else
     g_debug ("LDAP StartTLS initialized.");


### PR DESCRIPTION
LDAP version is by default set to 3, but when StarTLS is disabled then the initialization is done for the second time. And after the initialization version is set to 2. This change is to set the version back to 3.

Signed-off-by: Franciszek Klajn <fklajn@opera.com>

**What**:

LDAP version setting bugfix
jira: T4-398

**Why**:

Because without the change LDAP authentication over LDAPS is not possible on recent Linux distribution.

**How**:

The change has been tested on a test system (Debian Bullseye).

**Checklist**:

- [X] Tests
- [X] PR merge commit message adjusted
