### PR TITLE
Fix: openvasd: get result detail source from right place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,8 @@ if (BUILD_TESTS AND NOT SKIP_SRC)
     DEPENDS array-test alivedetection-test boreas_error-test boreas_io-test
             cli-test cpeutils-test cvss-test ping-test sniffer-test util-test networking-test
             passwordbasedauthentication-test xmlutils-test version-test versionutils-test
-            osp-test nvti-test hosts-test jsonpull-test compressutils-test)
+            osp-test nvti-test hosts-test jsonpull-test compressutils-test
+            openvasd-test)
 
 endif (BUILD_TESTS AND NOT SKIP_SRC)
 

--- a/openvasd/CMakeLists.txt
+++ b/openvasd/CMakeLists.txt
@@ -44,6 +44,25 @@ if (BUILD_SHARED)
     ${CURL_LDFLAGS} ${LINKER_HARDENING_FLAGS})
 endif (BUILD_SHARED)
 
+## Tests
+
+if (BUILD_TESTS)
+  add_executable (openvasd-test
+                  EXCLUDE_FROM_ALL
+                  openvasd_tests.c ../base/array.c ../base/networking.c)
+
+  add_test (openvasd-test openvasd-test)
+
+  target_include_directories (openvasd-test PRIVATE ${CGREEN_INCLUDE_DIRS})
+
+  target_link_libraries (openvasd-test ${CGREEN_LIBRARIES}
+                         ${GLIB_LDFLAGS} ${CJSON_LDFLAGS} ${CURL_LDFLAGS}
+                         ${LINKER_HARDENING_FLAGS})
+
+  add_custom_target (tests-openvasd
+                     DEPENDS openvasd-test)
+endif (BUILD_TESTS)
+
 ## Install
 configure_file (libgvm_openvasd.pc.in ${CMAKE_BINARY_DIR}/libgvm_openvasd.pc @ONLY)
 

--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -1178,19 +1178,23 @@ openvasd_parsed_results (openvasd_connector_t conn, unsigned long first,
             && cJSON_IsString (detail_obj))
           detail_value = g_strdup (detail_obj->valuestring);
 
-        cJSON *source_obj = NULL;
-        if ((source_obj = cJSON_GetObjectItem (detail_obj, "type")) != NULL
-            && cJSON_IsObject (source_obj))
-          detail_source_type = g_strdup (detail_obj->valuestring);
+        detail_obj = cJSON_GetObjectItem (item, "source");
+        if (detail_obj && cJSON_IsObject (detail_obj))
+          {
+            cJSON *source_obj;
 
-        if ((source_obj = cJSON_GetObjectItem (detail_obj, "name")) != NULL
-            && cJSON_IsString (source_obj))
-          detail_source_name = g_strdup (detail_obj->valuestring);
+            if ((source_obj = cJSON_GetObjectItem (detail_obj, "type")) != NULL
+                && cJSON_IsObject (source_obj))
+              detail_source_type = g_strdup (source_obj->valuestring);
 
-        if ((source_obj = cJSON_GetObjectItem (detail_obj, "description"))
-              != NULL
-            && cJSON_IsString (source_obj))
-          detail_source_description = g_strdup (detail_obj->valuestring);
+            if ((source_obj = cJSON_GetObjectItem (detail_obj, "name")) != NULL
+                && cJSON_IsString (source_obj))
+              detail_source_name = g_strdup (source_obj->valuestring);
+
+            if ((source_obj = cJSON_GetObjectItem (detail_obj, "description")) != NULL
+                && cJSON_IsString (source_obj))
+              detail_source_description = g_strdup (source_obj->valuestring);
+          }
       }
 
     result = openvasd_result_new (id, type, ip_address, hostname, oid, port,

--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -1184,7 +1184,7 @@ openvasd_parsed_results (openvasd_connector_t conn, unsigned long first,
             cJSON *source_obj;
 
             if ((source_obj = cJSON_GetObjectItem (detail_obj, "type")) != NULL
-                && cJSON_IsObject (source_obj))
+                && cJSON_IsString (source_obj))
               detail_source_type = g_strdup (source_obj->valuestring);
 
             if ((source_obj = cJSON_GetObjectItem (detail_obj, "name")) != NULL

--- a/openvasd/openvasd_tests.c
+++ b/openvasd/openvasd_tests.c
@@ -1,0 +1,78 @@
+/* SPDX-FileCopyrightText: 2019-2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "openvasd.c"
+
+#include <cgreen/cgreen.h>
+#include <cgreen/mocks.h>
+
+Describe (openvasd);
+BeforeEach (openvasd)
+{
+}
+
+AfterEach (openvasd)
+{
+}
+
+/* parse_results */
+
+Ensure (openvasd, parse_results_handles_details)
+{
+  const gchar *str;
+  GSList *results;
+  openvasd_result_t result;
+
+
+  results = NULL;
+
+  str = "[ {"
+    "  \"id\": 16,"
+    "  \"type\": \"host_detail\","
+    "  \"ip_address\": \"192.168.0.101\","
+    "  \"hostname\": \"g\","
+    "  \"oid\": \"1.3.6.1.4.1.25623.1.0.103997\","
+    "  \"message\": \"<host><detail><name>MAC</name><value>94:E6:F7:67:4B:C0</value><source><type>nvt</type><name>1.3.6.1.4.1.25623.1.0.103585</name><description>Nmap MAC Scan</description></source></detail></host>\","
+    "  \"detail\": {"
+    "    \"name\": \"MAC\","
+    "    \"value\": \"00:1A:2B:3C:4D:5E\","
+    "    \"source\": {"
+    "      \"type\": \"nvt\","
+    "      \"name\": \"1.3.6.1.4.1.25623.1.0.103585\","
+    "      \"description\": \"Nmap MAC Scan\""
+    "    }"
+    "  }"
+    "} ]";
+
+  parse_results (str, &results);
+
+  assert_that (g_slist_length (results), is_equal_to (1));
+
+  result = results->data;
+  assert_that (result->detail_name, is_equal_to_string ("MAC"));
+  assert_that (result->detail_value, is_equal_to_string ("00:1A:2B:3C:4D:5E"));
+  assert_that (result->detail_source_type, is_equal_to_string ("nvt"));
+  assert_that (result->detail_source_name, is_equal_to_string ("1.3.6.1.4.1.25623.1.0.103585"));
+  assert_that (result->detail_source_description, is_equal_to_string ("Nmap MAC Scan"));
+
+  if (g_slist_length (results))
+    g_slist_free_full (results, (GDestroyNotify) openvasd_result_free);
+}
+
+/* Test suite. */
+int
+main (int argc, char **argv)
+{
+  TestSuite *suite;
+
+  suite = create_test_suite ();
+
+  add_test_with_context (suite, openvasd, parse_results_handles_details);
+
+  if (argc > 1)
+    return run_single_test (suite, argv[1], create_text_reporter ());
+
+  return run_test_suite (suite, create_text_reporter ());
+}


### PR DESCRIPTION
## What

In `openvasd_parsed_results`, get `detail_source_*` from `detail > source > *`, instead of from  `detail > value > *`.

## Why

This seems to be the intention, according to the API and rust code.

Note that this also catches a problem where `cJSON_GetObjectItem (detail_obj, "type")` could have been called when `detail_obj` was NULL.

