### PR TITLE
Use g_memdup2 when available

### DIFF
--- a/base/networking.c
+++ b/base/networking.c
@@ -48,7 +48,8 @@
  */
 #define G_LOG_DOMAIN "libgvm base"
 
-#if (GLIB_MAJOR_VERSION >= 2) && (GLIB_MINOR_VERSION >= 67) && (GLIB_MICRO_VERSION >= 3)
+#if (GLIB_MAJOR_VERSION >= 2) && (GLIB_MINOR_VERSION >= 67) \
+  && (GLIB_MICRO_VERSION >= 3)
 #define memdup g_memdup2
 #else
 #define memdup g_memdup

--- a/base/networking.c
+++ b/base/networking.c
@@ -48,6 +48,12 @@
  */
 #define G_LOG_DOMAIN "libgvm base"
 
+#if (GLIB_MAJOR_VERSION >= 2) && (GLIB_MINOR_VERSION >= 67) && (GLIB_MICRO_VERSION >= 3)
+#define memdup g_memdup2
+#else
+#define memdup g_memdup
+#endif
+
 /* Global variables */
 
 /* Source interface name eg. eth1. */
@@ -368,19 +374,13 @@ gvm_resolve_list (const char *name)
         {
           struct sockaddr_in *addrin = (struct sockaddr_in *) p->ai_addr;
           ipv4_as_ipv6 (&(addrin->sin_addr), &dst);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-          list = g_slist_prepend (list, g_memdup (&dst, sizeof (dst)));
-#pragma GCC diagnostic pop
+          list = g_slist_prepend (list, memdup (&dst, sizeof (dst)));
         }
       else if (p->ai_family == AF_INET6)
         {
           struct sockaddr_in6 *addrin = (struct sockaddr_in6 *) p->ai_addr;
           memcpy (&dst, &(addrin->sin6_addr), sizeof (struct in6_addr));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-          list = g_slist_prepend (list, g_memdup (&dst, sizeof (dst)));
-#pragma GCC diagnostic pop
+          list = g_slist_prepend (list, memdup (&dst, sizeof (dst)));
         }
       p = p->ai_next;
     }

--- a/util/kb.c
+++ b/util/kb.c
@@ -40,7 +40,8 @@
  */
 #define G_LOG_DOMAIN "libgvm util"
 
-#if (GLIB_MAJOR_VERSION >= 2) && (GLIB_MINOR_VERSION >= 67) && (GLIB_MICRO_VERSION >= 3)
+#if (GLIB_MAJOR_VERSION >= 2) && (GLIB_MINOR_VERSION >= 67) \
+  && (GLIB_MICRO_VERSION >= 3)
 #define memdup g_memdup2
 #else
 #define memdup g_memdup

--- a/util/kb.c
+++ b/util/kb.c
@@ -40,6 +40,12 @@
  */
 #define G_LOG_DOMAIN "libgvm util"
 
+#if (GLIB_MAJOR_VERSION >= 2) && (GLIB_MINOR_VERSION >= 67) && (GLIB_MICRO_VERSION >= 3)
+#define memdup g_memdup2
+#else
+#define memdup g_memdup
+#endif
+
 /**
  * @file kb.c
  *
@@ -692,10 +698,7 @@ redis2kbitem_single (const char *name, const redisReply *elt, int force_int)
   else
     {
       item->type = KB_TYPE_STR;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-      item->v_str = g_memdup (elt->str, elt->len + 1);
-#pragma GCC diagnostic pop
+      item->v_str = memdup (elt->str, elt->len + 1);
       item->len = elt->len;
     }
 


### PR DESCRIPTION
## What

Use `g_memdup2` instead of `g_memdup` if the glib version is new enough.

## Why

There's a vulnerability in `g_memdup` with large sizes, so we may as well use `g_memdup2`.  And this removes the build warnings.

## References

Glib announcement: https://discourse.gnome.org/t/port-your-module-from-g-memdup-to-g-memdup2-now/5538

PR that made the build pass with the warnings: greenbone/gvm-libs/pull/605

