### PR TITLE
Fix: add const for libxml2 2.12.0 API change

### DIFF
--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -3030,7 +3030,7 @@ xml_file_iterator_next (xml_file_iterator_t iterator, gchar **error)
             {
               if (error)
                 {
-                  xmlErrorPtr xml_error;
+                  const xmlError *xml_error;
                   xml_error = xmlCtxtGetLastError (iterator->parser_ctxt);
                   *error = g_strdup_printf ("error parsing XML"
                                             " (line %d column %d): %s",


### PR DESCRIPTION
## What

Adjust type for return from `xmlCtxtGetLastError`.

## Why

The libxml2 API changed.

## References

libxml return type was changed in [61034116d0a3c8b295c6137956adc3ae55720711](https://github.com//GNOME/libxml2/commit/61034116d0a3c8b295c6137956adc3ae55720711).
See discussion [here](https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7) and [here](https://gitlab.gnome.org/GNOME/libxml2/-/issues/622).

Closes #855.

## Test

1. Install libxml2 2.13.5 from source.
2. Ensure it's used
```patch
--- util/CMakeLists.txt
+++ util/CMakeLists.txt
@@ -34,7 +34,7 @@ pkg_check_modules (LIBSSH REQUIRED libssh>=0.6.0)
 pkg_check_modules (REDIS REQUIRED hiredis>=0.10.1)
 
 # for fast XML we need libxml2
-pkg_check_modules (LIBXML2 REQUIRED libxml-2.0>=2.0)
+pkg_check_modules (LIBXML2 REQUIRED libxml-2.0>=2.13)
 
 # for gpgmeutils we need libgpgme
 pkg_check_modules (GPGME REQUIRED gpgme>=1.7.0)
```
3. Compile gvm-libs, before PR output was:
```
/home/user/fresh/main/gvm-libs/util/xmlutils.c:3034:29: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
 3034 |                   xml_error = xmlCtxtGetLastError (iterator->parser_ctxt);
      |                             ^
```
