### PR TITLE
Add: set_log_tz

### DIFF
--- a/base/logging.h
+++ b/base/logging.h
@@ -54,4 +54,7 @@ get_log_reference (void);
 void
 free_log_reference (void);
 
+void
+set_log_tz (const gchar *);
+
 #endif /* not _GVM_LOGGING_H */


### PR DESCRIPTION
## What

Add the function `set_log_tz` to the logging API.

## Why

This lets the logging caller specify which timezone is used for all log message.