### PR TITLE
Add: New function uri_cpe_to_uri_product

### DIFF
--- a/util/cpeutils.c
+++ b/util/cpeutils.c
@@ -130,6 +130,26 @@ uri_cpe_to_fs_product (const char *uri_cpe)
 }
 
 /**
+ * @brief Convert a URI CPE to a formatted string product.
+ *
+ * @param[in]  uri_cpe  A CPE v2.2-conformant URI.
+ *
+ * @return  A CPE v2.2-conformant URI product.
+ */
+char *
+uri_cpe_to_uri_product (const char *uri_cpe)
+{
+  cpe_struct_t cpe;
+  char *fs_cpe;
+
+  cpe_struct_init (&cpe);
+  uri_cpe_to_cpe_struct (uri_cpe, &cpe);
+  fs_cpe = cpe_struct_to_uri_product (&cpe);
+  cpe_struct_free (&cpe);
+  return (fs_cpe);
+}
+
+/**
  * @brief Convert a formatted string CPE to a URI CPE.
  *
  * @param[in]  fs_cpe  A formatted string CPE.

--- a/util/cpeutils.h
+++ b/util/cpeutils.h
@@ -41,6 +41,9 @@ char *
 uri_cpe_to_fs_product (const char *);
 
 char *
+uri_cpe_to_uri_product (const char *);
+
+char *
 fs_cpe_to_uri_cpe (const char *);
 
 char *

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -281,6 +281,18 @@ Ensure (cpeutils, cpe_struct_match)
   cpe_struct_free (&cpe2);
 }
 
+Ensure (cpeutils, uri_cpe_to_uri_product)
+{
+  const char *uri_cpe;
+  gchar *uri_product;
+
+  uri_cpe = "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win2003~x64~";
+
+  uri_product = uri_cpe_to_uri_product (uri_cpe);
+  assert_string_equal (uri_product, "cpe:/a:hp:insight_diagnostics");
+  g_free (uri_product);
+}
+
 /* Test suite. */
 int
 main (int argc, char **argv)
@@ -296,6 +308,7 @@ main (int argc, char **argv)
   add_test_with_context (suite, cpeutils, uri_cpe_to_fs_cpe);
   add_test_with_context (suite, cpeutils, fs_cpe_to_uri_cpe);
   add_test_with_context (suite, cpeutils, cpe_struct_match);
+  add_test_with_context (suite, cpeutils, uri_cpe_to_uri_product);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What
The new function uri_cpe_to_uri_product is added to the CPE utilities.

## Why
This is needed for the new CVE scanner in gvmd.

## References
GEA-885

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


