### PR TITLE
Add: function read_text_string_c

### DIFF
--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -1390,6 +1390,30 @@ read_text_c (gvm_connection_t *connection, char **text)
 }
 
 /**
+ * @brief Read text from the server.
+ *
+ * @param[in]  connection  Connection.
+ * @param[out] string      Destination for output.
+ *
+ * @return 0 success, -1 read error, -2 argument error.
+ */
+int
+read_text_string_c (gvm_connection_t *connection, GString **string)
+{
+  int ret;
+
+  if ((string == NULL) || (*string == NULL))
+    return -2;
+
+  if (connection->tls)
+    ret = try_read_string (&connection->session, 0, string);
+  else
+    ret = try_read_string_s (connection->socket, 0, string);
+
+  return ret;
+}
+
+/**
  * @brief Read entity and text. Free the entity immediately.
  *
  * @param[in]   session  Pointer to GNUTLS session to read from.

--- a/util/xmlutils.h
+++ b/util/xmlutils.h
@@ -137,6 +137,9 @@ int
 read_text_c (gvm_connection_t *, char **);
 
 int
+read_text_string_c (gvm_connection_t *, GString **);
+
+int
 parse_entity (const char *, entity_t *);
 
 void


### PR DESCRIPTION
## What

Add read_text_string_c.  Skips XML parsing like read_text_c, but reads into a GString.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

Convenient if the caller is already using a GString.

<!-- Describe why are these changes necessary? -->



