### PR TITLE
Add: Add excerpt_size field to credentials_t

### DIFF
--- a/base/credentials.h
+++ b/base/credentials.h
@@ -34,6 +34,8 @@ typedef struct
   ///< Dynamic Severity setting of user.
   /*@null@ */ gchar *role;
   ///< Role of user.
+  /*@null@ */ int excerpt_size;
+  ///< Note/Override Excerpt Size setting of user.
 } credentials_t;
 
 void


### PR DESCRIPTION
## What
The credentials struct now has a new field for the setting "Note/Override Excerpt Size".

## Why
This allows gvmd to cache the setting so it does not have to query the database for every reference to a note or override in a report.

## References
GEA-86

