### PR TITLE
Fix: Retry and Rename other workflow file for openvas-scanner, DEVOPS-1224

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -180,5 +180,5 @@ jobs:
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: ${{ matrix.repository }}
-          workflow: container.yml
+          workflow: ${{ matrix.repository == 'greenbone/openvas-scanner' && 'push-container.yml' || 'container.yml' }}
           ref: main

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -180,5 +180,5 @@ jobs:
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: ${{ matrix.repository }}
-          workflow: ${{ matrix.repository == 'greenbone/openvas-scanner' && 'push-container.yml' || 'container.yml' }}
+          workflow: ${{ matrix.repository == 'greenbone/openvas-scanner' && 'control.yml' || 'container.yml' }}
           ref: main


### PR DESCRIPTION
## What

Replace push-container.yml with control.yml

## Why

'Trigger update container images in related projects (greenbone/openvas-scanner)' Action still fails, because push-container.yml misses workflow_dispatch trigger.
Only found sbom-upload.yml or control.yml with the workflow_dispatch trigger in openvas-scanner.

Trying if the latter one is the correct one.

Alternatively, I started a search for the history of the container.yml file.
So there exists some dereferenced commit in openvas-scanner, which is foundable with:
`~/Greenbone/openvas-scanner/ > git log --all --full-history -- .github/workflows/container.yml `

This might be some clue why and how the workflow files have changed.

## References

https://github.com/greenbone/gvm-libs/pull/834

## Checklist

- [ ] Tests


