### PR TITLE
Add: first test of mqtt.c

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -164,6 +164,9 @@ if (BUILD_TESTS)
                  ${GCRYPT_LDFLAGS} ${LDAP_LDFLAGS} ${REDIS_LDFLAGS}
                  ${LIBXML2_LDFLAGS} ${UUID_LDFLAGS}
                  ${LINKER_HARDENING_FLAGS})
+  add_unit_test (mqtt-test mqtt_tests.c gvm_util_shared gvm_base_shared
+                 ${GLIB_LDFLAGS} ${LIBPAHO_LDFLAGS} ${UUID_LDFLAGS}
+                 ${LINKER_HARDENING_FLAGS})
   add_unit_test (versionutils-test versionutils_tests.c
                  ${GLIB_LDFLAGS} ${GIO_LDFLAGS} ${GPGME_LDFLAGS} ${ZLIB_LDFLAGS}
                  ${RADIUS_LDFLAGS} ${LIBSSH_LDFLAGS} ${GNUTLS_LDFLAGS}

--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -185,19 +185,10 @@ mqtt_disconnect (mqtt_t *mqtt)
 static void
 mqtt_client_destroy (mqtt_t *mqtt)
 {
-  if (mqtt == NULL)
-    return;
-
-  MQTTClient client;
-  client = (MQTTClient) mqtt->client;
-
-  if (client != NULL)
-    {
-      MQTTClient_destroy (&client);
-      client = NULL;
-    }
-
-  return;
+  if (mqtt && mqtt->client) {
+    MQTTClient_destroy (&mqtt->client);
+    mqtt->client = NULL;
+  }
 }
 
 /**

--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -52,7 +52,7 @@ static gboolean mqtt_initialized = FALSE;
 /**
  * @brief Set the global init status.
 
- * @param status Status of initialization.
+ * @param status  Status of initialization.
  */
 static void
 mqtt_set_initialized_status (gboolean status)
@@ -74,7 +74,7 @@ mqtt_is_initialized ()
 /**
  * @brief Set the global mqtt server URI.
 
- * @param server_uri_in Server uri to set.
+ * @param server_uri_in  Server uri to set.
  */
 static void
 mqtt_set_global_server_uri (const char *server_uri_in)
@@ -96,7 +96,7 @@ mqtt_get_global_server_uri ()
 /**
  * @brief Set the global mqtt username.
 
- * @param username to set.
+ * @param username  to set.
  */
 static void
 mqtt_set_global_username (const char *username)
@@ -116,7 +116,7 @@ mqtt_get_global_username ()
 /**
  * @brief Set the global mqtt password.
 
- * @param password to set.
+ * @param password  to set.
  */
 static void
 mqtt_set_global_password (const char *password)
@@ -179,7 +179,7 @@ mqtt_disconnect (mqtt_t *mqtt)
 /**
  * @brief Destroy the MQTTClient client of the mqtt_t
  *
- * @param[in] mqtt mqtt_t handle.
+ * @param[in] mqtt  mqtt_t handle.
  *
  */
 static void
@@ -237,8 +237,8 @@ mqtt_reset ()
 /**
  * @brief Create a new mqtt client.
  *
- * @param mqtt  mqtt_t
- * @param address address of the broker
+ * @param mqtt     mqtt_t
+ * @param address  Address of the broker
  *
  * @return MQTTClient or NULL on error.
  */
@@ -269,7 +269,7 @@ mqtt_create (mqtt_t *mqtt, const char *address)
 /**
  * @brief Set a random client ID.
  *
- * @param mqtt mqtt_t
+ * @param mqtt  mqtt_t
  *
  * @return Client ID which was set, NULL on failure.
  */
@@ -446,9 +446,9 @@ mqtt_reinit ()
 /**
  * @brief Use the provided client to publish message on a topic
  *
- * @param mqtt  mqtt_t
- * @param topic Topic to publish on.
- * @param msg   Message to publish on queue.
+ * @param mqtt   mqtt_t
+ * @param topic  Topic to publish on.
+ * @param msg    Message to publish on queue.
  *
  * @return 0 on success, <0 on failure.
  */
@@ -495,8 +495,8 @@ mqtt_client_publish (mqtt_t *mqtt, const char *topic, const char *msg)
 /**
  * @brief Publish a message on topic using the global client
  *
- * @param topic topic
- * @param msg   message
+ * @param topic  topic
+ * @param msg    message
  *
  * @return 0 on success, <0 on error.
  */
@@ -523,9 +523,9 @@ mqtt_publish (const char *topic, const char *msg)
  * This function should not be chosen for repeated and frequent messaging. Its
  * meant for error messages and the likes emitted by openvas.
  *
- * @param server_uri_in Server URI
- * @param topic         Topic to publish to
- * @param msg           Message to publish
+ * @param server_uri_in  Server URI
+ * @param topic          Topic to publish to
+ * @param msg            Message to publish
  *
  * @return 0 on success, <0 on failure.
  */
@@ -544,11 +544,11 @@ mqtt_publish_single_message (const char *server_uri_in, const char *topic,
  * This function should not be chosen for repeated and frequent messaging. Its
  * meant for error messages and the likes emitted by openvas.
  *
- * @param server_uri_in Server URI
- * @param username_in   Username
- * @param passwd_in     Password
- * @param topic         Topic to publish to
- * @param msg           Message to publish
+ * @param server_uri_in  Server URI
+ * @param username_in    Username
+ * @param passwd_in      Password
+ * @param topic          Topic to publish to
+ * @param msg            Message to publish
  *
  * @return 0 on success, <0 on failure.
  */
@@ -620,8 +620,8 @@ mqtt_publish_single_message_auth (const char *server_uri_in,
  * To be able to subscribe to a topic the client needs to be connected to a
  * broker.
  *
- * @param mqtt   contains the mqtt client
- * @param qos    quality of service of messages within topic
+ * @param mqtt   Contains the mqtt client
+ * @param qos    Quality of service of messages within topic
  * @param topic  Topic to subscribe to
  *
  * @return 0 on success, -1 when given mqtt is not useable, -2 when subscription
@@ -655,7 +655,7 @@ mqtt_subscribe_r (mqtt_t *mqtt, int qos, const char *topic)
  * broker. To do that call `mqtt_init` before `mqtt_subscribe`.
  *
  *
- * @param topic         Topic to subscribe to
+ * @param topic  Topic to subscribe to
  *
  * @return 0 on success, -1 when mqtt is not initialized, -2 when subscription
  * failed.
@@ -673,7 +673,7 @@ mqtt_subscribe (const char *topic)
  *
  * This function unsubscribes given client from a given topic.
  *
- * @param mqtt   contains the mqtt client
+ * @param mqtt   Contains the mqtt client
  * @param topic  Topic to unsubscribe from
  *
  * @return 0 on success, -1 when given mqtt is not useable, -2 when unsubscribe
@@ -700,7 +700,7 @@ mqtt_unsubscribe_r (mqtt_t *mqtt, const char *topic)
  *
  * This function unsubscribes global client from a given topic.
  *
- * @param topic         Topic to unsubscribe from
+ * @param topic  Topic to unsubscribe from
  *
  * @return 0 on success, -1 when given mqtt is not useable, -2 when unsubscribe
  * failed.
@@ -722,17 +722,20 @@ mqtt_unsubscribe (const char *topic)
  *
  * <b>Important note:</b> The application must free() the memory allocated
  * to the topic and payload when processing is complete.
- * @param mqtt an already created and connected mqtt client.
- * @param[out] topic The address of a pointer to a topic. This function
- * allocates the memory for the topic and returns it to the application
- * by setting <i>topic</i> to point to the topic.
- * @param[out] topic_len The length of the topic.
- * @param[out] payload The address of a pointer to the received message. This
- * function allocates the memory for the payload and returns it to the
- * application by setting <i>payload</i> to point to the received message.
- * The pointer is set to NULL if the timeout expires.
- * @param[out] payload_len The length of the payload.
- * @param timeout The length of time to wait for a message in milliseconds.
+ *
+ * @param      mqtt   An already created and connected mqtt client.
+ * @param[out] topic  The address of a pointer to a topic. This function
+ *                    allocates the memory for the topic and returns it to the
+ *                    application by setting <i>topic</i> to point to the topic.
+ * @param[out] topic_len  The length of the topic.
+ * @param[out] payload    The address of a pointer to the received message. This
+ *                        function allocates the memory for the payload and returns
+ *                        it to the application by setting <i>payload</i> to point
+ *                        to the received message.
+ *                        The pointer is set to NULL if the timeout expires.
+ * @param[out] payload_len  The length of the payload.
+ * @param      timeout      The length of time to wait for a message in milliseconds.
+ *
  * @return 0 on message retrieved, 1 on no message retrieved and -1 on an error.
  */
 static int
@@ -816,16 +819,19 @@ exit:
  *
  * <b>Important note:</b> The application must free() the memory allocated
  * to the topic and payload when processing is complete.
- * @param[out] topic The address of a pointer to a topic. This function
- * allocates the memory for the topic and returns it to the application
- * by setting <i>topic</i> to point to the topic.
- * @param[out] topic_len The length of the topic.
- * @param[out] payload The address of a pointer to the received message. This
- * function allocates the memory for the payload and returns it to the
- * application by setting <i>payload</i> to point to the received message.
- * The pointer is set to NULL if the timeout expires.
- * @param[out] payload_len The length of the payload.
- * @param timeout The length of time to wait for a message in milliseconds.
+ *
+ * @param[out] topic   The address of a pointer to a topic. This function
+ *                     allocates the memory for the topic and returns it to the
+ *                     application by setting <i>topic</i> to point to the topic.
+ * @param[out] topic_len  The length of the topic.
+ * @param[out] payload    The address of a pointer to the received message. This
+ *                        function allocates the memory for the payload and returns
+ *                        it to the application by setting <i>payload</i> to point
+ *                        to the received message.
+ *                        The pointer is set to NULL if the timeout expires.
+ * @param[out] payload_len  The length of the payload.
+ * @param      timeout      The length of time to wait for a message in milliseconds.
+ *
  * @return 0 on message retrieved, 1 on timeout and -1 on an error.
  */
 int

--- a/util/mqtt.c
+++ b/util/mqtt.c
@@ -185,10 +185,11 @@ mqtt_disconnect (mqtt_t *mqtt)
 static void
 mqtt_client_destroy (mqtt_t *mqtt)
 {
-  if (mqtt && mqtt->client) {
-    MQTTClient_destroy (&mqtt->client);
-    mqtt->client = NULL;
-  }
+  if (mqtt && mqtt->client)
+    {
+      MQTTClient_destroy (&mqtt->client);
+      mqtt->client = NULL;
+    }
 }
 
 /**
@@ -720,12 +721,13 @@ mqtt_unsubscribe (const char *topic)
  *                    application by setting <i>topic</i> to point to the topic.
  * @param[out] topic_len  The length of the topic.
  * @param[out] payload    The address of a pointer to the received message. This
- *                        function allocates the memory for the payload and returns
- *                        it to the application by setting <i>payload</i> to point
- *                        to the received message.
+ *                        function allocates the memory for the payload and
+ *                        returns it to the application by setting
+ *                        <i>payload</i> to point to the received message.
  *                        The pointer is set to NULL if the timeout expires.
  * @param[out] payload_len  The length of the payload.
- * @param      timeout      The length of time to wait for a message in milliseconds.
+ * @param      timeout      The length of time to wait for a message in
+ *                          milliseconds.
  *
  * @return 0 on message retrieved, 1 on no message retrieved and -1 on an error.
  */
@@ -811,17 +813,18 @@ exit:
  * <b>Important note:</b> The application must free() the memory allocated
  * to the topic and payload when processing is complete.
  *
- * @param[out] topic   The address of a pointer to a topic. This function
- *                     allocates the memory for the topic and returns it to the
- *                     application by setting <i>topic</i> to point to the topic.
+ * @param[out] topic  The address of a pointer to a topic. This function
+ *                    allocates the memory for the topic and returns it to the
+ *                    application by setting <i>topic</i> to point to the topic.
  * @param[out] topic_len  The length of the topic.
  * @param[out] payload    The address of a pointer to the received message. This
- *                        function allocates the memory for the payload and returns
- *                        it to the application by setting <i>payload</i> to point
- *                        to the received message.
+ *                        function allocates the memory for the payload and
+ *                        returns it to the application by setting
+ *                        <i>payload</i> to point to the received message.
  *                        The pointer is set to NULL if the timeout expires.
  * @param[out] payload_len  The length of the payload.
- * @param      timeout      The length of time to wait for a message in milliseconds.
+ * @param      timeout      The length of time to wait for a message in
+ *                          milliseconds.
  *
  * @return 0 on message retrieved, 1 on timeout and -1 on an error.
  */

--- a/util/mqtt_tests.c
+++ b/util/mqtt_tests.c
@@ -1,0 +1,63 @@
+/* SPDX-FileCopyrightText: 2019-2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "mqtt.c"
+
+#include <cgreen/assertions.h>
+#include <cgreen/cgreen.h>
+#include <cgreen/constraint_syntax_helpers.h>
+#include <cgreen/internal/c_assertions.h>
+#include <cgreen/mocks.h>
+
+void
+MQTTClient_destroy (MQTTClient *client) {
+  (void) client;
+}
+
+Describe (mqtt);
+BeforeEach (mqtt)
+{
+}
+
+AfterEach (mqtt)
+{
+}
+
+/* mqtt_client_destroy */
+
+Ensure (mqtt, mqtt_client_destroy_nulls_client)
+{
+  MQTTClient client;
+  mqtt_t *mqtt;
+
+  mqtt = g_malloc0 (sizeof (*mqtt));
+  mqtt_set_client_id (mqtt);
+  client = mqtt_create (mqtt, "address");
+  mqtt_set_client (mqtt, client);
+  assert_that (mqtt->client, is_not_null);
+
+  mqtt_client_destroy (mqtt);
+  assert_that (mqtt->client, is_null);
+
+  // Cleanup
+  mqtt_client_data_destroy (&mqtt);
+  assert_that (mqtt, is_null);
+}
+
+/* Test suite. */
+int
+main (int argc, char **argv)
+{
+  TestSuite *suite;
+
+  suite = create_test_suite ();
+
+  add_test_with_context (suite, mqtt, mqtt_client_destroy_nulls_client);
+
+  if (argc > 1)
+    return run_single_test (suite, argv[1], create_text_reporter ());
+
+  return run_test_suite (suite, create_text_reporter ());
+}

--- a/util/mqtt_tests.c
+++ b/util/mqtt_tests.c
@@ -12,7 +12,8 @@
 #include <cgreen/mocks.h>
 
 void
-MQTTClient_destroy (MQTTClient *client) {
+MQTTClient_destroy (MQTTClient *client)
+{
   (void) client;
 }
 


### PR DESCRIPTION
## What

Add `mqtt_tests.c`.

At the same time, clear the client field in `mqtt_client_destroy`. This is a very minor change, mostly an excuse to add a test. It's also safe because the mqtt is always freed by `mqtt_client_data_destroy` straight after `mqtt_client_destroy`.

## Why

Start of test coverage for mqtt.c.
