### PR TITLE
Adapt Docker build and fixes a bug that assumes size_t is unsigned long

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY . /source
 RUN sh /source/.github/install-dependencies.sh
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
-RUN DESTDIR=/install cmake --build /build -- install 
+RUN DESTDIR=/install cmake --build /build -- install
 
 FROM debian:stable-slim
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -15,6 +15,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: 'set IS_VERSION_TAG'
+        run: |
+          echo "IS_VERSION_TAG=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}" >> $GITHUB_ENV
+          # set defaults
+          echo "IS_LATEST_TAG=false" >> $GITHUB_ENV
+      - name: 'set IS_LATEST_TAG'
+        if: ( env.IS_VERSION_TAG )
+        run: |
+          # find the latest version that is not ourself
+          export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort)
+          # get major minor patch versions
+          IFS='.' read -r latest_major latest_minor latest_patch << EOF
+          $LATEST_VERSION
+          EOF
+          IFS='.' read -r tag_major tag_minor tag_patch << EOF
+          ${{ github.ref_name }}
+          EOF
+          # remove leading v
+          latest_major=$(echo $latest_major | cut -c2-)
+          tag_major=$(echo $tag_major | cut -c2-)
+          echo "$tag_major >= $latest_major"
+          if [[ $tag_major -ge $latest_major && ($tag_minor -ne 0 || $tag_patch -ne 0) ]]; then
+            # set this tag to latest and stable
+            echo "IS_LATEST_TAG=true" >> $GITHUB_ENV
+          fi
       - name: Setup container meta information
         id: meta
         uses: docker/metadata-action@v4
@@ -25,16 +50,15 @@ jobs:
             org.opencontainers.image.base.name=debian:stable-slim
           flavor: latest=false # no auto latest container tag for git tags
           tags: |
-            # use container tag for git tags
-            type=match,pattern=v(.*),group=1
-            # use latest for latest tag from stable branch
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v22.4') }}
-            # use stable for latest 22.4 tag
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v22.4') }}
-            # use oldstable for latest 21.4 tag
-            type=raw,value=oldstable,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v21.4') }}
-            # use edge for default branch
-            type=edge
+            # when IS_LATEST_TAG is set create a stable and a latest tag
+            type=raw,value=latest,enable=${{ env.IS_LATEST_TAG }}
+            type=raw,value=stable,enable=${{ env.IS_LATEST_TAG }}
+            # if tag version is set than create a version tags
+            type=semver,pattern={{version}},enable=${{ env.IS_VERSION_TAG }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ env.IS_VERSION_TAG }}
+            type=semver,pattern={{major}},enable=${{ env.IS_VERSION_TAG }}
+            # if we are on the main branch set edge
+            type=edge,branch=main
             # use branch-sha otherwise for pushes to branches other then main (will not be uploaded)
             type=raw,value={{branch}}-{{sha}},enable=${{ github.ref_type == 'branch' && github.event_name == 'push' && github.ref_name != 'main' }}
             # use pr-$PR_ID for pull requests (will not be uploaded)

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -40,7 +40,7 @@ jobs:
             # set this tag to latest and stable
             echo "IS_LATEST_TAG=true" >> $GITHUB_ENV
           fi
-      - name: Setup container meta information
+      - name: 'Setup meta information (IS_VERSION_TAG: ${{ env.IS_VERSION_TAG }}, IS_LATEST_TAG: ${{ env.IS_LATEST_TAG }} )'
         id: meta
         uses: docker/metadata-action@v4
         with:

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -145,7 +145,7 @@ osp_connection_new (const char *host, int port, const char *cacert,
 
       if (strlen (host) >= sizeof (addr.sun_path))
         {
-          g_warning ("%s: given host / socket path too long (%lu > %lu bytes)",
+          g_warning ("%s: given host / socket path too long (%zu > %zu bytes)",
                      __func__, strlen (host), sizeof (addr.sun_path) - 1);
           return NULL;
         }


### PR DESCRIPTION
 Adapt docker images

Pushes the version tags to docker hub on a tag release

- greenbone/gvm-libs:${major}
- greenbone/gvm-libs:${major.minor}
- greenbone/gvm-libs:${major.minor.patch}

This will allow container users to choose the newest 22 without
having to adapt to each minor or patch version manually. If the
latest 22 is buggy, they can jump back to either a patch or a minor
version until there is a new 22 version that fixes it.

When the tag version is the highest major version and is not the first
major release with minor and patch version is 0 than it also creates a
latest and stable tag.

Just to give an overview, here are some examples:

Release 22.5.1 on greenbone/gvm-libs would result in the
following tags:

- greenbone/gvm-libs:22
- greenbone/gvm-libs:22.5
- greenbone/gvm-libs:22.5.1
- greenbone/gvm-libs:latest
- greenbone/gvm-libs:stable

Release 23.0.0 on greenbone/gvm-libs would result in the
following tags:

- greenbone/gvm-libs:23
- greenbone/gvm-libs:23.0
- greenbone/gvm-libs:23.0.0

Release 23.0.1 on greenbone/gvm-libs would result in the
following tags:

- greenbone/gvm-libs:23
- greenbone/gvm-libs:23.0
- greenbone/gvm-libs:23.0.1
- greenbone/gvm-libs:latest
- greenbone/gvm-libs:stable

Release 22.5.2 when there is already a 23.0.1 version available would
result in the following tags:

- greenbone/gvm-libs:22
- greenbone/gvm-libs:22.5
- greenbone/gvm-libs:22.5.2

Additionally it fixes: https://github.com/greenbone/gvm-libs/issues/762