### PR TITLE
Doc: Add missing package name to apt-get install line in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,6 +44,7 @@ Install prerequisites on Debian GNU/Linux 'Bullseye' 11:
     apt-get install \
     cmake \
     pkg-config \
+    libcjson-dev \
     libglib2.0-dev \
     libgpgme-dev \
     libgnutls28-dev \


### PR DESCRIPTION
## What
#830 had added the package name on top but not included the Debian package name here

## Why
Obvious...

## References
None
