### PR TITLE
Fix: Dynamically adapt to workflow file in openvas-scanner repo

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -180,5 +180,5 @@ jobs:
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: ${{ matrix.repository }}
-          workflow: container.yml
+          workflow: ${{ matrix.repository == 'greenbone/openvas-scanner' && 'push-container.yml' || 'container.yml' }}
           ref: main


### PR DESCRIPTION
## What

'Trigger update container images in related projects' are broken in gvm-libs for openvas-scanner and boreas

## Why

- openvas-scanner workflow is broken because container.yml has been renamed/removed
- boreas workflow is broken because gvm-libs now requires libssh-dev: https://github.com/greenbone/boreas/pull/67

## References

- https://mattermost.greenbone.net/gb/pl/i8wqemtaubgozchdp8yhm8zper
- https://github.com/greenbone/gvm-libs/actions/runs/10904200164/job/30262026614
- https://jira.greenbone.net/browse/DEVOPS-1224
- https://github.com/greenbone/boreas/pull/67

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


