### PR TITLE
Fix: Fixed the problem with escaped colons in fs CPEs.

### DIFF
--- a/util/cpeutils.c
+++ b/util/cpeutils.c
@@ -812,8 +812,13 @@ get_fs_component (const char *fs_cpe, int index)
     component_end = component_start;
   else
     {
-      for (c = component_start; *c != '\0' && *c != ':'; c++)
-        ;
+      for (c = component_start; *c != '\0'; c++)
+        {
+          if (*c == ':' && c == component_start)
+            break;
+          else if (c > component_start && *c == ':' && *(c - 1) != '\\')
+            break;
+        }
     }
 
   component_end = c;

--- a/util/cpeutils.c
+++ b/util/cpeutils.c
@@ -801,9 +801,7 @@ get_fs_component (const char *fs_cpe, int index)
     {
       for (int i = 0; *c != '\0' && i < index; c++)
         {
-          if (*c == ':' && c == fs_cpe)
-            i++;
-          else if (*c == ':' && !escaped)
+          if (*c == ':' && !escaped)
             i++;
           else if (*c == '\\' && !escaped)
             escaped = TRUE;

--- a/util/cpeutils.c
+++ b/util/cpeutils.c
@@ -783,6 +783,7 @@ get_fs_component (const char *fs_cpe, int index)
   char *component = NULL;
   char *c;
   char *component_start, *component_end;
+  gboolean escaped;
 
   if (!fs_cpe)
     return NULL;
@@ -793,6 +794,7 @@ get_fs_component (const char *fs_cpe, int index)
   c = (char *) fs_cpe;
 
   /* find start of component */
+  escaped = FALSE;
   if (index == 0)
     component_start = c;
   else
@@ -801,23 +803,30 @@ get_fs_component (const char *fs_cpe, int index)
         {
           if (*c == ':' && c == fs_cpe)
             i++;
-          else if (c > fs_cpe && *c == ':' && *(c - 1) != '\\')
+          else if (*c == ':' && !escaped)
             i++;
+          else if (*c == '\\' && !escaped)
+            escaped = TRUE;
+          else
+            escaped = FALSE;
         }
       component_start = c;
     }
 
   /* find end of component */
+  escaped = FALSE;
   if (*component_start == '\0')
     component_end = component_start;
   else
     {
       for (c = component_start; *c != '\0'; c++)
         {
-          if (*c == ':' && c == component_start)
+          if (*c == ':' && !escaped)
             break;
-          else if (c > component_start && *c == ':' && *(c - 1) != '\\')
-            break;
+          if (*c == '\\' && !escaped)
+            escaped = TRUE;
+          else
+            escaped = FALSE;
         }
     }
 

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -230,6 +230,15 @@ Ensure (cpeutils, fs_cpe_to_uri_cpe)
       "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A2003~x64~"));
   g_free (uri_cpe);
 
+  fs_cpe =
+    "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win2003\\\\:x64:*";
+  uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
+  assert_that (
+    uri_cpe,
+    is_equal_to_string (
+      "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win2003%5C~x64~"));
+  g_free (uri_cpe);
+
   fs_cpe = "This is a ~:SIGNAL:~ test.";
   uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
   g_free (uri_cpe);

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -212,6 +212,24 @@ Ensure (cpeutils, fs_cpe_to_uri_cpe)
       "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win2003~x64~"));
   g_free (uri_cpe);
 
+  fs_cpe =
+    "cpe:2.3:a:hp:insight_diagnostics:7\\:4.0.1570:-:*:*:online:win2003:x64:*";
+  uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
+  assert_that (
+    uri_cpe,
+    is_equal_to_string (
+      "cpe:/a:hp:insight_diagnostics:7%3A4.0.1570:-:~~online~win2003~x64~"));
+  g_free (uri_cpe);
+
+  fs_cpe =
+    "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win\\:2003:x64:*";
+  uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
+  assert_that (
+    uri_cpe,
+    is_equal_to_string (
+      "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A2003~x64~"));
+  g_free (uri_cpe);
+
   fs_cpe = "This is a ~:SIGNAL:~ test.";
   uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
   g_free (uri_cpe);

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -230,6 +230,15 @@ Ensure (cpeutils, fs_cpe_to_uri_cpe)
       "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A2003~x64~"));
   g_free (uri_cpe);
 
+  fs_cpe =
+    "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win\\:\\:2003:x64:*";
+  uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
+  assert_that (
+    uri_cpe,
+    is_equal_to_string (
+      "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A%3A2003~x64~"));
+  g_free (uri_cpe);
+
   fs_cpe = "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:"
            "win2003\\\\:x64:*";
   uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -230,8 +230,8 @@ Ensure (cpeutils, fs_cpe_to_uri_cpe)
       "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A2003~x64~"));
   g_free (uri_cpe);
 
-  fs_cpe =
-    "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win2003\\\\:x64:*";
+  fs_cpe = "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:"
+           "win2003\\\\:x64:*";
   uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
   assert_that (
     uri_cpe,

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -230,13 +230,14 @@ Ensure (cpeutils, fs_cpe_to_uri_cpe)
       "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A2003~x64~"));
   g_free (uri_cpe);
 
-  fs_cpe =
-    "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win\\:\\:2003:x64:*";
+  fs_cpe = "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win\\:\\:"
+           "2003:x64:*";
   uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
   assert_that (
     uri_cpe,
     is_equal_to_string (
-      "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A%3A2003~x64~"));
+      "cpe:/"
+      "a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win%3A%3A2003~x64~"));
   g_free (uri_cpe);
 
   fs_cpe = "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:"


### PR DESCRIPTION
## What
When implementing GEA-635 we encountered a problem with a formatted string CPE that contained an escaped colon (e. g.) in the version part. This problem is fixed now.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This was a bug.
<!-- Describe why are these changes necessary? -->

## References
GEA-635
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


