### PR TITLE
Change: move assignments out of if conditions (boreas)

### DIFF
--- a/boreas/alivedetection.c
+++ b/boreas/alivedetection.c
@@ -331,7 +331,8 @@ alive_detection_init (gvm_hosts_t *hosts, alive_test_t alive_test)
   /* Scanner */
 
   /* Sockets */
-  if ((error = set_all_needed_sockets (&scanner, alive_test)) != 0)
+  error = set_all_needed_sockets (&scanner, alive_test);
+  if (error != 0)
     return error;
 
   /* Do not print results in stdout. Only set for command line clients*/
@@ -339,8 +340,8 @@ alive_detection_init (gvm_hosts_t *hosts, alive_test_t alive_test)
 
   /* kb_t redis connection */
   int scandb_id = atoi (prefs_get ("ov_maindbid"));
-  if ((scanner.main_kb = kb_direct_conn (prefs_get ("db_address"), scandb_id))
-      == NULL)
+  scanner.main_kb = kb_direct_conn (prefs_get ("db_address"), scandb_id);
+  if (scanner.main_kb == NULL)
     return -7;
   /* TODO: pcap handle */
   // scanner.pcap_handle = open_live (NULL, FILTER_STR); //
@@ -398,7 +399,8 @@ alive_detection_init (gvm_hosts_t *hosts, alive_test_t alive_test)
   int max_scan_hosts = INT_MAX, pref_value;
 
   /* Check that the max_scan_hosts is set and it is greater than 0 */
-  if ((pref_str = prefs_get ("max_scan_hosts")) != NULL)
+  pref_str = prefs_get ("max_scan_hosts");
+  if (pref_str != NULL)
     {
       pref_value = atoi (pref_str);
       if (pref_value > 0)
@@ -482,7 +484,8 @@ start_alive_detection (void *hosts_to_test)
   gvm_hosts_t *hosts;
   alive_test_t alive_test;
 
-  if ((alive_test_err = get_alive_test_methods (&alive_test)) != 0)
+  alive_test_err = get_alive_test_methods (&alive_test);
+  if (alive_test_err != 0)
     {
       g_warning ("%s: %s. Exit Boreas.", __func__,
                  str_boreas_error (alive_test_err));
@@ -495,7 +498,8 @@ start_alive_detection (void *hosts_to_test)
     }
 
   hosts = (gvm_hosts_t *) hosts_to_test;
-  if ((init_err = alive_detection_init (hosts, alive_test)) != 0)
+  init_err = alive_detection_init (hosts, alive_test);
+  if (init_err != 0)
     {
       g_warning (
         "%s. Boreas could not initialise alive detection. %s. Exit Boreas.",

--- a/boreas/arp.c
+++ b/boreas/arp.c
@@ -329,7 +329,8 @@ send_arp_v4 (const char *dst_str)
 
   if (srcip == INADDR_ANY)
     {
-      if ((uint32_t) -1 == (srcip = libnet_get_ipaddr4 (libnet)))
+      srcip = libnet_get_ipaddr4 (libnet);
+      if ((uint32_t) -1 == srcip)
         {
           g_warning ("%s: Unable to get the IPv4 address of default "
                      "interface %s: %s. Address '%s' will be skipped.",

--- a/boreas/boreas_io.c
+++ b/boreas/boreas_io.c
@@ -94,7 +94,8 @@ send_limit_msg (int num_not_scanned_hosts)
     return -1;
 
   dbid = atoi (prefs_get ("ov_maindbid"));
-  if ((main_kb = kb_direct_conn (prefs_get ("db_address"), dbid)))
+  main_kb = kb_direct_conn (prefs_get ("db_address"), dbid);
+  if (main_kb)
     {
       char buf[256];
       g_snprintf (buf, 256,
@@ -439,9 +440,11 @@ send_dead_hosts_to_ospd_openvas (int count_dead_hosts)
 gchar *
 get_openvas_scan_id (const gchar *db_address, int db_id)
 {
-  kb_t main_kb = NULL;
+  kb_t main_kb;
   gchar *scan_id;
-  if ((main_kb = kb_direct_conn (db_address, db_id)))
+
+  main_kb = kb_direct_conn (db_address, db_id);
+  if (main_kb)
     {
       scan_id = kb_item_get_str (main_kb, ("internal/scanid"));
       kb_lnk_reset (main_kb);

--- a/boreas/cli.c
+++ b/boreas/cli.c
@@ -50,7 +50,8 @@ init_cli (scanner_t *scanner, gvm_hosts_t *hosts, alive_test_t alive_test,
                          gvm_host_value_str (host), host);
 
   /* Sockets. */
-  if ((error = set_all_needed_sockets (scanner, alive_test)) != 0)
+  error = set_all_needed_sockets (scanner, alive_test);
+  if (error != 0)
     return error;
 
   /* Only init portlist if either TCP-ACK or TCP-SYN ping is used. */
@@ -224,7 +225,8 @@ is_host_alive (const char *ip_str, int *count)
   const gchar *port_list = NULL;
 
   hosts = gvm_hosts_new (ip_str);
-  if ((alive_test_err = get_alive_test_methods (&alive_test)) != 0)
+  alive_test_err = get_alive_test_methods (&alive_test);
+  if (alive_test_err != 0)
     {
       g_warning ("%s: %s. Exit Boreas.", __func__,
                  str_boreas_error (alive_test_err));

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -520,7 +520,8 @@ set_socket (socket_type_t socket_type, int *scanner_socket)
    * on pinging broadcast address */
   if (!error)
     {
-      if ((error = set_broadcast (soc)) != 0)
+      error = set_broadcast (soc);
+      if (error != 0)
         return error;
     }
 
@@ -542,30 +543,38 @@ set_all_needed_sockets (scanner_t *scanner, alive_test_t alive_test)
   boreas_error_t error = NO_ERROR;
   if (alive_test & ALIVE_TEST_ICMP)
     {
-      if ((error = set_socket (ICMPV4, &(scanner->icmpv4soc))) != 0)
+      error = set_socket (ICMPV4, &(scanner->icmpv4soc));
+      if (error != 0)
         return error;
-      if ((error = set_socket (ICMPV6, &(scanner->icmpv6soc))) != 0)
+      error = set_socket (ICMPV6, &(scanner->icmpv6soc));
+      if (error != 0)
         return error;
     }
 
   if ((alive_test & ALIVE_TEST_TCP_ACK_SERVICE)
       || (alive_test & ALIVE_TEST_TCP_SYN_SERVICE))
     {
-      if ((error = set_socket (TCPV4, &(scanner->tcpv4soc))) != 0)
+      error = set_socket (TCPV4, &(scanner->tcpv4soc));
+      if (error != 0)
         return error;
-      if ((error = set_socket (TCPV6, &(scanner->tcpv6soc))) != 0)
+      error = set_socket (TCPV6, &(scanner->tcpv6soc));
+      if (error != 0)
         return error;
-      if ((error = set_socket (UDPV4, &(scanner->udpv4soc))) != 0)
+      error = set_socket (UDPV4, &(scanner->udpv4soc));
+      if (error != 0)
         return error;
-      if ((error = set_socket (UDPV6, &(scanner->udpv6soc))) != 0)
+      error = set_socket (UDPV6, &(scanner->udpv6soc));
+      if (error != 0)
         return error;
     }
 
   if ((alive_test & ALIVE_TEST_ARP))
     {
-      if ((error = set_socket (ARPV4, &(scanner->arpv4soc))) != 0)
+      error = set_socket (ARPV4, &(scanner->arpv4soc));
+      if (error != 0)
         return error;
-      if ((error = set_socket (ARPV6, &(scanner->arpv6soc))) != 0)
+      error = set_socket (ARPV6, &(scanner->arpv6soc));
+      if (error != 0)
         return error;
     }
 


### PR DESCRIPTION
## What

Move assignment statements out of `if` conditions where possible. So
```
if ((a = b))...
```
becomes
```
a = b
if (a)...
```

## Why

Putting the `=` in the condition is error prone because it's easy to read the `=` as `==`.

Having the `=` in the condition is also harder to read because an extra pair of parens is required around the `=` statement.

## References

Follow on to /pull/890.
