### PR TITLE
Add: XML element_to_string function

### DIFF
--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -1919,3 +1919,33 @@ element_next (element_t element)
     return element->next;
   return NULL;
 }
+
+/**
+ * @brief Output the XML element as a string.
+ *
+ * The generated XML string will include namespace definitions from ancestor
+ *  elements.
+ *
+ * @param[in]  element  The element to output as a string.
+ *
+ * @return The newly allocated XML string.
+ */
+gchar *
+element_to_string (element_t element)
+{
+  xmlBufferPtr buffer;
+  char *xml_string;
+
+  // Copy element to ensure XML namespaces are included
+  element_t element_copy;
+  element_copy = xmlCopyNode (element, 1);
+
+  buffer = xmlBufferCreate ();
+  xmlNodeDump (buffer, element_copy->doc, element_copy, 0, 0);
+  xmlFreeNode (element_copy);
+
+  xml_string = g_strdup ((char *) xmlBufferContent (buffer));
+
+  xmlBufferFree (buffer);
+  return xml_string;
+}

--- a/util/xmlutils.h
+++ b/util/xmlutils.h
@@ -186,4 +186,7 @@ element_t element_first_child (element_t);
 
 element_t element_next (element_t);
 
+gchar *
+element_to_string (element_t element);
+
 #endif /* not _GVM_XMLUTILS_H */


### PR DESCRIPTION
## What
The new `element_to_string` function can be used to save an XML element as a string, including inherited namespaces.

## Why
This required to store the original XML of SCAP data in the gvmd database.
 
## References
GEA-138
used by greenbone/gvmd#1935
