### PR TITLE
Change: Adjust triggering gvmd and gsad repos after new release

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -87,20 +87,27 @@ jobs:
   trigger-stable-projects:
     needs: production
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-    name: Trigger update container images in related projects
+    name: Trigger update container images in related projects for new tags
     strategy:
       fail-fast: false
       matrix:
         repository: ["greenbone/gvmd", "greenbone/gsad"]
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger stable ${{ matrix.repository }} container image build
+      - name: Trigger ${{ matrix.repository }} build container image build
+        uses: greenbone/actions/trigger-workflow@v2
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: ${{ matrix.repository }}
+          workflow: build-container.yml
+          ref: main
+      - name: Trigger ${{ matrix.repository }} container image build
         uses: greenbone/actions/trigger-workflow@v2
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: ${{ matrix.repository }}
           workflow: container.yml
-          ref: stable
+          ref: main
 
   trigger-related-projects:
     needs: production
@@ -109,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        repository: ["greenbone/openvas-scanner", "greenbone/gvmd", "greenbone/gsad", "greenbone/boreas"]
+        repository: ["greenbone/openvas-scanner", "greenbone/boreas"]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger main ${{ matrix.repository }} container image build


### PR DESCRIPTION

## What

Adjust triggering gvmd and gsad repos after new release

## Why

Trigger builds of gvmd and gsad container images after a new tag has been created.

## References
GEA-196
https://github.com/greenbone/gvmd/pull/2005
