### PR TITLE
Move openvasd_start_scan warning up in case the cJSON err is empty

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -810,6 +810,7 @@ openvasd_start_scan (openvasd_connector_t conn, gchar *data)
   if (!parser)
     {
       const gchar *error_ptr = cJSON_GetErrorPtr ();
+      g_warning ("%s: Error parsing json string to get the scan ID", __func__);
       if (error_ptr != NULL)
         {
           response->body = g_strdup_printf ("{\"error\": \"%s\"}", error_ptr);
@@ -819,7 +820,6 @@ openvasd_start_scan (openvasd_connector_t conn, gchar *data)
         {
           response->body = g_strdup (
             "{\"error\": \"Parsing json string to get the scan ID\"}");
-          g_warning ("%s: Parsing json string to get the scan ID", __func__);
         }
       response->code = RESP_CODE_ERR;
       cJSON_Delete (parser);


### PR DESCRIPTION
## What

In `openvasd_start_scan` move the `Error parsing ... ID` warning out of the `if` so that the warning is printed even when there is an error message from `cJSON_GetErrorPtr`.

## Why

Sometimes the error message from `cJSON_GetErrorPtr` is an empty string, for example when there is an error connecting to the scanner. This makes it hard to locate the problem.

Note that this is a small helper fix. The real issue is that all the callers of `openvasd_send_request` are only checking the return for `RESP_CODE_ERR` (-1) when the return can also be eg 403. There are many of these so the fix needs some planning and a bigger PR.


