### PR TITLE
Add osp_get_vts_ext_str

### DIFF
--- a/osp/osp.c
+++ b/osp/osp.c
@@ -121,6 +121,10 @@ static int
 osp_send_command (osp_connection_t *, entity_t *, const char *, ...)
   __attribute__ ((__format__ (__printf__, 3, 4)));
 
+static int
+osp_send_command_str (osp_connection_t *, gchar **, const char *, ...)
+  __attribute__ ((__format__ (__printf__, 3, 4)));
+
 /**
  * @brief Open a new connection to an OSP server.
  *
@@ -226,6 +230,58 @@ osp_send_command (osp_connection_t *connection, entity_t *response,
       if (gvm_server_vsendf (&connection->session, fmt, ap) == -1)
         goto out;
       if (read_entity (&connection->session, response))
+        goto out;
+    }
+
+  rc = 0;
+
+out:
+  va_end (ap);
+
+  return rc;
+}
+
+/**
+ * @brief Send a command to an OSP server.
+ *
+ * @param[in]   connection  Connection to OSP server.
+ * @param[out]  response    Response from OSP server.
+ * @param[in]   fmt         OSP Command to send.
+ *
+ * @return 0 and response, 1 if error.
+ */
+static int
+osp_send_command_str (osp_connection_t *connection, gchar **str,
+                      const char *fmt, ...)
+{
+  va_list ap;
+  int rc = 1;
+
+  *str = NULL;
+
+  va_start (ap, fmt);
+
+  if (!connection || !fmt)
+    goto out;
+
+  if (*connection->host == '/')
+    {
+      if (gvm_socket_vsendf (connection->socket, fmt, ap) == -1)
+        goto out;
+      gvm_connection_t conn;
+      conn.socket = connection->socket;
+      conn.session = connection->session;
+      conn.host_string = connection->host;
+      conn.port = connection->port;
+      conn.tls = 0;
+      if (read_entity_and_text_c (&conn, NULL, str))
+        goto out;
+    }
+  else
+    {
+      if (gvm_server_vsendf (&connection->session, fmt, ap) == -1)
+        goto out;
+      if (read_entity_and_text (&connection->session, NULL, str))
         goto out;
     }
 
@@ -620,6 +676,45 @@ osp_get_vts_ext (osp_connection_t *connection, osp_get_vts_opts_t opts,
     }
 
   if (osp_send_command (connection, vts, "<get_vts/>"))
+    return 1;
+  return 0;
+}
+
+/**
+ * @brief Get filtered set of VTs from an OSP server.
+ *
+ * @param[in]   connection  Connection to an OSP server.
+ * @param[in]   opts        Struct containing the options to apply.
+ * @param[out]  vts         VTs.
+ *
+ * @return 0 if success, 1 if error.
+ */
+int
+osp_get_vts_ext_str (osp_connection_t *connection, osp_get_vts_opts_t opts,
+                     gchar **str)
+{
+  if (!connection)
+    return 1;
+
+  if (str == NULL)
+    return 1;
+
+  if (opts.version_only == 1)
+    {
+      if (osp_send_command_str (connection, str, "<get_vts version_only='1'/>"))
+        return 1;
+      return 0;
+    }
+
+  if (opts.filter)
+    {
+      if (osp_send_command_str (connection, str, "<get_vts filter='%s'/>",
+                                opts.filter))
+        return 1;
+      return 0;
+    }
+
+  if (osp_send_command_str (connection, str, "<get_vts/>"))
     return 1;
   return 0;
 }

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -126,6 +126,9 @@ int
 osp_get_vts_ext (osp_connection_t *, osp_get_vts_opts_t, entity_t *);
 
 int
+osp_get_vts_ext_str (osp_connection_t *, osp_get_vts_opts_t, gchar **);
+
+int
 osp_start_scan (osp_connection_t *, const char *, const char *, GHashTable *,
                 const char *, char **);
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -2080,3 +2080,55 @@ element_to_string (element_t element)
   xmlBufferFree (buffer);
   return xml_string;
 }
+
+/**
+ * @brief Print an XML element tree to a GString, appending it if string is not
+ * @brief empty.
+ *
+ * @param[in]      element  Element tree to print to string.
+ * @param[in,out]  string  String to write to.
+ */
+void
+print_element_to_string (element_t element, GString *string)
+{
+  gchar *text_escaped, *text;
+  element_t ch;
+  xmlAttr *attribute;
+
+  text_escaped = NULL;
+
+  g_string_append_printf (string, "<%s", element_name (element));
+
+  attribute = element->properties;
+  while (attribute)
+    {
+      xmlChar* value;
+
+      value = xmlNodeListGetString (element->doc, attribute->children, 1);
+
+      text_escaped = g_markup_escape_text ((gchar *) value, -1);
+      g_string_append_printf (string, " %s=\"%s\"", attribute->name, text_escaped);
+      g_free (text_escaped);
+
+      xmlFree(value); 
+
+      attribute = attribute->next;
+    }
+
+  g_string_append_printf (string, ">");
+
+  text = element_text (element);
+  text_escaped = g_markup_escape_text (text, -1);
+  g_free (text);
+  g_string_append_printf (string, "%s", text_escaped);
+  g_free (text_escaped);
+
+  ch = element_first_child (element);
+  while (ch)
+    {
+      print_element_to_string (ch, string);
+      ch = element_next (ch);
+    }
+
+  g_string_append_printf (string, "</%s>", element_name (element));
+}

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -759,8 +759,7 @@ try_read_entity_and_string (gnutls_session_t *session, int timeout,
  * @return 0 success, -1 read error, -2 parse error, -3 end of file, -4 timeout.
  */
 static int
-try_read_string_s (int socket, int timeout,
-                   GString **string_return)
+try_read_string_s (int socket, int timeout, GString **string_return)
 {
   GString *string;
   time_t last_time;
@@ -2102,15 +2101,16 @@ print_element_to_string (element_t element, GString *string)
   attribute = element->properties;
   while (attribute)
     {
-      xmlChar* value;
+      xmlChar *value;
 
       value = xmlNodeListGetString (element->doc, attribute->children, 1);
 
       text_escaped = g_markup_escape_text ((gchar *) value, -1);
-      g_string_append_printf (string, " %s=\"%s\"", attribute->name, text_escaped);
+      g_string_append_printf (string, " %s=\"%s\"", attribute->name,
+                              text_escaped);
       g_free (text_escaped);
 
-      xmlFree(value); 
+      xmlFree (value);
 
       attribute = attribute->next;
     }

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -790,7 +790,7 @@ try_read_string_s (int socket, int timeout,
   if (string_return == NULL)
     string = NULL;
   else if (*string_return == NULL)
-    string = g_string_new ("");
+    string = g_string_sized_new (8192);
   else
     string = *string_return;
 

--- a/util/xmlutils.h
+++ b/util/xmlutils.h
@@ -189,4 +189,7 @@ element_t element_next (element_t);
 gchar *
 element_to_string (element_t element);
 
+void
+print_element_to_string (element_t element, GString *string);
+
 #endif /* not _GVM_XMLUTILS_H */

--- a/util/xmlutils_tests.c
+++ b/util/xmlutils_tests.c
@@ -499,6 +499,23 @@ Ensure (xmlutils, parse_element_free_using_child)
   element_free (element);
 }
 
+Ensure (xmlutils, print_element_to_string_prints)
+{
+  element_t element;
+  const gchar *xml;
+  GString *str;
+
+  xml = "<a aa=\"1\">a text<b><c ca=\"x\" ca2=\"y\">1</c><d/><e></e></b> and more a text</a>";
+  str = g_string_new ("");
+
+  assert_that (parse_element (xml, &element), is_equal_to (0));
+  print_element_to_string (element, str);
+  assert_that (str->str,
+               is_equal_to_string ("<a aa=\"1\">a text and more a text<b><c ca=\"x\" ca2=\"y\">1</c><d></d><e></e></b></a>"));
+  g_string_free (str, TRUE);
+  element_free (element);
+}
+
 /* Test suite. */
 
 int
@@ -529,6 +546,8 @@ main (int argc, char **argv)
                          parse_element_item_metadata_with_namespace);
   add_test_with_context (suite, xmlutils, parse_element_item_handles_cdata);
   add_test_with_context (suite, xmlutils, parse_element_free_using_child);
+
+  add_test_with_context (suite, xmlutils, print_element_to_string_prints);
 
   add_test_with_context (suite, xmlutils,
                          element_next_handles_multiple_children);

--- a/util/xmlutils_tests.c
+++ b/util/xmlutils_tests.c
@@ -505,13 +505,15 @@ Ensure (xmlutils, print_element_to_string_prints)
   const gchar *xml;
   GString *str;
 
-  xml = "<a aa=\"1\">a text<b><c ca=\"x\" ca2=\"y\">1</c><d/><e></e></b> and more a text</a>";
+  xml = "<a aa=\"1\">a text<b><c ca=\"x\" ca2=\"y\">1</c><d/><e></e></b> and "
+        "more a text</a>";
   str = g_string_new ("");
 
   assert_that (parse_element (xml, &element), is_equal_to (0));
   print_element_to_string (element, str);
-  assert_that (str->str,
-               is_equal_to_string ("<a aa=\"1\">a text and more a text<b><c ca=\"x\" ca2=\"y\">1</c><d></d><e></e></b></a>"));
+  assert_that (str->str, is_equal_to_string (
+                           "<a aa=\"1\">a text and more a text<b><c ca=\"x\" "
+                           "ca2=\"y\">1</c><d></d><e></e></b></a>"));
   g_string_free (str, TRUE);
   element_free (element);
 }


### PR DESCRIPTION
## What

Adds function `osp_get_vts_ext_str`.  Like `osp_get_vts_ext`, but returns a string instead of an entity tree.

## Why

Allows the caller to choose the XML parser.

## References

Required by https://github.com/greenbone/gvmd/pull/1959.

## Checklist

- [x] Tests (`print_element_to_string` only)