### PR TITLE
Nitpick: use consistent return style

### DIFF
--- a/boreas/util.c
+++ b/boreas/util.c
@@ -34,6 +34,11 @@ set_socket (socket_type_t, int *);
  *
  * From W.Richard Stevens "UNIX NETWORK PROGRAMMING" book. libfree/in_cksum.c
  * TODO: Section 8.7 of TCPv2 has more efficient implementation
+ *
+ * @param[in]  addr  Data to checksum over.
+ * @param[in]  len   Length of data in bytes.
+ *
+ * @return Checksum in bytes.
  **/
 uint16_t
 in_cksum (uint16_t *addr, int len)

--- a/boreas/util.c
+++ b/boreas/util.c
@@ -65,7 +65,7 @@ in_cksum (uint16_t *addr, int len)
   sum = (sum >> 16) + (sum & 0xffff); /* add hi 16 to low 16 */
   sum += (sum >> 16);                 /* add carry */
   answer = ~sum;                      /* truncate to 16 bits */
-  return (answer);
+  return answer;
 }
 
 /**

--- a/boreas/util_tests.c
+++ b/boreas/util_tests.c
@@ -65,6 +65,31 @@ __wrap_setsockopt (__attribute__ ((unused)) int sockfd,
   return (int) mock (sockfd, level, optname, optval, optlen);
 }
 
+/* in_cksum */
+
+Ensure (util, in_cksum_small)
+{
+  int len;
+  // https://web.archive.org/web/20020916085726/http://www.netfor2.com/checksum.html
+  uint16_t data[] = { 0x0100, 0xF203, 0xF4F5, 0xF6F7 };
+
+  len = sizeof (data); // len is in bytes
+  assert_that (in_cksum ((uint16_t *) data, len), is_equal_to (0x210E));
+}
+
+Ensure (util, in_cksum_bigger)
+{
+  int len;
+  // https://en.wikipedia.org/wiki/Internet_checksum
+  uint16_t data[] = { 0x4500, 0x0073, 0x0000, 0x4000, 0x4011, 0xC0A8,
+                      0x0001, 0xC0A8, 0x00C7 };
+
+  len = sizeof (data); // len is in bytes
+  assert_that (in_cksum ((uint16_t *) data, len), is_equal_to (0xB861));
+}
+
+/* set_all_needed_sockets */
+
 Ensure (util, set_all_needed_sockets)
 {
   g_socket_use_real = false;
@@ -214,6 +239,8 @@ main (int argc, char **argv)
 
   suite = create_test_suite ();
 
+  add_test_with_context (suite, util, in_cksum_small);
+  add_test_with_context (suite, util, in_cksum_bigger);
   add_test_with_context (suite, util, fill_ports_array);
   add_test_with_context (suite, util, set_all_needed_sockets);
   add_test_with_context (suite, util, set_socket);

--- a/boreas/util_tests.c
+++ b/boreas/util_tests.c
@@ -71,7 +71,7 @@ Ensure (util, in_cksum_small)
 {
   int len;
   // https://web.archive.org/web/20020916085726/http://www.netfor2.com/checksum.html
-  uint16_t data[] = { 0x0100, 0xF203, 0xF4F5, 0xF6F7 };
+  uint16_t data[] = {0x0100, 0xF203, 0xF4F5, 0xF6F7};
 
   len = sizeof (data); // len is in bytes
   assert_that (in_cksum ((uint16_t *) data, len), is_equal_to (0x210E));
@@ -81,8 +81,8 @@ Ensure (util, in_cksum_bigger)
 {
   int len;
   // https://en.wikipedia.org/wiki/Internet_checksum
-  uint16_t data[] = { 0x4500, 0x0073, 0x0000, 0x4000, 0x4011, 0xC0A8,
-                      0x0001, 0xC0A8, 0x00C7 };
+  uint16_t data[] = {0x4500, 0x0073, 0x0000, 0x4000, 0x4011,
+                     0xC0A8, 0x0001, 0xC0A8, 0x00C7};
 
   len = sizeof (data); // len is in bytes
   assert_that (in_cksum ((uint16_t *) data, len), is_equal_to (0xB861));

--- a/util/cpeutils.c
+++ b/util/cpeutils.c
@@ -106,7 +106,7 @@ uri_cpe_to_fs_cpe (const char *uri_cpe)
   uri_cpe_to_cpe_struct (uri_cpe, &cpe);
   fs_cpe = cpe_struct_to_fs_cpe (&cpe);
   cpe_struct_free (&cpe);
-  return (fs_cpe);
+  return fs_cpe;
 }
 
 /**
@@ -126,7 +126,7 @@ uri_cpe_to_fs_product (const char *uri_cpe)
   uri_cpe_to_cpe_struct (uri_cpe, &cpe);
   fs_cpe = cpe_struct_to_fs_product (&cpe);
   cpe_struct_free (&cpe);
-  return (fs_cpe);
+  return fs_cpe;
 }
 
 /**
@@ -146,7 +146,7 @@ uri_cpe_to_uri_product (const char *uri_cpe)
   uri_cpe_to_cpe_struct (uri_cpe, &cpe);
   fs_cpe = cpe_struct_to_uri_product (&cpe);
   cpe_struct_free (&cpe);
-  return (fs_cpe);
+  return fs_cpe;
 }
 
 /**
@@ -166,7 +166,7 @@ fs_cpe_to_uri_cpe (const char *fs_cpe)
   fs_cpe_to_cpe_struct (fs_cpe, &cpe);
   uri_cpe = cpe_struct_to_uri_cpe (&cpe);
   cpe_struct_free (&cpe);
-  return (uri_cpe);
+  return uri_cpe;
 }
 
 /**
@@ -186,7 +186,7 @@ fs_cpe_to_uri_product (const char *fs_cpe)
   fs_cpe_to_cpe_struct (fs_cpe, &cpe);
   uri_cpe = cpe_struct_to_uri_product (&cpe);
   cpe_struct_free (&cpe);
-  return (uri_cpe);
+  return uri_cpe;
 }
 
 /**
@@ -295,7 +295,7 @@ cpe_struct_to_uri_cpe (const cpe_struct_t *cpe)
 
   char *result = g_string_free (uri_cpe, FALSE);
   trim_pct (result);
-  return (result);
+  return result;
 }
 
 /**
@@ -336,7 +336,7 @@ cpe_struct_to_uri_product (const cpe_struct_t *cpe)
 
   char *result = g_string_free (uri_cpe, FALSE);
   trim_pct (result);
-  return (result);
+  return result;
 }
 
 /**
@@ -593,7 +593,7 @@ decode_uri_component (const char *component)
   gboolean embedded;
 
   if (!component)
-    return (NULL);
+    return NULL;
 
   if (strcmp (component, "") == 0 || strcmp (component, " ") == 0)
     {
@@ -661,7 +661,7 @@ decode_uri_component (const char *component)
             {
               g_string_free (decoded_component, TRUE);
               g_free (tmp_component);
-              return (NULL);
+              return NULL;
             }
         }
 
@@ -677,7 +677,7 @@ decode_uri_component (const char *component)
             {
               g_string_free (decoded_component, TRUE);
               g_free (tmp_component);
-              return (NULL);
+              return NULL;
             }
         }
 
@@ -697,7 +697,7 @@ decode_uri_component (const char *component)
         {
           g_string_free (decoded_component, TRUE);
           g_free (tmp_component);
-          return (NULL);
+          return NULL;
         }
       index = index + 3;
       embedded = TRUE;
@@ -883,7 +883,7 @@ unbind_fs_component (char *component)
 
   unbound_component = add_quoting (component);
   g_free (component);
-  return (unbound_component);
+  return unbound_component;
 }
 
 /**
@@ -903,7 +903,7 @@ add_quoting (const char *component)
   gboolean embedded;
 
   if (!component)
-    return (NULL);
+    return NULL;
 
   quoted_component = g_string_sized_new (2 * strlen (component));
   tmp_component = (char *) g_strdup (component);
@@ -948,7 +948,7 @@ add_quoting (const char *component)
           else
             {
               g_free (tmp_component);
-              return (NULL);
+              return NULL;
             }
         }
       if (*c == '?')
@@ -966,7 +966,7 @@ add_quoting (const char *component)
           else
             {
               g_free (tmp_component);
-              return (NULL);
+              return NULL;
             }
         }
       g_string_append_c (quoted_component, '\\');
@@ -1298,39 +1298,39 @@ cpe_struct_match (cpe_struct_t *source, cpe_struct_t *target)
 
   relation = compare_component (source->part, target->part);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->vendor, target->vendor);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->product, target->product);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->version, target->version);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->update, target->update);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->edition, target->edition);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->sw_edition, target->sw_edition);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->target_sw, target->target_sw);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->target_hw, target->target_hw);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->other, target->other);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->language, target->language);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
 
-  return (TRUE);
+  return TRUE;
 }
 
 /**
@@ -1353,27 +1353,27 @@ cpe_struct_match_tail (cpe_struct_t *source, cpe_struct_t *target)
 
   relation = compare_component (source->update, target->update);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->edition, target->edition);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->sw_edition, target->sw_edition);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->target_sw, target->target_sw);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->target_hw, target->target_hw);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->other, target->other);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
   relation = compare_component (source->language, target->language);
   if (relation != SUPERSET && relation != EQUAL)
-    return (FALSE);
+    return FALSE;
 
-  return (TRUE);
+  return TRUE;
 }
 
 /**
@@ -1419,37 +1419,37 @@ compare_component (const char *source, const char *target)
     {
       g_free (source_cpy);
       g_free (target_cpy);
-      return (UNDEFINED);
+      return UNDEFINED;
     }
   if (strcmp (source_cpy, target_cpy) == 0)
     {
       g_free (source_cpy);
       g_free (target_cpy);
-      return (EQUAL);
+      return EQUAL;
     }
   if (strcmp (source_cpy, "ANY") == 0)
     {
       g_free (source_cpy);
       g_free (target_cpy);
-      return (SUPERSET);
+      return SUPERSET;
     }
   if (strcmp (target_cpy, "ANY") == 0)
     {
       g_free (source_cpy);
       g_free (target_cpy);
-      return (SUBSET);
+      return SUBSET;
     }
   if (strcmp (target_cpy, "NA") == 0 || strcmp (source_cpy, "NA") == 0)
     {
       g_free (source_cpy);
       g_free (target_cpy);
-      return (DISJOINT);
+      return DISJOINT;
     }
 
   result = compare_strings (source_cpy, target_cpy);
   g_free (source_cpy);
   g_free (target_cpy);
-  return (result);
+  return result;
 }
 
 /**
@@ -1551,7 +1551,7 @@ count_escapes (const char *str, int start, int end)
       if (active && i >= start)
         result++;
     }
-  return (result);
+  return result;
 }
 
 /**
@@ -1623,13 +1623,13 @@ index_of (const char *str, const char *sub_str, int offset)
   char *begin_substr;
 
   if (offset > (int) strlen (str))
-    return (-1);
+    return -1;
 
   start = (char *) str + offset;
   begin_substr = strstr (start, sub_str);
   if (begin_substr == NULL)
-    return (-1);
-  return (begin_substr - str);
+    return -1;
+  return begin_substr - str;
 }
 
 /**

--- a/util/versionutils.c
+++ b/util/versionutils.c
@@ -69,13 +69,13 @@ cmp_versions (const char *version1, const char *version2)
     {
       g_free (ver1);
       g_free (ver2);
-      return (-5);
+      return -5;
     }
   if (strcmp (ver1, ver2) == 0)
     {
       g_free (ver1);
       g_free (ver2);
-      return (0);
+      return 0;
     }
 
   release_state1 = get_release_state (ver1, index1);
@@ -104,7 +104,7 @@ cmp_versions (const char *version1, const char *version2)
     }
 
   if (part1 == NULL && part2 == NULL)
-    return (release_state2 - release_state1);
+    return release_state2 - release_state1;
 
   if (is_text (part1) || is_text (part2))
     {
@@ -125,18 +125,18 @@ cmp_versions (const char *version1, const char *version2)
     {
       g_free (part2);
       if (rs2)
-        return (rs2 - release_state1);
+        return rs2 - release_state1;
       else
-        return (-1);
+        return -1;
     }
 
   if (part2 == NULL)
     {
       g_free (part1);
       if (rs1)
-        return (release_state2 - rs1);
+        return release_state2 - rs1;
       else
-        return (1);
+        return 1;
     }
 
   int ret = -5;
@@ -163,7 +163,7 @@ cmp_versions (const char *version1, const char *version2)
   g_free (part2);
   g_free (ver1);
   g_free (ver2);
-  return (ret);
+  return ret;
 }
 
 /**
@@ -183,10 +183,10 @@ prepare_version_string (const char *version)
   gboolean is_digit;
 
   if (!version)
-    return (NULL);
+    return NULL;
 
   if (strlen (version) > 1024)
-    return (NULL);
+    return NULL;
 
   ver = g_strdup (version);
 
@@ -280,7 +280,7 @@ get_release_state (const char *version, int index)
   part = get_part (version, index);
 
   if (part == NULL)
-    return (0);
+    return 0;
 
   if (strcmp (part, "dev") == 0 || strcmp (part, "development") == 0)
     rel_stat = 4;
@@ -292,7 +292,7 @@ get_release_state (const char *version, int index)
     rel_stat = 1;
 
   g_free (part);
-  return (rel_stat);
+  return rel_stat;
 }
 
 /**
@@ -316,13 +316,13 @@ get_part (const char *version, int index)
     }
 
   if (begin == (int) strlen (version))
-    return (NULL);
+    return NULL;
 
   for (end = begin + 1; end < (int) strlen (version) && version[end] != '.';
        end++)
     ;
 
-  return (str_cpy ((char *) (version + begin), end - begin));
+  return str_cpy ((char *) (version + begin), end - begin);
 }
 
 /**
@@ -336,13 +336,13 @@ static gboolean
 is_text (const char *part)
 {
   if (!part)
-    return (FALSE);
+    return FALSE;
   if (strcmp (part, "dev") == 0 || strcmp (part, "alpha") == 0
       || strcmp (part, "beta") == 0 || strcmp (part, "rc") == 0)
-    return (FALSE);
+    return FALSE;
   if (g_ascii_isdigit (*part))
-    return (FALSE);
-  return (TRUE);
+    return FALSE;
+  return TRUE;
 }
 
 /**
@@ -361,5 +361,5 @@ str_cpy (char *source, int size)
   result = (char *) g_malloc (size + 1);
   memset (result, 0, size + 1);
   strncpy (result, source, size);
-  return (result);
+  return result;
 }


### PR DESCRIPTION
## What

Use `return x;` instead of `return (x);`.

Also add tests of `in_cksum`, for coverage.

## Why

Easier if they're all the same.