### PR TITLE
Add: gvm_json_obj_str

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -1094,13 +1094,7 @@ parse_results (const gchar *body, GSList **results)
   cJSON *result_obj = NULL;
   const gchar *err = NULL;
   openvasd_result_t result = NULL;
-  gchar *type = NULL;
-  gchar *ip_address = NULL;
-  gchar *hostname = NULL;
-  gchar *oid = NULL;
   int port = 0;
-  gchar *protocol = NULL;
-  gchar *message = NULL;
   gchar *detail_name = NULL;
   gchar *detail_value = NULL;
   gchar *detail_source_type = NULL;
@@ -1126,33 +1120,9 @@ parse_results (const gchar *body, GSList **results)
       // error
       goto res_cleanup;
 
-    if ((item = cJSON_GetObjectItem (result_obj, "type")) != NULL
-        && cJSON_IsString (item))
-      type = g_strdup (item->valuestring);
-
-    if ((item = cJSON_GetObjectItem (result_obj, "ip_address")) != NULL
-        && cJSON_IsString (item))
-      ip_address = g_strdup (item->valuestring);
-
-    if ((item = cJSON_GetObjectItem (result_obj, "hostname")) != NULL
-        && cJSON_IsString (item))
-      hostname = g_strdup (item->valuestring);
-
-    if ((item = cJSON_GetObjectItem (result_obj, "oid")) != NULL
-        && cJSON_IsString (item))
-      oid = g_strdup (item->valuestring);
-
     if ((item = cJSON_GetObjectItem (result_obj, "port")) != NULL
         && cJSON_IsNumber (item))
       port = item->valueint;
-
-    if ((item = cJSON_GetObjectItem (result_obj, "protocol")) != NULL
-        && cJSON_IsString (item))
-      protocol = g_strdup (item->valuestring);
-
-    if ((item = cJSON_GetObjectItem (result_obj, "message")) != NULL
-        && cJSON_IsString (item))
-      message = g_strdup (item->valuestring);
 
     if ((item = cJSON_GetObjectItem (result_obj, "detail")) != NULL
         && cJSON_IsObject (item))
@@ -1188,8 +1158,14 @@ parse_results (const gchar *body, GSList **results)
       }
 
     result = openvasd_result_new (gvm_json_obj_double (result_obj, "id"),
-                                  type, ip_address, hostname, oid, port,
-                                  protocol, message, detail_name, detail_value,
+                                  gvm_json_obj_str (result_obj, "type"),
+                                  gvm_json_obj_str (result_obj, "ip_address"),
+                                  gvm_json_obj_str (result_obj, "hostname"),
+                                  gvm_json_obj_str (result_obj, "oid"),
+                                  port,
+                                  gvm_json_obj_str (result_obj, "protocol"),
+                                  gvm_json_obj_str (result_obj, "message"),
+                                  detail_name, detail_value,
                                   detail_source_type, detail_source_name,
                                   detail_source_description);
 
@@ -1811,23 +1787,11 @@ openvasd_parsed_scans_preferences (openvasd_connector_t conn, GSList **params)
 
   cJSON_ArrayForEach (param_obj, parser)
   {
-    const gchar *id = NULL, *name = NULL, *desc = NULL;
     gchar *defval = NULL, *param_type = NULL;
     openvasd_param_t *param = NULL;
     int val, mandatory = 0;
     char buf[6];
     cJSON *item = NULL;
-    if ((item = cJSON_GetObjectItem (param_obj, "id")) != NULL
-        && cJSON_IsString (item))
-      id = g_strdup (item->valuestring);
-
-    if ((item = cJSON_GetObjectItem (param_obj, "name")) != NULL
-        && cJSON_IsString (item))
-      name = g_strdup (item->valuestring);
-
-    if ((item = cJSON_GetObjectItem (param_obj, "description")) != NULL
-        && cJSON_IsString (item))
-      desc = g_strdup (item->valuestring);
 
     if ((item = cJSON_GetObjectItem (param_obj, "default")) != NULL)
       {
@@ -1861,8 +1825,11 @@ openvasd_parsed_scans_preferences (openvasd_connector_t conn, GSList **params)
       }
 
     param =
-      openvasd_param_new (g_strdup (id), g_strdup (name), g_strdup (defval),
-                          g_strdup (desc), g_strdup (param_type), mandatory);
+      openvasd_param_new (g_strdup (gvm_json_obj_str (param_obj, "id")),
+                          g_strdup (gvm_json_obj_str (param_obj, "name")),
+                          g_strdup (defval),
+                          g_strdup (gvm_json_obj_str (param_obj, "description")),
+                          g_strdup (param_type), mandatory);
     g_free (defval);
     g_free (param_type);
     *params = g_slist_append (*params, param);

--- a/openvasd/vtparser.c
+++ b/openvasd/vtparser.c
@@ -78,7 +78,9 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
 {
   if (cJSON_IsObject (tag_obj))
     {
-      cJSON *item = NULL;
+      cJSON *item;
+      gchar *severity_vector;
+
       if ((item = cJSON_GetObjectItem (tag_obj, "affected")) != NULL
           && cJSON_IsString (item))
         nvti_set_affected (nvt, item->valuestring);
@@ -128,7 +130,6 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
         nvti_set_detection (nvt, item->valuestring);
 
       // Parse severity
-      gchar *severity_vector = NULL;
 
       severity_vector = gvm_json_obj_str (tag_obj, "severity_vector");
       if (!severity_vector)
@@ -136,9 +137,7 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
 
       if (severity_vector)
         {
-          gchar *severity_type = NULL;
-          gchar *cvss_base;
-
+          gchar *severity_type, *cvss_base;
           double cvss_base_dbl;
 
           if (g_strrstr (severity_vector, "CVSS:3"))

--- a/openvasd/vtparser.c
+++ b/openvasd/vtparser.c
@@ -130,20 +130,13 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
       // Parse severity
       gchar *severity_vector = NULL;
 
-      if ((item = cJSON_GetObjectItem (tag_obj, "severity_vector")) != NULL
-          && cJSON_IsString (item))
-        severity_vector = item->valuestring;
-
+      severity_vector = gvm_json_obj_str (tag_obj, "severity_vector");
       if (!severity_vector)
-        {
-          if ((item = cJSON_GetObjectItem (tag_obj, "cvss_base_vector")) != NULL
-              && cJSON_IsString (item))
-            severity_vector = item->valuestring;
-        }
+         severity_vector = gvm_json_obj_str (tag_obj, "cvss_base_vector");
 
       if (severity_vector)
         {
-          gchar *severity_origin = NULL, *severity_type = NULL;
+          gchar *severity_type = NULL;
           gchar *cvss_base;
 
           double cvss_base_dbl;
@@ -155,12 +148,9 @@ add_tags_to_nvt (nvti_t *nvt, cJSON *tag_obj)
 
           cvss_base_dbl = get_cvss_score_from_base_metrics (severity_vector);
 
-          if ((item = cJSON_GetObjectItem (tag_obj, "severity_origin")) != NULL
-              && cJSON_IsString (item))
-            severity_origin = item->valuestring;
-
           nvti_add_vtseverity (
-            nvt, vtseverity_new (severity_type, severity_origin,
+            nvt, vtseverity_new (severity_type,
+                                 gvm_json_obj_str (tag_obj, "severity_origin"),
                                  gvm_json_obj_double (tag_obj, "severity_date"),
                                  cvss_base_dbl, severity_vector));
 

--- a/util/json.c
+++ b/util/json.c
@@ -82,3 +82,23 @@ gvm_json_obj_double (cJSON *obj, const gchar *key)
 
   return 0;
 }
+
+/**
+ * @brief Get a string field from a JSON object.
+ *
+ * @param[in]  obj  Object
+ * @param[in]  key  Field name.
+ *
+ * @return A string. Will be freed by cJSON_Delete.
+ */
+gchar *
+gvm_json_obj_str (cJSON *obj, const gchar *key)
+{
+  cJSON *item;
+
+  item = cJSON_GetObjectItem (obj, key);
+  if (item && cJSON_IsString (item))
+    return item->valuestring;
+
+  return 0;
+}

--- a/util/json.h
+++ b/util/json.h
@@ -17,4 +17,7 @@ gvm_json_string_escape (const char *, gboolean);
 double
 gvm_json_obj_double (cJSON *, const gchar *);
 
+gchar *
+gvm_json_obj_str (cJSON *, const gchar *);
+
 #endif /* _GVM_JSON_H */

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -62,6 +62,32 @@ Ensure (json, gvm_json_obj_double_0_when_missing)
   assert_that_double (d, is_equal_to_double (0));
 }
 
+/* gvm_json_obj_str */
+
+Ensure (json, gvm_json_obj_str_gets_value)
+{
+  cJSON *json;
+  const gchar *s;
+
+  json = cJSON_Parse ("{ \"eg\": \"abc\" }");
+  assert_that (json, is_not_null);
+  s = gvm_json_obj_str (json, "eg");
+  assert_that (s, is_equal_to_string ("abc"));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_str_null_when_missing)
+{
+  cJSON *json;
+  const gchar *s;
+
+  json = cJSON_Parse ("{ \"eg\": \"abc\" }");
+  assert_that (json, is_not_null);
+  s = gvm_json_obj_str (json, "err");
+  assert_that (s, is_null);
+  cJSON_Delete (json);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -73,6 +99,9 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, json, gvm_json_obj_double_gets_value);
   add_test_with_context (suite, json, gvm_json_obj_double_0_when_missing);
+
+  add_test_with_context (suite, json, gvm_json_obj_str_gets_value);
+  add_test_with_context (suite, json, gvm_json_obj_str_null_when_missing);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

Add `gvm_json_obj_str` to `json.c`, and use it in `openvasd.c` and `vtparser.c`.

## Why

This is neater than using the three line cJSON snippet.

As with `gvm_json_obj_double`, this removes many assignments that were happening inside `if` conditions.

## References

Similar to /pull/876.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


