### PR TITLE
Change: Disable build of openvasd for oldstable

### DIFF
--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
   libcgreen1-dev \
   lcov \
   && rm -rf /var/lib/apt/lists/*
-RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DOPENVASD=0 -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
 FROM debian:oldstable-slim

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif (NOT CMAKE_BUILD_TYPE)
 OPTION(BUILD_STATIC "Build static versions of the libraries" OFF)
 OPTION(ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
 OPTION(BUILD_TESTS "Build tests for the libraries" OFF)
+OPTION(OPENVASD "Build openvasd library" ON)
 
 if (NOT BUILD_STATIC)
   set (BUILD_SHARED ON)
@@ -258,9 +259,12 @@ if (NOT SKIP_SRC)
   add_subdirectory (base)
   add_subdirectory (boreas)
   add_subdirectory (util)
-  add_subdirectory (openvasd)
   add_subdirectory (osp)
   add_subdirectory (gmp)
+
+  if (OPENVASD)
+    add_subdirectory (openvasd)
+  endif (OPENVASD)
 endif (NOT SKIP_SRC)
 
 ## Documentation


### PR DESCRIPTION
## What
The CMake option OPENVASD is added and used to disable building the openvasd library in the oldstable Docker images.

## Why
This is needed because openvasd would need a newer libcurl version.

