### PR TITLE
Add: gvm_json_obj_int

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -1094,7 +1094,6 @@ parse_results (const gchar *body, GSList **results)
   cJSON *result_obj = NULL;
   const gchar *err = NULL;
   openvasd_result_t result = NULL;
-  int port = 0;
   gchar *detail_name = NULL;
   gchar *detail_value = NULL;
   gchar *detail_source_type = NULL;
@@ -1119,10 +1118,6 @@ parse_results (const gchar *body, GSList **results)
     if (!cJSON_IsObject (result_obj))
       // error
       goto res_cleanup;
-
-    if ((item = cJSON_GetObjectItem (result_obj, "port")) != NULL
-        && cJSON_IsNumber (item))
-      port = item->valueint;
 
     if ((item = cJSON_GetObjectItem (result_obj, "detail")) != NULL
         && cJSON_IsObject (item))
@@ -1162,7 +1157,7 @@ parse_results (const gchar *body, GSList **results)
                                   gvm_json_obj_str (result_obj, "ip_address"),
                                   gvm_json_obj_str (result_obj, "hostname"),
                                   gvm_json_obj_str (result_obj, "oid"),
-                                  port,
+                                  gvm_json_obj_int (result_obj, "port"),
                                   gvm_json_obj_str (result_obj, "protocol"),
                                   gvm_json_obj_str (result_obj, "message"),
                                   detail_name, detail_value,

--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -1257,12 +1257,12 @@ openvasd_get_scan_status (openvasd_connector_t conn)
 static int
 get_member_value_or_fail (cJSON *reader, const gchar *member)
 {
-  cJSON *item = NULL;
-  if ((item = cJSON_GetObjectItem (reader, member)) == NULL
-      && cJSON_IsNumber (item))
+  int ret;
+
+  if (gvm_json_obj_check_int (reader, member, &ret))
     return -1;
 
-  return item->valueint;
+  return ret;
 }
 
 static int

--- a/openvasd/vtparser.c
+++ b/openvasd/vtparser.c
@@ -246,13 +246,11 @@ add_preferences_to_nvt (nvti_t *nvt, cJSON *vt_obj)
               }
             class = prefs_item->valuestring;
 
-            if ((prefs_item = cJSON_GetObjectItem (prefs_obj, "id")) == NULL
-                || !cJSON_IsNumber (prefs_item))
+            if (gvm_json_obj_check_int (prefs_obj, "id", &id))
               {
                 g_warning ("%s: PREF missing id attribute", __func__);
                 continue;
               }
-            id = prefs_item->valueint;
 
             if ((prefs_item = cJSON_GetObjectItem (prefs_obj, "name")) == NULL
                 || !cJSON_IsString (prefs_item))

--- a/util/json.c
+++ b/util/json.c
@@ -88,7 +88,8 @@ gvm_json_obj_double (cJSON *obj, const gchar *key)
  *
  * @param[in]  obj  Object
  * @param[in]  key  Field name.
- * @param[out] val  Return location for int if int exists.
+ * @param[out] val  Either NULL or a return location for the int (only set if
+ *                  int field exists).
  *
  * @return 0 if such an int field exists, else 1.
  */

--- a/util/json.c
+++ b/util/json.c
@@ -84,6 +84,26 @@ gvm_json_obj_double (cJSON *obj, const gchar *key)
 }
 
 /**
+ * @brief Get an int field from a JSON object.
+ *
+ * @param[in]  obj  Object
+ * @param[in]  key  Field name.
+ *
+ * @return An int.
+ */
+int
+gvm_json_obj_int (cJSON *obj, const gchar *key)
+{
+  cJSON *item;
+
+  item = cJSON_GetObjectItem (obj, key);
+  if (item && cJSON_IsNumber (item))
+    return item->valueint;
+
+  return 0;
+}
+
+/**
  * @brief Get a string field from a JSON object.
  *
  * @param[in]  obj  Object

--- a/util/json.c
+++ b/util/json.c
@@ -98,11 +98,12 @@ gvm_json_obj_check_int (cJSON *obj, const gchar *key, int *val)
   cJSON *item;
 
   item = cJSON_GetObjectItem (obj, key);
-  if (item && cJSON_IsNumber (item)) {
-    if (val)
-      *val = item->valueint;
-    return 0;
-  }
+  if (item && cJSON_IsNumber (item))
+    {
+      if (val)
+        *val = item->valueint;
+      return 0;
+    }
   return 1;
 }
 

--- a/util/json.c
+++ b/util/json.c
@@ -88,6 +88,29 @@ gvm_json_obj_double (cJSON *obj, const gchar *key)
  *
  * @param[in]  obj  Object
  * @param[in]  key  Field name.
+ * @param[out] val  Return location for int if int exists.
+ *
+ * @return 0 if such an int field exists, else 1.
+ */
+int
+gvm_json_obj_check_int (cJSON *obj, const gchar *key, int *val)
+{
+  cJSON *item;
+
+  item = cJSON_GetObjectItem (obj, key);
+  if (item && cJSON_IsNumber (item)) {
+    if (val)
+      *val = item->valueint;
+    return 0;
+  }
+  return 1;
+}
+
+/**
+ * @brief Get an int field from a JSON object.
+ *
+ * @param[in]  obj  Object
+ * @param[in]  key  Field name.
  *
  * @return An int.
  */

--- a/util/json.h
+++ b/util/json.h
@@ -17,6 +17,9 @@ gvm_json_string_escape (const char *, gboolean);
 double
 gvm_json_obj_double (cJSON *, const gchar *);
 
+int
+gvm_json_obj_int (cJSON *, const gchar *);
+
 gchar *
 gvm_json_obj_str (cJSON *, const gchar *);
 

--- a/util/json.h
+++ b/util/json.h
@@ -18,6 +18,9 @@ double
 gvm_json_obj_double (cJSON *, const gchar *);
 
 int
+gvm_json_obj_check_int (cJSON *, const gchar *, int *);
+
+int
 gvm_json_obj_int (cJSON *, const gchar *);
 
 gchar *

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -88,6 +88,44 @@ Ensure (json, gvm_json_obj_str_null_when_missing)
   cJSON_Delete (json);
 }
 
+/* gvm_json_obj_int */
+
+Ensure (json, gvm_json_obj_int_gets_value)
+{
+  cJSON *json;
+  int i;
+
+  json = cJSON_Parse ("{ \"eg\": 33 }");
+  assert_that (json, is_not_null);
+  i = gvm_json_obj_int (json, "eg");
+  assert_that (i, is_equal_to (33));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_int_0_when_missing)
+{
+  cJSON *json;
+  int i;
+
+  json = cJSON_Parse ("{ \"eg\": 33 }");
+  assert_that (json, is_not_null);
+  i = gvm_json_obj_int (json, "err");
+  assert_that (i, is_equal_to (0));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_int_0_when_str)
+{
+  cJSON *json;
+  int i;
+
+  json = cJSON_Parse ("{ \"eg\": \"abc\" }");
+  assert_that (json, is_not_null);
+  i = gvm_json_obj_int (json, "eg");
+  assert_that (i, is_equal_to (0));
+  cJSON_Delete (json);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -102,6 +140,10 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, json, gvm_json_obj_str_gets_value);
   add_test_with_context (suite, json, gvm_json_obj_str_null_when_missing);
+
+  add_test_with_context (suite, json, gvm_json_obj_int_gets_value);
+  add_test_with_context (suite, json, gvm_json_obj_int_0_when_missing);
+  add_test_with_context (suite, json, gvm_json_obj_int_0_when_str);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -126,6 +126,50 @@ Ensure (json, gvm_json_obj_int_0_when_str)
   cJSON_Delete (json);
 }
 
+/* gvm_json_obj_check_int */
+
+Ensure (json, gvm_json_obj_check_int_0_when_has)
+{
+  cJSON *json;
+
+  json = cJSON_Parse ("{ \"eg\": 33 }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_int (json, "eg", NULL), is_equal_to (0));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_check_int_1_when_missing)
+{
+  cJSON *json;
+
+  json = cJSON_Parse ("{ \"eg\": 33 }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_int (json, "err", NULL), is_equal_to (1));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_check_int_1_when_str)
+{
+  cJSON *json;
+
+  json = cJSON_Parse ("{ \"eg\": \"33\" }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_int (json, "eg", NULL), is_equal_to (1));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_check_int_0_and_val_when_has)
+{
+  cJSON *json;
+  int ret;
+
+  json = cJSON_Parse ("{ \"eg\": 33 }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_int (json, "eg", &ret), is_equal_to (0));
+  assert_that (ret, is_equal_to (33));
+  cJSON_Delete (json);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -144,6 +188,11 @@ main (int argc, char **argv)
   add_test_with_context (suite, json, gvm_json_obj_int_gets_value);
   add_test_with_context (suite, json, gvm_json_obj_int_0_when_missing);
   add_test_with_context (suite, json, gvm_json_obj_int_0_when_str);
+
+  add_test_with_context (suite, json, gvm_json_obj_check_int_0_when_has);
+  add_test_with_context (suite, json, gvm_json_obj_check_int_1_when_missing);
+  add_test_with_context (suite, json, gvm_json_obj_check_int_1_when_str);
+  add_test_with_context (suite, json, gvm_json_obj_check_int_0_and_val_when_has);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -192,7 +192,8 @@ main (int argc, char **argv)
   add_test_with_context (suite, json, gvm_json_obj_check_int_0_when_has);
   add_test_with_context (suite, json, gvm_json_obj_check_int_1_when_missing);
   add_test_with_context (suite, json, gvm_json_obj_check_int_1_when_str);
-  add_test_with_context (suite, json, gvm_json_obj_check_int_0_and_val_when_has);
+  add_test_with_context (suite, json,
+                         gvm_json_obj_check_int_0_and_val_when_has);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

Add `gvm_json_obj_int` to `json.c`, and use it in `openvasd.c`.

Also add `gvm_json_obj_check_int`, and use it in `openvasd.c` and `vtparser.c`. This variant allows you to know if the int field was present, and to get the int at the same time.

## Why

These are neater than using the cJSON snippets. They're similar to `gvm_json_obj_str`.

As with `gvm_json_obj_double`, this removes assignments that were happening inside `if` conditions.

`gvm_json_obj_check_int` is only used twice but there will be a `gvm_json_obj_check_str` that is used more.

It's handy to have both the regular version and the `check` version because the regular version saves having to create a variable, but in some cases we need to know if the field exists before using it.

## References

Similar to /pull/876 and /pull/877.

## Checklist

- [x] Tests


