### PR TITLE
Change: use strrchr instead of rindex

### DIFF
--- a/util/kb.c
+++ b/util/kb.c
@@ -251,7 +251,7 @@ parse_port_of_addr (const char *addr, int tcp_indicator_len)
 {
   char *tmp;
   int is_ip_v6;
-  tmp = rindex (addr + tcp_indicator_len, ':');
+  tmp = strrchr (addr + tcp_indicator_len, ':');
   if (tmp == NULL)
     return NULL;
   is_ip_v6 = addr[tcp_indicator_len] == '[';


### PR DESCRIPTION
## What

Use strchr.

## Why

rindex is deprecated.

## References

rindex was removed in POSIX-2008: https://man7.org/linux/man-pages/man3/index.3.html#HISTORY
