### PR TITLE
Fix: prevent segfault in gvm_ssh_public_from_private

### DIFF
--- a/util/sshutils.c
+++ b/util/sshutils.c
@@ -76,6 +76,8 @@ gvm_ssh_public_from_private (const char *private_key, const char *passphrase)
   const char *type;
   int ret;
 
+  if (private_key == NULL)
+    return NULL;
   decrypted_priv = gvm_ssh_pkcs8_decrypt (private_key, passphrase);
   ret = ssh_pki_import_privkey_base64 (decrypted_priv ? decrypted_priv
                                                       : private_key,


### PR DESCRIPTION
## What

Prevent a segfault in `gvm_ssh_public_from_private` when calling GMP GET_CREDENTIALS with `format="key"`.

## Why

Segfault bad.

## Reproduce

Create a password credential.
```
o m m '<create_credential><name>segf</name><login>segf</login><password>segf</password></create_credential>'
```
Get the credential with format `key`:
```
o m m '<get_credentials format="key" filter="name=segf"/>'
```
Before the PR the response is empty and this happens in the log:
```
md manage:MESSAGE:2024-05-13 13h48.53 EDT:588564: Received Segmentation fault signal
md   main:MESSAGE:2024-05-13 13h49.25 EDT:588625: BACKTRACE: gvmd: Serving client(+0x70026) [0x5555555c4026]
```
After the PR the log is clear and the response is good:
```
<get_credentials_response status="200" status_text="OK">
  <credential id="85a3848c-1890-4bf0-835e-bed8a6af691d">
    ...
```

