### PR TITLE
Only libcurl 7.77.0 provides the needed functions.

### DIFF
--- a/openvasd/CMakeLists.txt
+++ b/openvasd/CMakeLists.txt
@@ -13,7 +13,7 @@ endif (NOT PKG_CONFIG_FOUND)
 ## Dependency checks
 
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
-pkg_check_modules (CURL REQUIRED libcurl>=7.74.0)
+pkg_check_modules (CURL REQUIRED libcurl>=7.77.0)
 
 # for json parsing we need cJSON
 pkg_check_modules (CJSON REQUIRED libcjson>=1.7.14)


### PR DESCRIPTION
## What

fix  https://github.com/greenbone/gvm-libs/issues/858

## Why

Only newer versions of libcurl provides the needed functions


