### PR TITLE
Add osp_send_command_str

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -1295,6 +1295,26 @@ nvti_set_name (nvti_t *n, const gchar *name)
 }
 
 /**
+ * @brief Set the name of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param name The name to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_name (nvti_t *n, gchar *name)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->name);
+  n->name = name;
+  return 0;
+}
+
+/**
  * @brief Set the summary of a NVT.
  *
  * @param n The NVT Info structure.
@@ -1311,6 +1331,26 @@ nvti_set_summary (nvti_t *n, const gchar *summary)
 
   g_free (n->summary);
   n->summary = g_strdup (summary);
+  return 0;
+}
+
+/**
+ * @brief Set the summary of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param solution The summary to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_summary (nvti_t *n, gchar *summary)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->summary);
+  n->summary = summary;
   return 0;
 }
 
@@ -1335,6 +1375,26 @@ nvti_set_insight (nvti_t *n, const gchar *insight)
 }
 
 /**
+ * @brief Set the insight text of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param insight The insight text to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_insight (nvti_t *n, gchar *insight)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->insight);
+  n->insight = insight;
+  return 0;
+}
+
+/**
  * @brief Set the affected text of a NVT.
  *
  * @param n The NVT Info structure.
@@ -1355,6 +1415,26 @@ nvti_set_affected (nvti_t *n, const gchar *affected)
 }
 
 /**
+ * @brief Set the affected text of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param affected The affected text to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_affected (nvti_t *n, gchar *affected)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->affected);
+  n->affected = affected;
+  return 0;
+}
+
+/**
  * @brief Set the impact text of a NVT.
  *
  * @param n The NVT Info structure.
@@ -1371,6 +1451,26 @@ nvti_set_impact (nvti_t *n, const gchar *impact)
 
   g_free (n->impact);
   n->impact = g_strdup (impact);
+  return 0;
+}
+
+/**
+ * @brief Set the impact text of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param affected The impact text to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_impact (nvti_t *n, gchar *impact)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->impact);
+  n->impact = impact;
   return 0;
 }
 
@@ -1429,6 +1529,26 @@ nvti_set_solution (nvti_t *n, const gchar *solution)
 
   g_free (n->solution);
   n->solution = g_strdup (solution);
+  return 0;
+}
+
+/**
+ * @brief Set the solution of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param solution The solution to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_solution (nvti_t *n, gchar *solution)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->solution);
+  n->solution = solution;
   return 0;
 }
 
@@ -1756,6 +1876,26 @@ nvti_set_detection (nvti_t *n, const gchar *detection)
 }
 
 /**
+ * @brief Set the detection text of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param detection The detection text to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_detection (nvti_t *n, gchar *detection)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->detection);
+  n->detection = detection;
+  return 0;
+}
+
+/**
  * @brief Set the QoD type of a NVT.
  *
  * @param n The NVT Info structure.
@@ -1820,6 +1960,26 @@ nvti_set_family (nvti_t *n, const gchar *family)
 
   g_free (n->family);
   n->family = g_strdup (family);
+  return 0;
+}
+
+/**
+ * @brief Set the family of a NVT, using the given memory.
+ *
+ * @param n The NVT Info structure.
+ *
+ * @param family The family to set. The string will be used directly.
+ *
+ * @return 0 for success. Anything else indicates an error.
+ */
+int
+nvti_put_family (nvti_t *n, gchar *family)
+{
+  if (!n)
+    return -1;
+
+  g_free (n->family);
+  n->family = family;
   return 0;
 }
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -179,19 +179,31 @@ nvti_set_oid (nvti_t *, const gchar *);
 int
 nvti_set_name (nvti_t *, const gchar *);
 int
+nvti_put_name (nvti_t *, gchar *);
+int
 nvti_set_summary (nvti_t *, const gchar *);
+int
+nvti_put_summary (nvti_t *, gchar *);
 int
 nvti_set_insight (nvti_t *, const gchar *);
 int
+nvti_put_insight (nvti_t *, gchar *);
+int
 nvti_set_affected (nvti_t *, const gchar *);
 int
+nvti_put_affected (nvti_t *, gchar *);
+int
 nvti_set_impact (nvti_t *, const gchar *);
+int
+nvti_put_impact (nvti_t *, gchar *);
 int
 nvti_set_creation_time (nvti_t *, const time_t);
 int
 nvti_set_modification_time (nvti_t *, const time_t);
 int
 nvti_set_solution (nvti_t *, const gchar *);
+int
+nvti_put_solution (nvti_t *, gchar *);
 int
 nvti_set_solution_type (nvti_t *, const gchar *);
 int
@@ -217,6 +229,8 @@ nvti_set_required_udp_ports (nvti_t *, const gchar *);
 int
 nvti_set_detection (nvti_t *, const gchar *);
 int
+nvti_put_detection (nvti_t *, gchar *);
+int
 nvti_set_qod_type (nvti_t *, const gchar *);
 int
 nvti_set_qod (nvti_t *, const gchar *);
@@ -226,6 +240,8 @@ int
 nvti_set_category (nvti_t *, const gint);
 int
 nvti_set_family (nvti_t *, const gchar *);
+int
+nvti_put_family (nvti_t *, gchar *);
 
 int
 nvti_add_refs (nvti_t *, const gchar *, const gchar *, const gchar *);

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -266,7 +266,6 @@ osp_send_command_str (osp_connection_t *connection, gchar **str,
 
   if (*connection->host == '/')
     {
-      g_warning ("%s: send sock", __func__);
       if (gvm_socket_vsendf (connection->socket, fmt, ap) == -1)
         goto out;
       gvm_connection_t conn;
@@ -280,7 +279,6 @@ osp_send_command_str (osp_connection_t *connection, gchar **str,
     }
   else
     {
-      g_warning ("%s: send sess", __func__);
       if (gvm_server_vsendf (&connection->session, fmt, ap) == -1)
         goto out;
       if (read_entity_and_text (&connection->session, NULL, str))

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -256,14 +256,12 @@ osp_send_command_str (osp_connection_t *connection, gchar **str,
 {
   va_list ap;
   int rc = 1;
-  //  entity_t entity;
-  //  entity_t *response = &entity;
 
   *str = NULL;
 
   va_start (ap, fmt);
 
-  if (!connection || !fmt) // || !response)
+  if (!connection || !fmt)
     goto out;
 
   if (*connection->host == '/')
@@ -290,54 +288,11 @@ osp_send_command_str (osp_connection_t *connection, gchar **str,
     }
 
   rc = 0;
-  //free_entity (entity);
 
 out:
   va_end (ap);
 
   return rc;
-
-
-#if 0  
-  va_list ap;
-  int rc = 1;
-  gvm_connection_t conn;
-
-  va_start (ap, fmt);
-
-  if (!connection || !fmt || !response)
-    goto out;
-
-  conn.socket = connection->socket;
-  conn.session = connection->session;
-
-  if (*connection->host == '/')
-    {
-      g_warning ("%s: send sock", __func__);
-      if (gvm_socket_vsendf (connection->socket, fmt, ap) == -1)
-        goto out;
-    }
-  else
-    {
-      g_warning ("%s: send sess", __func__);
-      if (gvm_server_vsendf (&connection->session, fmt, ap) == -1)
-        goto out;
-    }
-
-  g_warning ("%s: read", __func__);
-  entity_t entity; // FIX
-  if (read_entity_and_text_c (&conn, &entity, response))
-    goto out;
-  g_warning ("%s: read success", __func__);
-  free_entity(entity); //
-
-  rc = 0;
-
-out:
-  va_end (ap);
-
-  return rc;
-#endif
 }
 
 /**

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -259,6 +259,8 @@ osp_send_command_str (osp_connection_t *connection, gchar **str,
   //  entity_t entity;
   //  entity_t *response = &entity;
 
+  *str = NULL;
+
   va_start (ap, fmt);
 
   if (!connection || !fmt) // || !response)

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -126,6 +126,9 @@ int
 osp_get_vts_ext (osp_connection_t *, osp_get_vts_opts_t, entity_t *);
 
 int
+osp_get_vts_ext_str (osp_connection_t *, osp_get_vts_opts_t, gchar **);
+
+int
 osp_start_scan (osp_connection_t *, const char *, const char *, GHashTable *,
                 const char *, char **);
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -837,15 +837,16 @@ try_read_string_s (int socket, int timeout,
           if (count == 0)
             {
               /* End of file. */
-              if (string && *string_return == NULL)
-                g_string_free (string, TRUE);
               if (timeout > 0)
                 {
                   if (fcntl (socket, F_SETFL, 0L) < 0)
                     g_warning ("%s :failed to set socket flag: %s", __func__,
                                strerror (errno));
                 }
-              return -3;
+              if (string)
+                *string_return = string;
+              g_free (buffer);
+              return 0;
             }
           break;
         }

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -2031,8 +2031,12 @@ element_attribute (element_t element, const gchar *name)
 element_t
 element_first_child (element_t element)
 {
-  if (element)
-    return element->children;
+  if (element) {
+    element = element->children;
+    while (element && (element->type != XML_ELEMENT_NODE))
+      element = element->next;
+    return element;
+  }
   return NULL;
 }
 
@@ -2046,8 +2050,12 @@ element_first_child (element_t element)
 element_t
 element_next (element_t element)
 {
-  if (element)
-    return element->next;
+  if (element) {
+    element = element->next;
+    while (element && (element->type != XML_ELEMENT_NODE))
+      element = element->next;
+    return element;
+  }
   return NULL;
 }
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -1227,7 +1227,7 @@ read_string (gnutls_session_t *session, GString **string)
   int ret = 0;
   entity_t entity;
 
-  if (!(ret = read_entity_and_string (session, &entity /* FIX NULL? */, string)))
+  if (!(ret = read_entity_and_string (session, &entity, string)))
     free_entity (entity);
 
   return ret;

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -790,7 +790,7 @@ try_read_string_s (int socket, int timeout,
   if (string_return == NULL)
     string = NULL;
   else if (*string_return == NULL)
-    string = g_string_new ("");
+    string = g_string_sized_new (8192);
   else
     string = *string_return;
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -2092,15 +2092,29 @@ void
 print_element_to_string (element_t element, GString *string)
 {
   gchar *text_escaped, *text;
+  element_t ch;
+  xmlAttr *attribute;
 
   text_escaped = NULL;
 
   g_string_append_printf (string, "<%s", element_name (element));
-  /* FIX
-  if (element->attributes && g_hash_table_size (element->attributes))
-    g_hash_table_foreach (element->attributes, foreach_print_attribute_to_string,
-                          string);
-  */
+
+  attribute = element->properties;
+  while (attribute)
+    {
+      xmlChar* value;
+
+      value = xmlNodeListGetString (element->doc, attribute->children, 1);
+ 
+      text_escaped = g_markup_escape_text ((gchar *) value, -1);
+      g_string_append_printf (string, " %s=\"%s\"", attribute->name, text_escaped);
+      g_free (text_escaped);
+
+      xmlFree(value); 
+
+      attribute = attribute->next;
+    }
+
   g_string_append_printf (string, ">");
 
   text = element_text (element);
@@ -2109,6 +2123,12 @@ print_element_to_string (element_t element, GString *string)
   g_string_append_printf (string, "%s", text_escaped);
   g_free (text_escaped);
 
-  //g_slist_foreach (element->entities, foreach_print_element_to_string, string);  FIX
+  ch = element_first_child (element);
+  while (ch)
+    {
+      print_element_to_string (ch, string);
+      ch = element_next (ch);
+    }
+
   g_string_append_printf (string, "</%s>", element_name (element));
 }

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -759,6 +759,133 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
  * @return 0 success, -1 read error, -2 parse error, -3 end of file, -4 timeout.
  */
 static int
+try_read_string_s (int socket, int timeout,
+                   GString **string_return)
+{
+  GString *string;
+  time_t last_time;
+  /* Buffer for reading from the socket. */
+  char *buffer;
+
+  /* Record the start time. */
+
+  if (time (&last_time) == -1)
+    {
+      g_warning ("   failed to get current time: %s\n", strerror (errno));
+      return -1;
+    }
+
+  if (timeout > 0)
+    {
+      /* Turn off blocking. */
+
+      if (fcntl (socket, F_SETFL, O_NONBLOCK) == -1)
+        return -1;
+    }
+
+  buffer = g_malloc0 (BUFFER_SIZE);
+
+  /* Setup return arg. */
+
+  if (string_return == NULL)
+    string = NULL;
+  else if (*string_return == NULL)
+    string = g_string_new ("");
+  else
+    string = *string_return;
+
+  /* Read until encountering end of file or error. */
+
+  while (1)
+    {
+      int count;
+      while (1)
+        {
+          g_debug ("   asking for %i\n", BUFFER_SIZE);
+          count = read (socket, buffer, BUFFER_SIZE);
+          if (count < 0)
+            {
+              if (errno == EINTR)
+                /* Interrupted, try read again. */
+                continue;
+              if (timeout > 0)
+                {
+                  if (errno == EAGAIN)
+                    {
+                      /* Server still busy, either timeout or try read again. */
+                      if ((timeout - (time (NULL) - last_time)) <= 0)
+                        {
+                          g_warning ("   timeout\n");
+                          if (fcntl (socket, F_SETFL, 0L) < 0)
+                            g_warning ("%s :failed to set socket flag: %s",
+                                       __func__, strerror (errno));
+                          g_free (buffer);
+                          if (string && *string_return == NULL)
+                            g_string_free (string, TRUE);
+                          return -4;
+                        }
+                    }
+                  continue;
+                }
+              if (string && *string_return == NULL)
+                g_string_free (string, TRUE);
+              if (timeout > 0)
+                fcntl (socket, F_SETFL, 0L);
+              g_free (buffer);
+              return -1;
+            }
+          if (count == 0)
+            {
+              /* End of file. */
+              if (string && *string_return == NULL)
+                g_string_free (string, TRUE);
+              if (timeout > 0)
+                {
+                  if (fcntl (socket, F_SETFL, 0L) < 0)
+                    g_warning ("%s :failed to set socket flag: %s", __func__,
+                               strerror (errno));
+                }
+              return -3;
+            }
+          break;
+        }
+
+      g_debug ("<= %.*s\n", (int) count, buffer);
+
+      if (string)
+        g_string_append_len (string, buffer, count);
+
+      if ((timeout > 0) && (time (&last_time) == -1))
+        {
+          g_warning ("   failed to get current time (1): %s\n",
+                     strerror (errno));
+          if (fcntl (socket, F_SETFL, 0L) < 0)
+            g_warning ("%s :failed to set server socket flag: %s", __func__,
+                       strerror (errno));
+          g_free (buffer);
+          if (string && *string_return == NULL)
+            g_string_free (string, TRUE);
+          return -1;
+        }
+    }
+}
+
+/**
+ * @brief Try read an XML entity tree from the socket.
+ *
+ * @param[in]   socket         Socket to read from.
+ * @param[in]   timeout        Server idle time before giving up, in seconds.  0
+ * to wait forever.
+ * @param[out]  entity         Pointer to an entity tree.
+ * @param[out]  string_return  An optional return location for the text read
+ *                             from the session.  If NULL then it simply
+ *                             remains NULL.  If a pointer to NULL then it
+ * points to a freshly allocated GString on successful return. Otherwise it
+ * points to an existing GString onto which the text is appended.
+ *
+ * @return 0 success, -1 read error, -2 parse error, -3 end of file, -4 timeout.
+ */
+static int
 try_read_entity_and_string_s (int socket, int timeout, entity_t *entity,
                               GString **string_return)
 {
@@ -1015,6 +1142,9 @@ read_entity_and_string_c (gvm_connection_t *connection, entity_t *entity,
   if (connection->tls)
     return try_read_entity_and_string (&connection->session, 0, entity,
                                        string_return);
+  if (entity == NULL)
+    return try_read_string_s (connection->socket, 0, string_return);
+
   return try_read_entity_and_string_s (connection->socket, 0, entity,
                                        string_return);
 }
@@ -1096,7 +1226,7 @@ read_string (gnutls_session_t *session, GString **string)
   int ret = 0;
   entity_t entity;
 
-  if (!(ret = read_entity_and_string (session, &entity, string)))
+  if (!(ret = read_entity_and_string (session, &entity /* FIX NULL? */, string)))
     free_entity (entity);
 
   return ret;
@@ -1948,4 +2078,36 @@ element_to_string (element_t element)
 
   xmlBufferFree (buffer);
   return xml_string;
+}
+
+/**
+ * @brief Print an XML element tree to a GString, appending it if string is not
+ * @brief empty.
+ *
+ * @param[in]      element  Element tree to print to string.
+ * @param[in,out]  string  String to write to.
+ */
+void
+print_element_to_string (element_t element, GString *string)
+{
+  gchar *text_escaped, *text;
+
+  text_escaped = NULL;
+
+  g_string_append_printf (string, "<%s", element_name (element));
+  /* FIX
+  if (element->attributes && g_hash_table_size (element->attributes))
+    g_hash_table_foreach (element->attributes, foreach_print_attribute_to_string,
+                          string);
+  */
+  g_string_append_printf (string, ">");
+
+  text = element_text (element);
+  text_escaped = g_markup_escape_text (text, -1);
+  g_free (text);
+  g_string_append_printf (string, "%s", text_escaped);
+  g_free (text_escaped);
+
+  //g_slist_foreach (element->entities, foreach_print_element_to_string, string);  FIX
+  g_string_append_printf (string, "</%s>", element_name (element));
 }

--- a/util/xmlutils.h
+++ b/util/xmlutils.h
@@ -189,4 +189,7 @@ element_t element_next (element_t);
 gchar *
 element_to_string (element_t element);
 
+void
+print_element_to_string (element_t element, GString *string);
+
 #endif /* not _GVM_XMLUTILS_H */

--- a/util/xmlutils_tests.c
+++ b/util/xmlutils_tests.c
@@ -499,6 +499,23 @@ Ensure (xmlutils, parse_element_free_using_child)
   element_free (element);
 }
 
+Ensure (xmlutils, print_element_to_string_prints)
+{
+  element_t element;
+  const gchar *xml;
+  GString *str;
+
+  xml = "<a aa=\"1\">a text<b><c ca=\"x\" ca2=\"y\">1</c><d/><e></e></b> and more a text</a>";
+  str = g_string_new ("");
+
+  assert_that (parse_element (xml, &element), is_equal_to (0));
+  print_element_to_string (element, str);
+  assert_that (str->str,
+               is_equal_to_string ("<a aa=\"1\">a text and more a text<b><c ca=\"x\" ca2=\"y\">1</c><d></d><e></e></b></a>"));
+  g_string_free (str, TRUE);
+  element_free (element);
+}
+
 /* Test suite. */
 
 int
@@ -529,6 +546,8 @@ main (int argc, char **argv)
                          parse_element_item_metadata_with_namespace);
   add_test_with_context (suite, xmlutils, parse_element_item_handles_cdata);
   add_test_with_context (suite, xmlutils, parse_element_free_using_child);
+
+  add_test_with_context (suite, xmlutils, print_element_to_string_prints);
 
   add_test_with_context (suite, xmlutils,
                          element_next_handles_multiple_children);


### PR DESCRIPTION
## What

Add `osp_get_vts_ext_str`, including `osp_send_command_str` and `try_read_s`.

## Why

This allows reading the VT XML directly into a string, skipping the glib XML parsing.

## References

GEA-49

## Checklist

- [x] Possibly `osp_get_vts_ext_str` should be an option of `osp_get_vts_ext`, with the return going in the opts. No, because osp_get_vts_ext has an entity return arg, so it would be too messy.
- [x] Address FIX in `read_string`, `print_element_to_string`


