### PR TITLE
Fix: Update release workflow to create patch releases for stable

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -30,5 +30,5 @@ jobs:
           gpg-key: ${{ secrets.GPG_KEY }}
           gpg-fingerprint: ${{ secrets.GPG_FINGERPRINT }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          strategy: calendar
+          strategy: patch
           ref: ${{ env.RELEASE_REF }}


### PR DESCRIPTION
## What

Update release workflow to create patch releases for stable

## Why

Using calendar would create a new 23.X.Y release. For the stable branch we just want to increment the patch version.