### PR TITLE
Always free the MQTTResponse

### DIFF
--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -354,6 +354,7 @@ mqtt_connect (mqtt_t *mqtt, const char *server_uri, const char *username,
 
   mqtt_set_client (mqtt, client);
 
+  MQTTResponse_free (resp);
   return 0;
 }
 
@@ -489,6 +490,7 @@ mqtt_client_publish (mqtt_t *mqtt, const char *topic, const char *msg)
                msg, token, topic);
     }
 
+  MQTTResponse_free (resp);
   return rc;
 }
 
@@ -640,8 +642,10 @@ mqtt_subscribe_r (mqtt_t *mqtt, int qos, const char *topic)
     MQTTClient_subscribe5 (mqtt->client, topic, qos, &opts, &props);
   if (resp.reasonCode != MQTTREASONCODE_GRANTED_QOS_1)
     {
+      MQTTResponse_free (resp);
       return -2;
     }
+  MQTTResponse_free (resp);
   return 0;
 }
 


### PR DESCRIPTION
 ## What

In the MQTT library, also free the `MQTTResponse` on success.

Previously we were only freeing on error.

## Why

Freeing the response only on error is probably OK given the way we're using the API, but we might as well always free the response to be safe.

The documentation gives very little clue about precisely when to use `MQTTResponse_free`.

I see some `malloc`s of properties in the `WAIT_FOR_CONNACK` case in `MQTTClient_connectURIVersion`, which might indicate that on success there is memory to be freed, at least for `MQTTClient_connect5`.
