### PR TITLE
Fix: Fix issue DOS-290, by switching from libssh-gcrypt-dev to libgcr…

### DIFF
--- a/.github/install-dependencies.sh
+++ b/.github/install-dependencies.sh
@@ -13,7 +13,8 @@ apt-get update && \
   libgpgme-dev \
   libgnutls28-dev \
   uuid-dev \
-  libssh-gcrypt-dev \
+  libgcrypt-dev \
+  libssh-dev \
   libhiredis-dev \
   libxml2-dev \
   libpcap-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,7 +49,8 @@ Install prerequisites on Debian GNU/Linux 'Bullseye' 11:
     libgpgme-dev \
     libgnutls28-dev \
     uuid-dev \
-    libssh-gcrypt-dev \
+    libgcrypt-dev \
+    libssh-dev \
     libhiredis-dev \
     libxml2-dev \
     libpcap-dev \


### PR DESCRIPTION
Fix issue DOS-290

## What
 - switching from libssh-gcrypt-dev to libgcrypt-dev
 - adding libssh-dev
 
## Why
 - github action failed
 - libssh-gcrypt-dev not available in debian testing anymore
 - libssh-dev replaces ssh part
 - gcrypt-dev replaces gcrypt part

## References

Ticket: https://jira.greenbone.net/browse/DOS-290

GH Action: https://github.com/greenbone/gvm-libs/actions/runs/10886714228/job/30241572895#step:13:296

## Checklist
- [ ] Tests
- [ ] Additional Task: Refactoring Action into seperate Actions for clarity


