### PR TITLE
Change: Ensure dir exists in pidfile_create

### DIFF
--- a/base/pidfile.c
+++ b/base/pidfile.c
@@ -47,7 +47,7 @@ pidfile_create (gchar *pid_file_path)
 
   copy = g_strdup (pid_file_path);
   dir = dirname (copy);
-  
+
   /* Ensure directory exists. */
 
   if (g_mkdir_with_parents (dir, 0755)) /* "rwxr-xr-x" */


### PR DESCRIPTION
## What

Make sure the dir exists when creating the PID file.

Also log the name of the file when creating the PID file fails.

## Why

This always catches me when I install from source.

## References

Precedent in logging: https://github.com/greenbone/gvm-libs/blob/43bc281ab071f9d071c7f5f9a7ad8c9178871fb8/base/logging.c#L772

