### PR TITLE
Fix -Werror=maybe-uninitialized on GCC 12

### DIFF
--- a/base/networking.c
+++ b/base/networking.c
@@ -787,7 +787,7 @@ ip_islocalhost (struct sockaddr_storage *storage)
 {
   struct in_addr addr;
   struct in_addr *addr_p;
-  struct in6_addr addr6;
+  struct in6_addr addr6 = IN6ADDR_ANY_INIT;
   struct in6_addr *addr6_p;
   struct sockaddr_in *sin_p;
   struct sockaddr_in6 *sin6_p;


### PR DESCRIPTION
**What**:

The following error is happening on Ubuntu Lunar (development
version):

```
In function ‘ip_islocalhost’,
    inlined from ‘gvm_routethrough’ at ./base/networking.c:1032:11:
./base/networking.c:863:22: error: ‘addr6.__in6_u.__u6_addr32[3]’ may be used uninitialized [-Werror=maybe-uninitialized]
./base/networking.c: In function ‘gvm_routethrough’:
./base/networking.c:790:19: note: ‘addr6.__in6_u.__u6_addr32[3]’ was declared here
```

**Why**:

GCC 12 is more strict when checking for uninitialized variables.

**How**:

I rebuilt gvm-libs in Ubuntu with the proposed patch, and the build is
now passing.

**Checklist**:

- [ ] Tests N/A
- [ ] PR merge commit message adjusted N/A