### PR TITLE
Fix: Add libcjson1 to oldstable Dockerfile

### DIFF
--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -38,6 +38,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
+  libcjson1 \
   libglib2.0-0 \
   libgpgme11 \
   libgnutls30 \


### PR DESCRIPTION
## What
Add libcjson1 to oldstable Dockerfile

## Why
Builds using the resulting image can fail because of the missing dependency.