### PR TITLE
Fix: Use unsigned long for compression lengths

### DIFF
--- a/util/compressutils_tests.c
+++ b/util/compressutils_tests.c
@@ -22,14 +22,14 @@ Ensure (compressutils, can_compress_and_uncompress_without_header)
 {
   const char *testdata = "TEST-12345-12345-TEST";
 
-  size_t compressed_len;
+  unsigned long compressed_len;
   char *compressed =
     gvm_compress (testdata, strlen (testdata) + 1, &compressed_len);
   assert_that (compressed_len, is_greater_than (0));
   assert_that (compressed, is_not_null);
   assert_that (compressed, is_not_equal_to_string (testdata));
 
-  size_t uncompressed_len;
+  unsigned long uncompressed_len;
   char *uncompressed =
     gvm_uncompress (compressed, compressed_len, &uncompressed_len);
   assert_that (uncompressed_len, is_equal_to (strlen (testdata) + 1));
@@ -40,7 +40,7 @@ Ensure (compressutils, can_compress_and_uncompress_with_header)
 {
   const char *testdata = "TEST-12345-12345-TEST";
 
-  size_t compressed_len;
+  unsigned long compressed_len;
   char *compressed =
     gvm_compress_gzipheader (testdata, strlen (testdata) + 1, &compressed_len);
   assert_that (compressed_len, is_greater_than (0));
@@ -51,7 +51,7 @@ Ensure (compressutils, can_compress_and_uncompress_with_header)
   assert_that (compressed[1], is_equal_to ((char) 0x8b));
   assert_that (compressed[2], is_equal_to (8));
 
-  size_t uncompressed_len;
+  unsigned long uncompressed_len;
   char *uncompressed =
     gvm_uncompress (compressed, compressed_len, &uncompressed_len);
   assert_that (uncompressed_len, is_equal_to (strlen (testdata) + 1));
@@ -61,7 +61,7 @@ Ensure (compressutils, can_compress_and_uncompress_with_header)
 Ensure (compressutils, can_uncompress_using_reader)
 {
   const char *testdata = "TEST-12345-12345-TEST";
-  size_t compressed_len;
+  unsigned long compressed_len;
   char *compressed =
     gvm_compress_gzipheader (testdata, strlen (testdata) + 1, &compressed_len);
 
@@ -83,7 +83,7 @@ Ensure (compressutils, can_uncompress_using_reader)
 Ensure (compressutils, can_uncompress_using_fd_reader)
 {
   const char *testdata = "TEST-12345-12345-TEST";
-  size_t compressed_len;
+  unsigned long compressed_len;
   char *compressed =
     gvm_compress_gzipheader (testdata, strlen (testdata) + 1, &compressed_len);
 


### PR DESCRIPTION
## What

Pass `unsigned long` instead of `size_t` to the compression functions like `gvm_compress`.

## Why

It's the expected type.  On 32bit architectures like i386, using `size_t` leads to compile errors from `-Werror=incompatible-pointer-types`.

## Reproduce

1. Setup [Debian 12 i386](https://portal.cloud.hashicorp.com/vagrant/discover/generic-x32/debian12) in VM
2. `cd $BUILD && cmake $SOURCE -D CMAKE_C_FLAGS=-m32 -D CMAKE_C_COMPILER=gcc -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON`
3. `cd $BUILD && make -B VERBOSE=1`
4. `cd $BUILD && make -B VERBOSE=1 tests`

Should see errors like:
```
path/to/compressutils_tests.c:88:63: error: passing argument 3 of ‘gvm_compress_gzipheader’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   88 |     gvm_compress_gzipheader (testdata, strlen (testdata) + 1, &compressed_len);
      |                                                               ^~~~~~~~~~~~~~~
      |                                                               |
      |                                                               size_t * {aka unsigned int *}
```

## References

Closes #846.