### PR TITLE
Change: remove leading g_ that looks like glib

### DIFF
--- a/util/gpgmeutils.c
+++ b/util/gpgmeutils.c
@@ -425,10 +425,10 @@ create_all_certificates_trustlist (gpgme_ctx_t ctx, const char *homedir)
   gpgme_key_t key;
   gchar *trustlist_filename;
   GString *trustlist_content;
-  GError *g_err;
+  GError *error;
   gpgme_error_t err;
 
-  g_err = NULL;
+  error = NULL;
   gpgme_set_pinentry_mode (ctx, GPGME_PINENTRY_MODE_CANCEL);
 
   trustlist_filename = g_build_filename (homedir, "trustlist.txt", NULL);
@@ -450,11 +450,11 @@ create_all_certificates_trustlist (gpgme_ctx_t ctx, const char *homedir)
     }
 
   if (g_file_set_contents (trustlist_filename, trustlist_content->str,
-                           trustlist_content->len, &g_err)
+                           trustlist_content->len, &error)
       == FALSE)
     {
       g_warning ("%s: Could not write trust list: %s", __func__,
-                 g_err->message);
+                 error->message);
       g_free (trustlist_filename);
       g_string_free (trustlist_content, TRUE);
       return -1;

--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -383,9 +383,6 @@ mqtt_init_auth (const char *server_uri, const char *username,
                 const char *password)
 {
   mqtt_t *mqtt = NULL;
-  const char *g_server_uri;
-  const char *g_username;
-  const char *g_password;
 
   g_debug ("%s: start", __func__);
 
@@ -399,16 +396,13 @@ mqtt_init_auth (const char *server_uri, const char *username,
       return -1;
     }
   g_debug ("%s: client id set: %s", __func__, mqtt->client_id);
-  g_server_uri = mqtt_get_global_server_uri ();
-  if (g_server_uri == NULL)
+  if (mqtt_get_global_server_uri () == NULL)
     mqtt_set_global_server_uri (server_uri);
 
-  g_username = mqtt_get_global_username ();
-  if (g_username == NULL)
+  if (mqtt_get_global_username () == NULL)
     mqtt_set_global_username (username);
 
-  g_password = mqtt_get_global_password ();
-  if (g_password == NULL)
+  if (mqtt_get_global_password () == NULL)
     mqtt_set_global_password (password);
 
   if (mqtt_connect (mqtt, server_uri, username, password))


### PR DESCRIPTION
## What

Remove "g_" prefix from variable names.

## Why

It makes them look like they're part of glib.


