### PR TITLE
Add: gvm_json_obj_check_str

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -1383,7 +1383,6 @@ static int
 parse_status (const gchar *body, openvasd_scan_status_t status_info)
 {
   cJSON *parser = NULL;
-  cJSON *status = NULL;
   gchar *status_val = NULL;
   openvasd_status_t status_code = OPENVASD_SCAN_STATUS_ERROR;
 
@@ -1393,16 +1392,13 @@ parse_status (const gchar *body, openvasd_scan_status_t status_info)
   if ((parser = cJSON_Parse (body)) == NULL)
     return -1;
 
-  if ((status = cJSON_GetObjectItem (parser, "status")) == NULL
-      || !cJSON_IsString (status))
+  if (gvm_json_obj_check_str (parser, "status", &status_val))
     {
       cJSON_Delete (parser);
       return -1;
     }
 
-  status_val = g_strdup (status->valuestring);
   status_code = get_status_code_from_openvas (status_val);
-  g_free (status_val);
 
   status_info->status = status_code;
   status_info->end_time = gvm_json_obj_double (parser, "end_time");

--- a/util/json.c
+++ b/util/json.c
@@ -133,6 +133,31 @@ gvm_json_obj_int (cJSON *obj, const gchar *key)
  *
  * @param[in]  obj  Object
  * @param[in]  key  Field name.
+ * @param[out] val  Either NULL or a return location for the string (only set
+ *                  if string field exists). Freed by cJSON_Delete.
+ *
+ * @return 0 if such a field exists, else 1.
+ */
+int
+gvm_json_obj_check_str (cJSON *obj, const gchar *key, gchar **val)
+{
+  cJSON *item;
+
+  item = cJSON_GetObjectItem (obj, key);
+  if (item && cJSON_IsString (item))
+    {
+      if (val)
+        *val = item->valuestring;
+      return 0;
+    }
+  return 1;
+}
+
+/**
+ * @brief Get a string field from a JSON object.
+ *
+ * @param[in]  obj  Object
+ * @param[in]  key  Field name.
  *
  * @return A string. Will be freed by cJSON_Delete.
  */

--- a/util/json.h
+++ b/util/json.h
@@ -23,6 +23,9 @@ gvm_json_obj_check_int (cJSON *, const gchar *, int *);
 int
 gvm_json_obj_int (cJSON *, const gchar *);
 
+int
+gvm_json_obj_check_str (cJSON *, const gchar *, gchar **);
+
 gchar *
 gvm_json_obj_str (cJSON *, const gchar *);
 

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -62,6 +62,50 @@ Ensure (json, gvm_json_obj_double_0_when_missing)
   assert_that_double (d, is_equal_to_double (0));
 }
 
+/* gvm_json_obj_check_str */
+
+Ensure (json, gvm_json_obj_check_str_0_when_has)
+{
+  cJSON *json;
+
+  json = cJSON_Parse ("{ \"eg\": \"abc\" }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_str (json, "eg", NULL), is_equal_to (0));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_check_str_1_when_missing)
+{
+  cJSON *json;
+
+  json = cJSON_Parse ("{ \"eg\": \"abc\" }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_str (json, "err", NULL), is_equal_to (1));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_check_str_1_when_int)
+{
+  cJSON *json;
+
+  json = cJSON_Parse ("{ \"eg\": 29 }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_str (json, "eg", NULL), is_equal_to (1));
+  cJSON_Delete (json);
+}
+
+Ensure (json, gvm_json_obj_check_str_0_and_val_when_has)
+{
+  cJSON *json;
+  gchar *ret;
+
+  json = cJSON_Parse ("{ \"eg\": \"abc\" }");
+  assert_that (json, is_not_null);
+  assert_that (gvm_json_obj_check_str (json, "eg", &ret), is_equal_to (0));
+  assert_that (ret, is_equal_to_string ("abc"));
+  cJSON_Delete (json);
+}
+
 /* gvm_json_obj_str */
 
 Ensure (json, gvm_json_obj_str_gets_value)
@@ -194,6 +238,12 @@ main (int argc, char **argv)
   add_test_with_context (suite, json, gvm_json_obj_check_int_1_when_str);
   add_test_with_context (suite, json,
                          gvm_json_obj_check_int_0_and_val_when_has);
+
+  add_test_with_context (suite, json, gvm_json_obj_check_str_0_when_has);
+  add_test_with_context (suite, json, gvm_json_obj_check_str_1_when_missing);
+  add_test_with_context (suite, json, gvm_json_obj_check_str_1_when_int);
+  add_test_with_context (suite, json,
+                         gvm_json_obj_check_str_0_and_val_when_has);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

Add function `gvm_json_obj_check_str` and use it in `vtparser.c` and `openvasd.c`.

This is a variation on `gvm_json_obj_str` that allows you to retrieve the string field and at the same time get a return value that indicates if the field existed.

## Why

Neater than using the repeated cJSON snippets.

As with the similar PRs, this has the nice side effect of removing assignments from `if` conditions.

Note that the function returns 0 if the field exists, and an error value otherwise. Currently the error is always 1, but this style allows us to add more detail to the error value in future, eg if someone wants to know if the field existed but was the wrong type it could return 2.

## References

Similar to /pull/881 for ints.
Follows `gvm_json_obj_str` from /pull/877.

## Checklist

- [x] Tests


