### PR TITLE
Fix: Require libcurl >= 7.83.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ General build environment:
 
 Specific development libraries:
 * libcjson >= 1.7.14 (util)
-* libcurl >= 7.74.0 (openvasd)
+* libcurl >= 7.83.0 (openvasd)
 * libglib >= 2.42 (all)
 * libgio >= 2.42 (util)
 * zlib >= 1.2.8 (util)

--- a/openvasd/CMakeLists.txt
+++ b/openvasd/CMakeLists.txt
@@ -13,7 +13,7 @@ endif (NOT PKG_CONFIG_FOUND)
 ## Dependency checks
 
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
-pkg_check_modules (CURL REQUIRED libcurl>=7.77.0)
+pkg_check_modules (CURL REQUIRED libcurl>=7.83.0)
 
 # for json parsing we need cJSON
 pkg_check_modules (CJSON REQUIRED libcjson>=1.7.14)

--- a/util/kb.h
+++ b/util/kb.h
@@ -73,7 +73,7 @@ struct kb_item
   {
     char *v_str; /**< Hold an str value for this kb item. */
     int v_int;   /**< Hold an int value for this kb item. */
-  };             /**< Value of this knowledge base item. */
+  }; /**< Value of this knowledge base item. */
 
   size_t len;           /**< Length of string. */
   struct kb_item *next; /**< Next item in list. */


### PR DESCRIPTION


## What

A newer libcurl is required then stated and checked.

## Why

The curl function curl_easy_header is used which got introduced into libcurl with 7.83.0 according to
https://curl.se/libcurl/c/curl_easy_header.html.

## References

Closes #861