### PR TITLE
Remove failing workflow triggers

### DIFF
--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload test coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: build/coverage/coverage.xml
+          files: build/coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -76,23 +76,3 @@ jobs:
           repository: ${{ matrix.repository }}
           workflow: container.yml
           ref: main
-
-  trigger-related-projects:
-    needs: build-push-debian-stable-container
-    if: github.event_name != 'pull_request'
-    name: Trigger update container images in related projects
-    strategy:
-      fail-fast: false
-      matrix:
-        repository:
-          - "greenbone/openvas-scanner"
-          - "greenbone/boreas"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger main ${{ matrix.repository }} container image build
-        uses: greenbone/actions/trigger-workflow@v3
-        with:
-          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-          repository: ${{ matrix.repository }}
-          workflow: ${{ matrix.repository == 'greenbone/openvas-scanner' && 'control.yml' || 'container.yml' }}
-          ref: main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       image-url: community/gvm-libs
       image-labels: |
         org.opencontainers.image.vendor=Greenbone
-        org.opencontainers.image.base.name=debian:stable-slim
+        org.opencontainers.image.base.name=debian:oldstable-slim
       base-image-label: "oldstable"
       ref-name: ${{ inputs.ref-name }}
     secrets: inherit
@@ -46,7 +46,7 @@ jobs:
       image-url: community/gvm-libs
       image-labels: |
         org.opencontainers.image.vendor=Greenbone
-        org.opencontainers.image.base.name=debian:stable-slim
+        org.opencontainers.image.base.name=debian:testing-slim
       base-image-label: "testing"
       ref-name: ${{ inputs.ref-name }}
     secrets: inherit


### PR DESCRIPTION
## What

Don't trigger boreas and openvas-scanner repos when pushing to main branch.

## Why

Both triggers are failing at the moment and the scanner team has agreed on removing the triggers for now.

## References

https://jira.greenbone.net/browse/GEA-854

