### PR TITLE
Add: Add new functions related to reverse lookup

### DIFF
--- a/base/hosts.h
+++ b/base/hosts.h
@@ -19,6 +19,12 @@
  */
 #define FEATURE_HOSTS_ALLOWED_ONLY 1
 
+/** @brief Flag that indecates that this version includes
+ *  the functions gvm_reverse_lookup_only_excluded()
+ *  and gvm_reverse_lookup_unify_excluded()
+ */
+#define FEATURE_REVERSE_LOOKUP_EXCLUDED 1
+
 #include <glib.h>       /* for gchar, GList */
 #include <netinet/in.h> /* for in6_addr, in_addr */
 
@@ -140,6 +146,12 @@ gvm_hosts_reverse_lookup_only (gvm_hosts_t *);
 
 int
 gvm_hosts_reverse_lookup_unify (gvm_hosts_t *);
+
+gvm_hosts_t *
+gvm_hosts_reverse_lookup_only_excluded (gvm_hosts_t *);
+
+gvm_hosts_t *
+gvm_hosts_reverse_lookup_unify_excluded (gvm_hosts_t *);
 
 unsigned int
 gvm_hosts_count (const gvm_hosts_t *);


### PR DESCRIPTION
## What
Add gvm_reverse_lookup_only_excluded() and gvm_reverse_lookup_unify_excluded() This functions return a hosts structure containing the excluded hosts which did not satisfy the condition
Jira: SC-929


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
It is necessary to know the hosts which where removed from the original hosts list.
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


