### PR TITLE
Change: Don't perform alive tests if "consider alive" method is selected

### DIFF
--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -474,6 +474,7 @@ get_alive_test_methods (alive_test_t *alive_test)
     {
       *alive_test = atoi (alive_test_pref_as_str);
     }
+
   return error;
 }
 


### PR DESCRIPTION
## What
When more than one alive test method is selected, boreas check for each one until the host is alive. This will be done also even if the "consider alive" methods is selected. 
Jira: SC-934
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This patch improves boreas to not run other selected alive methods if "consider alive" method is set

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


