### PR TITLE
Change label of CodeCov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # gvm-libs
 
 [![GitHub releases](https://img.shields.io/github/release/greenbone/gvm-libs.svg)](https://github.com/greenbone/gvm-libs/releases)
-[![Code Documentation Coverage](https://img.shields.io/codecov/c/github/greenbone/gvm-libs.svg?label=Doc%20Coverage&logo=codecov)](https://codecov.io/gh/greenbone/gvm-libs)
+[![Code Documentation Coverage](https://img.shields.io/codecov/c/github/greenbone/gvm-libs.svg?label=Documentation%20Coverage&logo=codecov)](https://codecov.io/gh/greenbone/gvm-libs)
 [![Build and test C](https://github.com/greenbone/gvm-libs/actions/workflows/ci-c.yml/badge.svg)](https://github.com/greenbone/gvm-libs/actions/workflows/ci-c.yml)
 
 This is the libraries module for the Greenbone Community Edition.


### PR DESCRIPTION
The badge now says "Documentation Coverage" to make it clear that it is not measuring test coverage.