### PR TITLE
Fix: set reference to static

### DIFF
--- a/base/logging.c
+++ b/base/logging.c
@@ -49,12 +49,6 @@
 #define G_LOG_DOMAIN "libgvm base"
 
 /**
- * @brief for backward compatibility
- *
- */
-#define LOG_REFERENCES_AVAILABLE
-
-/**
  * @struct gvm_logging_t
  * @brief Logging stores the parameters loaded from a log configuration
  * @brief file, to be used internally by the gvm_logging module only.
@@ -581,7 +575,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
       /* If the current char is a % and the next one is a p, get the pid. */
       if ((*tmp == '%') && (*(tmp + 1) == 'p'))
         {
-          if (reference != NULL)
+          if (reference)
             {
               prepend_tmp =
                 g_strdup_printf ("%s%d%s%s", prepend_buf, (int) getpid (),

--- a/base/logging.c
+++ b/base/logging.c
@@ -389,7 +389,7 @@ gvm_log_unlock (void)
   g_mutex_unlock (logger_mutex);
 }
 
-char *reference = NULL;
+static char *reference = NULL;
 
 /**
  * @brief Set the log reference object.
@@ -407,7 +407,8 @@ char *reference = NULL;
 void
 set_log_reference (char *ref)
 {
-  g_free (reference);
+  if (reference)
+    g_free ((char *) reference);
   reference = ref;
 }
 
@@ -422,7 +423,7 @@ set_log_reference (char *ref)
 char *
 get_log_reference (void)
 {
-  return reference;
+  return (char *) reference;
 }
 
 /**
@@ -434,7 +435,8 @@ get_log_reference (void)
 void
 free_log_reference (void)
 {
-  g_free (reference);
+  if (reference)
+    g_free ((char *) reference);
   reference = NULL;
 }
 
@@ -579,7 +581,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
       /* If the current char is a % and the next one is a p, get the pid. */
       if ((*tmp == '%') && (*(tmp + 1) == 'p'))
         {
-          if (reference)
+          if (reference != NULL)
             {
               prepend_tmp =
                 g_strdup_printf ("%s%d%s%s", prepend_buf, (int) getpid (),

--- a/base/logging.h
+++ b/base/logging.h
@@ -27,6 +27,12 @@
 
 #include <glib.h> /* for GSList, gchar, GLogLevelFlags, gpointer */
 
+/**
+ * @brief for backward compatibility
+ *
+ */
+#define LOG_REFERENCES_AVAILABLE
+
 GSList *
 load_log_configuration (gchar *);
 


### PR DESCRIPTION
Sets reference in logging.c to static to prevent wrongful compiler
optimizations on initialization.

This is an attempt to fix: https://github.com/greenbone/gsad/issues/115
