### PR TITLE
Add: missing const

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -498,7 +498,7 @@ typedef struct nvtpref
  *         released using @ref nvtpref_free .
  */
 nvtpref_t *
-nvtpref_new (int id, gchar *name, gchar *type, gchar *dflt)
+nvtpref_new (int id, const gchar *name, const gchar *type, const gchar *dflt)
 {
   nvtpref_t *np = g_malloc0 (sizeof (nvtpref_t));
 

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -20,7 +20,7 @@
 typedef struct nvtpref nvtpref_t;
 
 nvtpref_t *
-nvtpref_new (int, gchar *, gchar *, gchar *);
+nvtpref_new (int, const gchar *, const gchar *, const gchar *);
 
 void
 nvtpref_free (nvtpref_t *);


### PR DESCRIPTION
## What

Add missing const attributes to nvtpref_new.

## Why

Needed to prevent warning if caller passes in a const.

