### PR TITLE
Change: Use debian:bullseye-slim base images

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -4,7 +4,7 @@
 ARG VERSION=unstable
 
 # Use '-slim' image for reduced image size
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 LABEL deprecated="This image is deprecated and may be removed soon."
 
 # This will make apt-get install without question

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=unstable
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/gvm-libs
-FROM debian:stable-slim AS build
+FROM debian:bullseye-slim AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install
@@ -10,7 +10,7 @@ RUN sh /source/.github/install-dependencies.sh
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -31,7 +31,7 @@ jobs:
           images: ${{ github.repository }}-build
           labels: |
             org.opencontainers.image.vendor=Greenbone
-            org.opencontainers.image.base.name=debian:stable-slim
+            org.opencontainers.image.base.name=debian:bullseye-slim
           flavor: latest=false # no latest container tag for git tags
           tags: |
             # create container tag for git tags

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -47,7 +47,7 @@ jobs:
           images: ${{ github.repository }}
           labels: |
             org.opencontainers.image.vendor=Greenbone
-            org.opencontainers.image.base.name=debian:stable-slim
+            org.opencontainers.image.base.name=debian:bullseye-slim
           flavor: latest=false # no auto latest container tag for git tags
           tags: |
             # when IS_LATEST_TAG is set create a stable and a latest tag


### PR DESCRIPTION
## What
Use debian:bullseye-slim base images instead of  debian:stable-slim

## Why
So the release of Debian Bookworm does not break compatibility.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


