### PR TITLE
Change: move assignments out of if conditions (util)

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -251,7 +251,8 @@ parse_port_of_addr (const char *addr, int tcp_indicator_len)
 {
   char *tmp;
   int is_ip_v6;
-  if ((tmp = rindex (addr + tcp_indicator_len, ':')) == NULL)
+  tmp = rindex (addr + tcp_indicator_len, ':');
+  if (tmp == NULL)
     return NULL;
   is_ip_v6 = addr[tcp_indicator_len] == '[';
   if (is_ip_v6 && (tmp - 1)[0] != ']')
@@ -276,7 +277,8 @@ connect_redis (const char *addr, int len)
   if (memcmp (addr, tcp_indicator, tcp_indicator_len) != 0)
     goto unix_connect;
   host_len = len - tcp_indicator_len;
-  if ((tmp = parse_port_of_addr (addr, tcp_indicator_len)) == NULL)
+  tmp = parse_port_of_addr (addr, tcp_indicator_len);
+  if (tmp == NULL)
     port = redis_default_port;
   else
     {
@@ -475,7 +477,8 @@ redis_new (kb_t *kb, const char *kb_path)
   kbr->kb.kb_ops = &KBRedisOperations;
   kbr->path = g_strdup (kb_path);
 
-  if ((rc = get_redis_ctx (kbr)) < 0)
+  rc = get_redis_ctx (kbr);
+  if (rc < 0)
     {
       redis_delete ((kb_t) kbr);
       return rc;

--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -474,8 +474,8 @@ mqtt_client_publish (mqtt_t *mqtt, const char *topic, const char *msg)
       return -2;
     }
 
-  if ((rc = MQTTClient_waitForCompletion (client, token, TIMEOUT))
-      != MQTTCLIENT_SUCCESS)
+  rc = MQTTClient_waitForCompletion (client, token, TIMEOUT);
+  if (rc != MQTTCLIENT_SUCCESS)
     {
       g_debug ("Message '%s' with delivery token %d could not be "
                "published on topic %s",
@@ -759,7 +759,8 @@ mqtt_retrieve_message_r (mqtt_t *mqtt, char **topic, int *topic_len,
                    (char *) message->payload, message->payloadlen, tmp,
                    *topic_len);
 
-          if ((*topic = calloc (1, *topic_len)) == NULL)
+          *topic = calloc (1, *topic_len);
+          if (*topic == NULL)
             {
               goto exit;
             }

--- a/util/radiusutils.c
+++ b/util/radiusutils.c
@@ -118,7 +118,8 @@ radius_init (const char *hostname, const char *secret)
     }
   unlink (config_filename);
 #else  // defined(RADIUS_AUTH_RADCLI)
-  if ((rh = rc_new ()) == NULL)
+  rh = rc_new ();
+  if (rh == NULL)
     {
       g_warning ("radius_init: Couldn't allocate memory");
       return NULL;

--- a/util/serverutils.c
+++ b/util/serverutils.c
@@ -1038,8 +1038,10 @@ server_new_gnutls_set (unsigned int end_type, const char *priority,
      is chosen.
   */
 
-  if ((err_gnutls = gnutls_priority_set_direct (
-         *server_session, priority ? priority : "NORMAL", NULL)))
+  err_gnutls = gnutls_priority_set_direct (*server_session,
+                                           priority ? priority : "NORMAL",
+                                           NULL);
+  if (err_gnutls)
     {
       g_warning ("%s: failed to set tls priorities: %s\n", __func__,
                  gnutls_strerror (err_gnutls));

--- a/util/serverutils.c
+++ b/util/serverutils.c
@@ -1022,7 +1022,7 @@ server_new_gnutls_set (unsigned int end_type, const char *priority,
                        gnutls_session_t *server_session,
                        gnutls_certificate_credentials_t *server_credentials)
 {
-  int err_gnutls;
+  int err;
 
   if (gnutls_init (server_session, end_type))
     {
@@ -1038,13 +1038,13 @@ server_new_gnutls_set (unsigned int end_type, const char *priority,
      is chosen.
   */
 
-  err_gnutls = gnutls_priority_set_direct (*server_session,
-                                           priority ? priority : "NORMAL",
-                                           NULL);
-  if (err_gnutls)
+  err = gnutls_priority_set_direct (*server_session,
+                                    priority ? priority : "NORMAL",
+                                    NULL);
+  if (err)
     {
       g_warning ("%s: failed to set tls priorities: %s\n", __func__,
-                 gnutls_strerror (err_gnutls));
+                 gnutls_strerror (err));
       gnutls_deinit (*server_session);
       return -1;
     }

--- a/util/serverutils.c
+++ b/util/serverutils.c
@@ -1039,8 +1039,7 @@ server_new_gnutls_set (unsigned int end_type, const char *priority,
   */
 
   err = gnutls_priority_set_direct (*server_session,
-                                    priority ? priority : "NORMAL",
-                                    NULL);
+                                    priority ? priority : "NORMAL", NULL);
   if (err)
     {
       g_warning ("%s: failed to set tls priorities: %s\n", __func__,

--- a/util/versionutils.c
+++ b/util/versionutils.c
@@ -78,9 +78,11 @@ cmp_versions (const char *version1, const char *version2)
       return (0);
     }
 
-  if ((release_state1 = get_release_state (ver1, index1)))
+  release_state1 = get_release_state (ver1, index1);
+  if (release_state1)
     index1++;
-  if ((release_state2 = get_release_state (ver2, index2)))
+  release_state2 = get_release_state (ver2, index2);
+  if (release_state2)
     index2++;
 
   part1 = get_part (ver1, index1);


### PR DESCRIPTION
## What

Move assignment statements out of `if` conditions where possible. So
```
if ((a = b))...
```
becomes
```
a = b
if (a)...
```

## Why

Putting the `=` in the condition is error prone because it's easy to read the `=` as `==`.

Having the `=` in the condition is also harder to read because an extra pair of parens is required around the `=` statement.

## References

Follow on to /pull/890.


