### PR TITLE
Fix: Use source size copying strings with memcpy

### DIFF
--- a/base/networking.c
+++ b/base/networking.c
@@ -81,6 +81,9 @@ gvm_source_iface_init (const char *iface)
   if (iface == NULL)
     return ret;
 
+  if (strlen (iface) >= sizeof (global_source_iface))
+    return ret;
+
   if (getifaddrs (&ifaddr) == -1)
     return ret;
 
@@ -111,7 +114,7 @@ gvm_source_iface_init (const char *iface)
 
   /* At least one address for the interface was found. */
   if (ret == 0)
-    memcpy (global_source_iface, iface, sizeof (global_source_iface) - 1);
+    memcpy (global_source_iface, iface, strlen (iface));
 
   freeifaddrs (ifaddr);
   return ret;

--- a/base/prefs.c
+++ b/base/prefs.c
@@ -170,14 +170,11 @@ void
 prefs_config (const char *config)
 {
   settings_iterator_t settings;
-  char buffer[2048];
 
   if (!global_prefs)
     prefs_init ();
 
-  memset (buffer, 0, sizeof (buffer));
-  memcpy (buffer, config, sizeof (buffer) - 1);
-  if (!init_settings_iterator_from_file (&settings, buffer, "Misc"))
+  if (!init_settings_iterator_from_file (&settings, config, "Misc"))
     {
       while (settings_iterator_next (&settings))
         prefs_set (settings_iterator_name (&settings),
@@ -186,7 +183,7 @@ prefs_config (const char *config)
       cleanup_settings_iterator (&settings);
     }
 
-  prefs_set ("config_file", buffer);
+  prefs_set ("config_file", config);
 }
 
 /**

--- a/base/proctitle.c
+++ b/base/proctitle.c
@@ -129,7 +129,7 @@ proctitle_set_args (const char *new_title, va_list args)
   formatted = g_strdup_vprintf (new_title, args);
 
   tmp = strlen (formatted);
-  if (tmp > max_prog_name)
+  if (tmp >= max_prog_name)
     {
       formatted[max_prog_name] = '\0';
       tmp = max_prog_name;

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -143,6 +143,13 @@ osp_connection_new (const char *host, int port, const char *cacert,
       struct sockaddr_un addr;
       int len;
 
+      if (strlen (host) >= sizeof (addr.sun_path))
+        {
+          g_warning ("%s: given host / socket path too long (%lu > %lu bytes)",
+                     __func__, strlen (host), sizeof (addr.sun_path) - 1);
+          return NULL;
+        }
+
       connection = g_malloc0 (sizeof (*connection));
       connection->socket = socket (AF_UNIX, SOCK_STREAM, 0);
       if (connection->socket == -1)
@@ -153,7 +160,7 @@ osp_connection_new (const char *host, int port, const char *cacert,
 
       addr.sun_family = AF_UNIX;
       memset (addr.sun_path, 0, sizeof (addr.sun_path));
-      memcpy (addr.sun_path, host, sizeof (addr.sun_path) - 1);
+      memcpy (addr.sun_path, host, strlen (host));
       len = strlen (addr.sun_path) + sizeof (addr.sun_family);
       if (connect (connection->socket, (struct sockaddr *) &addr, len) == -1)
         {


### PR DESCRIPTION
## What
When copying strings with memcpy in places where strncpy was used before, use the size of the source string instead of the destination size.

## Why
Using the destination size can cause errors if it is larger than the source size.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


