### PR TITLE
Allow to create messages in a PR for the dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,12 +1,13 @@
-name: 'Dependency Review'
+name: "Dependency Review"
 on: [pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Dependency Review'
+      - name: "Dependency Review"
         uses: greenbone/actions/dependency-review@v3


### PR DESCRIPTION


## What

Allow to create messages in a PR for the dependency review workflow

## Why

The workflow wants to write a message to the PR about the dependency review details. This requires the `pull-request: write` permission.