### PR TITLE
Change: Use Docker Hub credentials to pull private images

### DIFF
--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -22,10 +22,7 @@ jobs:
       contents: read
       security-events: write
     container:
-      image: greenbone/gvm-libs:edge
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      image: registry.community.greenbone.net/community/gvm-libs:edge
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -21,7 +21,11 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    container: greenbone/gvm-libs:edge
+    container:
+      image: greenbone/gvm-libs:edge
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What

Added Docker Hub authentication to GitHub Actions to allow pulling private images like `greenbone/gvm-libs.`

## Why

greenbone/gvm-libs Docker image has been moved to private, requiring authentication to pull.

## References


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


