### PR TITLE
Remove libcgreen-dev from build container docker image

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -35,6 +35,5 @@ RUN apt-get update && \
   libldap2-dev \
   libradcli-dev \
   libpaho-mqtt-dev \
-  libcgreen1-dev \
   lcov \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION


## What

Remove libcgreen-dev from build container docker image

## Why

libcgreen-dev is not available for debian stable.

## References

https://github.com/greenbone/gvm-libs/actions/runs/9515855202/job/26230948905#step:8:284

