### PR TITLE
Fix: Parse XML with XML_PARSE_HUGE option

### DIFF
--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -2014,8 +2014,8 @@ parse_element (const gchar *string, element_t *element)
   if (xmlMemSetup (g_free, g_malloc, g_realloc, g_strdup))
     return -4;
 
-  doc = xmlReadMemory (string, strlen (string), "noname.xml", NULL,
-                       XML_PARSE_HUGE);
+  doc =
+    xmlReadMemory (string, strlen (string), "noname.xml", NULL, XML_PARSE_HUGE);
   if (doc == NULL)
     return -2;
 

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -2014,7 +2014,8 @@ parse_element (const gchar *string, element_t *element)
   if (xmlMemSetup (g_free, g_malloc, g_realloc, g_strdup))
     return -4;
 
-  doc = xmlReadMemory (string, strlen (string), "noname.xml", NULL, 0);
+  doc = xmlReadMemory (string, strlen (string), "noname.xml", NULL,
+                       XML_PARSE_HUGE);
   if (doc == NULL)
     return -2;
 


### PR DESCRIPTION
## What
The libxml based parse_element function now parses the input with relaxed limits by using the XML_PARSE_HUGE option. 

## Why
This fixes problems with parsing larger XML files like the CPE dictionary.

## References
GEA-208
