### PR TITLE
Restrict element_first_child and element_next to element nodes.

### DIFF
--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -2031,8 +2031,12 @@ element_attribute (element_t element, const gchar *name)
 element_t
 element_first_child (element_t element)
 {
-  if (element)
-    return element->children;
+  if (element) {
+    element = element->children;
+    while (element && (element->type != XML_ELEMENT_NODE))
+      element = element->next;
+    return element;
+  }
   return NULL;
 }
 
@@ -2046,8 +2050,12 @@ element_first_child (element_t element)
 element_t
 element_next (element_t element)
 {
-  if (element)
-    return element->next;
+  if (element) {
+    element = element->next;
+    while (element && (element->type != XML_ELEMENT_NODE))
+      element = element->next;
+    return element;
+  }
   return NULL;
 }
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -2030,12 +2030,13 @@ element_attribute (element_t element, const gchar *name)
 element_t
 element_first_child (element_t element)
 {
-  if (element) {
-    element = element->children;
-    while (element && (element->type != XML_ELEMENT_NODE))
-      element = element->next;
-    return element;
-  }
+  if (element)
+    {
+      element = element->children;
+      while (element && (element->type != XML_ELEMENT_NODE))
+        element = element->next;
+      return element;
+    }
   return NULL;
 }
 
@@ -2049,12 +2050,13 @@ element_first_child (element_t element)
 element_t
 element_next (element_t element)
 {
-  if (element) {
-    element = element->next;
-    while (element && (element->type != XML_ELEMENT_NODE))
+  if (element)
+    {
       element = element->next;
-    return element;
-  }
+      while (element && (element->type != XML_ELEMENT_NODE))
+        element = element->next;
+      return element;
+    }
   return NULL;
 }
 


### PR DESCRIPTION
## What

In these two functions only offer nodes of type "ELEMENT", skipping other types of nodes like "ATTRIBUTE" and "TEXT".

## Why

This closes a bug in the element interface where the functions were returning attributes, text, etc but they are supposed to match `next_entities` and `first_entity`, which only return entities.

Existing usage in gvmd manage_sql_secinfo.c has always been safe because it always checks the name of an element before using the element.

## References

Required by https://github.com/greenbone/gvmd/pull/1959.

Waits for #768.
