### PR TITLE
Add: gvm_json_obj_double

### DIFF
--- a/openvasd/CMakeLists.txt
+++ b/openvasd/CMakeLists.txt
@@ -48,13 +48,14 @@ endif (BUILD_SHARED)
 if (BUILD_TESTS)
   add_executable (openvasd-test
                   EXCLUDE_FROM_ALL
-                  openvasd_tests.c ../base/array.c ../base/networking.c)
+                  openvasd_tests.c)
 
   add_test (openvasd-test openvasd-test)
 
   target_include_directories (openvasd-test PRIVATE ${CGREEN_INCLUDE_DIRS})
 
-  target_link_libraries (openvasd-test ${CGREEN_LIBRARIES}
+  target_link_libraries (openvasd-test gvm_base_shared gvm_util_shared
+                         ${CGREEN_LIBRARIES}
                          ${GLIB_LDFLAGS} ${CJSON_LDFLAGS} ${CURL_LDFLAGS}
                          ${LINKER_HARDENING_FLAGS})
 

--- a/openvasd/vtparser.c
+++ b/openvasd/vtparser.c
@@ -83,13 +83,9 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
           && cJSON_IsString (item))
         nvti_set_affected (nvt, item->valuestring);
 
-      if ((item = cJSON_GetObjectItem (tag_obj, "creation_date")) != NULL
-          && cJSON_IsNumber (item))
-        nvti_set_creation_time (nvt, item->valuedouble);
+      nvti_set_creation_time (nvt, gvm_json_obj_double (tag_obj, "creation_date"));
 
-      if ((item = cJSON_GetObjectItem (tag_obj, "last_modification")) != NULL
-          && cJSON_IsNumber (item))
-        nvti_set_modification_time (nvt, item->valuedouble);
+      nvti_set_modification_time (nvt, gvm_json_obj_double (tag_obj, "last_modification"));
 
       if ((item = cJSON_GetObjectItem (tag_obj, "insight")) != NULL
           && cJSON_IsString (item))
@@ -150,7 +146,6 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
           gchar *severity_origin = NULL, *severity_type = NULL;
           gchar *cvss_base;
 
-          time_t severity_date = 0;
           double cvss_base_dbl;
 
           if (g_strrstr (severity_vector, "CVSS:3"))
@@ -160,16 +155,13 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
 
           cvss_base_dbl = get_cvss_score_from_base_metrics (severity_vector);
 
-          if ((item = cJSON_GetObjectItem (tag_obj, "severity_date")) != NULL
-              && cJSON_IsNumber (item))
-            severity_date = item->valuedouble;
-
           if ((item = cJSON_GetObjectItem (tag_obj, "severity_origin")) != NULL
               && cJSON_IsString (item))
             severity_origin = item->valuestring;
 
           nvti_add_vtseverity (
-            nvt, vtseverity_new (severity_type, severity_origin, severity_date,
+            nvt, vtseverity_new (severity_type, severity_origin,
+                                 gvm_json_obj_double (tag_obj, "severity_date"),
                                  cvss_base_dbl, severity_vector));
 
           nvti_add_tag (nvt, "cvss_base_vector", severity_vector);

--- a/util/json.c
+++ b/util/json.c
@@ -62,3 +62,23 @@ gvm_json_string_escape (const char *string, gboolean single_quote)
     }
   return g_string_free (escaped, FALSE);
 }
+
+/**
+ * @brief Get a double field from a JSON object.
+ *
+ * @param[in]  obj  Object
+ * @param[in]  key  Field name.
+ *
+ * @return A double.
+ */
+double
+gvm_json_obj_double (cJSON *obj, const gchar *key)
+{
+  cJSON *item;
+
+  item = cJSON_GetObjectItem (obj, key);
+  if (item && cJSON_IsNumber (item))
+    return item->valuedouble;
+
+  return 0;
+}

--- a/util/json.h
+++ b/util/json.h
@@ -14,4 +14,7 @@
 gchar *
 gvm_json_string_escape (const char *, gboolean);
 
+double
+gvm_json_obj_double (cJSON *, const gchar *);
+
 #endif /* _GVM_JSON_H */

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -17,6 +17,8 @@ AfterEach (json)
 {
 }
 
+/* gvm_json_string_escape */
+
 Ensure (json, can_json_escape_strings)
 {
   const char *unescaped_string = "\"'Abc\\\b\f\n\r\t\001Äöü'\"";
@@ -36,6 +38,30 @@ Ensure (json, can_json_escape_strings)
   g_free (escaped_string);
 }
 
+/* gvm_json_obj_double */
+
+Ensure (json, gvm_json_obj_double_gets_value)
+{
+  cJSON *json;
+  double d;
+
+  json = cJSON_Parse ("{ \"eg\": 2.3 }");
+  assert_that (json, is_not_null);
+  d = gvm_json_obj_double (json, "eg");
+  assert_that_double (d, is_equal_to_double(2.3));
+}
+
+Ensure (json, gvm_json_obj_double_0_when_missing)
+{
+  cJSON *json;
+  double d;
+
+  json = cJSON_Parse ("{ \"eg\": 2.3 }");
+  assert_that (json, is_not_null);
+  d = gvm_json_obj_double (json, "err");
+  assert_that_double (d, is_equal_to_double(0));
+}
+
 int
 main (int argc, char **argv)
 {
@@ -44,6 +70,9 @@ main (int argc, char **argv)
   suite = create_test_suite ();
 
   add_test_with_context (suite, json, can_json_escape_strings);
+
+  add_test_with_context (suite, json, gvm_json_obj_double_gets_value);
+  add_test_with_context (suite, json, gvm_json_obj_double_0_when_missing);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -48,7 +48,7 @@ Ensure (json, gvm_json_obj_double_gets_value)
   json = cJSON_Parse ("{ \"eg\": 2.3 }");
   assert_that (json, is_not_null);
   d = gvm_json_obj_double (json, "eg");
-  assert_that_double (d, is_equal_to_double(2.3));
+  assert_that_double (d, is_equal_to_double (2.3));
 }
 
 Ensure (json, gvm_json_obj_double_0_when_missing)
@@ -59,7 +59,7 @@ Ensure (json, gvm_json_obj_double_0_when_missing)
   json = cJSON_Parse ("{ \"eg\": 2.3 }");
   assert_that (json, is_not_null);
   d = gvm_json_obj_double (json, "err");
-  assert_that_double (d, is_equal_to_double(0));
+  assert_that_double (d, is_equal_to_double (0));
 }
 
 int


### PR DESCRIPTION
## What

Add `gvm_json_obj_double` to `json.c`, and use it in `openvasd.c` and `vtparser.c`.

## Why

This is neater than using the three line cJSON snippet.

A nice side effect is that this removes many assignments that were happening inside `if` conditions.

## References

Related: /pull/852

## Checklist

- [x] Tests


