### PR TITLE
Fix: Fix parsing of colons in formatted string CPE components.

### DIFF
--- a/util/cpeutils.c
+++ b/util/cpeutils.c
@@ -812,7 +812,9 @@ get_fs_component (const char *fs_cpe, int index)
     component_end = component_start;
   else
     {
-      for (c = component_start; *c != '\0' && *c != ':'; c++)
+      for (c = component_start;
+           *c != '\0' && !(*c == ':' && c > fs_cpe && *(c - 1) != '\\');
+           c++)
         ;
     }
 

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -215,6 +215,22 @@ Ensure (cpeutils, fs_cpe_to_uri_cpe)
   fs_cpe = "This is a ~:SIGNAL:~ test.";
   uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
   g_free (uri_cpe);
+
+  fs_cpe =
+    "cpe:2.3:a:9base_project:9base:1\\:6-6:*:*:*:*:*:*:*";
+  uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
+  assert_that (uri_cpe, is_equal_to_string (
+                          "cpe:/a:9base_project:9base:1%3A6-6"));
+  g_free (uri_cpe);
+
+  fs_cpe =
+    "cpe:2.3:a:app\\:\\:cpanminus_project:app\\:\\:cpanminus:1.7000:*:*:*:*:perl:*:*";
+  uri_cpe = fs_cpe_to_uri_cpe (fs_cpe);
+  assert_that (
+    uri_cpe,
+    is_equal_to_string (
+      "cpe:/a:app%3A%3Acpanminus_project:app%3A%3Acpanminus:1.7000::~~~perl~~"));
+  g_free (uri_cpe);
 }
 
 Ensure (cpeutils, cpe_struct_match)


### PR DESCRIPTION
## What
Fix parsing of colons in formatted string CPE components.

## Why
Components with colons were not handled correctly. Some examples below:
`cpe:2.3:a:9base_project:9base:1\:6-6:*:*:*:*:*:*:*` should parse the version as `1:6-6`
`cpe:2.3:a:app\:\:cpanminus_project:app\:\:cpanminus:1.7000:*:*:*:*:perl:*:*` should parse the `vendor` as `app::cpanminus_project `and `product` as `app::cpanminus`

See for reference:
https://nvd.nist.gov/products/cpe/detail/49C19030-1A4C-4245-9773-A963C2713807
https://nvd.nist.gov/products/cpe/detail/36B03638-7BE3-4B79-95FB-C6AC0AFE53DC



