### PR TITLE
Fix: Revert "Change: Drop parsing for $Date"

### DIFF
--- a/base/nvti.c
+++ b/base/nvti.c
@@ -300,20 +300,45 @@ parse_nvt_timestamp (const gchar *str_time)
   int offset;
   struct tm tm;
 
-  if (strcmp ((char *) str_time, "") == 0)
-    return 0;
+  if ((strcmp ((char *) str_time, "") == 0)
+      || (strcmp ((char *) str_time, "$Date: $") == 0)
+      || (strcmp ((char *) str_time, "$Date$") == 0)
+      || (strcmp ((char *) str_time, "$Date:$") == 0)
+      || (strcmp ((char *) str_time, "$Date") == 0)
+      || (strcmp ((char *) str_time, "$$") == 0))
+    {
+      return 0;
+    }
 
   /* Parse the time. */
 
   /* 2011-08-09 08:20:34 +0200 (Tue, 09 Aug 2011) */
+  /* $Date: 2012-02-17 16:05:26 +0100 (Fr, 17. Feb 2012) $ */
+  /* $Date: Fri, 11 Nov 2011 14:42:28 +0100 $ */
   memset (&tm, 0, sizeof (struct tm));
   if (strptime ((char *) str_time, "%F %T %z", &tm) == NULL)
     {
       memset (&tm, 0, sizeof (struct tm));
-      if (strptime ((char *) str_time, "%a %b %d %T %Y %z", &tm) == NULL)
+      if (strptime ((char *) str_time, "$Date: %F %T %z", &tm) == NULL)
         {
-          g_warning ("%s: Failed to parse time: %s", __func__, str_time);
-          return 0;
+          memset (&tm, 0, sizeof (struct tm));
+          if (strptime ((char *) str_time, "%a %b %d %T %Y %z", &tm) == NULL)
+            {
+              memset (&tm, 0, sizeof (struct tm));
+              if (strptime ((char *) str_time, "$Date: %a, %d %b %Y %T %z", &tm)
+                  == NULL)
+                {
+                  memset (&tm, 0, sizeof (struct tm));
+                  if (strptime ((char *) str_time, "$Date: %a %b %d %T %Y %z",
+                                &tm)
+                      == NULL)
+                    {
+                      g_warning ("%s: Failed to parse time: %s", __func__,
+                                 str_time);
+                      return 0;
+                    }
+                }
+            }
         }
     }
   epoch_time = mktime (&tm);
@@ -327,8 +352,17 @@ parse_nvt_timestamp (const gchar *str_time)
 
   if ((sscanf ((char *) str_time, "%*u-%*u-%*u %*u:%*u:%*u %d%*[^]]", &offset)
        != 1)
+      && (sscanf ((char *) str_time, "$Date: %*u-%*u-%*u %*u:%*u:%*u %d%*[^]]",
+                  &offset)
+          != 1)
       && (sscanf ((char *) str_time, "%*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]",
                   &offset)
+          != 1)
+      && (sscanf ((char *) str_time,
+                  "$Date: %*s %*s %*s %*u %*u:%*u:%*u %d%*[^]]", &offset)
+          != 1)
+      && (sscanf ((char *) str_time,
+                  "$Date: %*s %*s %*s %*u:%*u:%*u %*u %d%*[^]]", &offset)
           != 1))
     {
       g_warning ("%s: Failed to parse timezone offset: %s", __func__, str_time);


### PR DESCRIPTION
Given testing with the enterprise feed it seems that $Date is still
used.

This reverts commit 32d9e66c351ac0ecab0ea7f6a943db8bd55f4617.
