### PR TITLE
Update dependencies

### DIFF
--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -9,25 +9,25 @@ COPY . /source
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   build-essential \
-  curl \
   cmake \
-  pkg-config \
+  curl \
   gnupg \
+  lcov \
+  libcgreen1-dev \
   libcjson-dev \
   libglib2.0-dev \
-  libgpgme-dev \
   libgnutls28-dev \
-  uuid-dev \
-  libssh-gcrypt-dev \
+  libgpgme-dev \
   libhiredis-dev \
-  libxml2-dev \
-  libpcap-dev \
-  libnet1-dev \
   libldap2-dev \
-  libradcli-dev \
+  libnet1-dev \
   libpaho-mqtt-dev \
-  libcgreen1-dev \
-  lcov \
+  libpcap-dev \
+  libradcli-dev \
+  libssh-gcrypt-dev \
+  libxml2-dev \
+  pkg-config \
+  uuid-dev \
   && rm -rf /var/lib/apt/lists/*
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DOPENVASD=0 -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
@@ -40,18 +40,18 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   libcjson1 \
   libglib2.0-0 \
-  libgpgme11 \
   libgnutls30 \
-  libuuid1 \
-  libjson-glib-1.0-0 \
-  libssh-gcrypt-4 \
+  libgpgme11 \
   libhiredis0.14 \
-  libxml2 \
-  libpcap0.8 \
-  libnet1 \
+  libjson-glib-1.0-0 \
   libldap-common \
-  libradcli4 \
+  libnet1 \
   libpaho-mqtt1.3 \
+  libpcap0.8 \
+  libradcli4 \
+  libssh-gcrypt-4 \
+  libuuid1 \
+  libxml2 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /install/ /

--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -43,7 +43,6 @@ RUN apt-get update && \
   libgnutls30 \
   libgpgme11 \
   libhiredis0.14 \
-  libjson-glib-1.0-0 \
   libldap-common \
   libnet1 \
   libpaho-mqtt1.3 \

--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -17,6 +17,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   libcjson1 \
+  libcurl3t64-gnutls \
   libglib2.0-0 \
   libgnutls30 \
   libgpgme11 \

--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -18,18 +18,18 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   libcjson1 \
   libglib2.0-0 \
-  libgpgme11 \
   libgnutls30 \
-  libuuid1 \
-  libssh-dev \
-  libhiredis1.1.0 \
+  libgpgme11 \
   libhiredis-dev \
-  libxml2 \
-  libpcap0.8 \
-  libnet1 \
+  libhiredis1.1.0 \
   libldap-common \
-  libradcli4 \
+  libnet1 \
   libpaho-mqtt1.3 \
+  libpcap0.8 \
+  libradcli4 \
+  libssh-dev \
+  libuuid1 \
+  libxml2 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /install/ /

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -17,6 +17,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   libcjson1 \
+  libcurl3-gnutls \
   libglib2.0-0 \
   libgnutls30 \
   libgpgme11 \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && \
   libgnutls30 \
   libgpgme11 \
   libhiredis0.14 \
-  libjson-glib-1.0-0 \
   libldap-common \
   libnet1 \
   libpaho-mqtt1.3 \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -18,18 +18,18 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   libcjson1 \
   libglib2.0-0 \
-  libgpgme11 \
   libgnutls30 \
-  libjson-glib-1.0-0 \
-  libuuid1 \
-  libssh-gcrypt-4 \
+  libgpgme11 \
   libhiredis0.14 \
-  libxml2 \
-  libpcap0.8 \
-  libnet1 \
+  libjson-glib-1.0-0 \
   libldap-common \
-  libradcli4 \
+  libnet1 \
   libpaho-mqtt1.3 \
+  libpcap0.8 \
+  libradcli4 \
+  libssh-gcrypt-4 \
+  libuuid1 \
+  libxml2 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /install/ /

--- a/.github/install-dependencies.sh
+++ b/.github/install-dependencies.sh
@@ -4,27 +4,26 @@ set -ex
 apt-get update && \
   apt-get install -y --no-install-recommends \
   build-essential \
-  curl \
   cmake \
-  pkg-config \
+  curl \
   gnupg \
+  lcov \
   libcjson-dev \
   libcurl4-openssl-dev \
-  libjson-glib-dev \
-  libglib2.0-dev \
-  libgpgme-dev \
-  libgnutls28-dev \
-  uuid-dev \
   libgcrypt-dev \
-  libssh-dev \
+  libglib2.0-dev \
+  libgnutls28-dev \
+  libgpgme-dev \
   libhiredis-dev \
-  libxml2-dev \
-  libpcap-dev \
-  libnet1-dev \
   libldap2-dev \
-  libradcli-dev \
+  libnet1-dev \
   libpaho-mqtt-dev \
-  lcov \
+  libpcap-dev \
+  libradcli-dev \
+  libssh-dev \
+  libxml2-dev \
+  pkg-config \
+  uuid-dev \
   && rm -rf /var/lib/apt/lists/*
 
 

--- a/.github/install-dependencies.sh
+++ b/.github/install-dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# This script installs openvas-smb-dependencies.
+# This script installs gvm-libs dependencies
 set -ex
 apt-get update && \
   apt-get install -y --no-install-recommends \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ Install prerequisites on Debian stable:
     apt-get install \
     cmake \
     libcjson-dev \
-    libcurl4-openssl-dev \
+    libcurl4-gnutls-dev \
     libgcrypt-dev \
     libglib2.0-dev \
     libgnutls28-dev \


### PR DESCRIPTION
## What

* Cleanup dependencies lists
* Don't install unused libjson-glib into docker images
* Install libcurl when required for openvasd (stable and testing docker images)
* Use same libcurl variant as OpenVAS Scanner (libcurl GnuTLS)

## Why

Fix and cleanup our dependencies

## References

https://forum.greenbone.net/t/openvas-scanner-and-gvm-libs-dependencies-conflict/20115


