### PR TITLE
Fix: some issues producing a segmentation fault.

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -299,7 +299,6 @@ openvasd_send_request (openvasd_connector_t conn,
     {
       g_warning ("%s: Error performing CURL request", __func__);
       response->body = g_strdup ("{\"error\": \"Error sending request\"}");
-      gvm_http_headers_free (custom_headers);
       gvm_http_response_cleanup (http_response);
       g_free (url);
       return response;

--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -900,7 +900,7 @@ openvasd_parsed_results (openvasd_connector_t conn, unsigned long first,
 openvasd_resp_t
 openvasd_get_scan_status (openvasd_connector_t conn)
 {
-  openvasd_resp_t response = NULL;
+  openvasd_resp_t response;
   GString *path = NULL;
   gvm_http_headers_t *customheader = NULL;
 
@@ -913,6 +913,7 @@ openvasd_get_scan_status (openvasd_connector_t conn)
     }
   else
     {
+      response = g_malloc0 (sizeof (struct openvasd_response));
       response->code = RESP_CODE_ERR;
       response->body = g_strdup ("{\"error\": \"Missing scan ID\"}");
       g_string_free (path, TRUE);


### PR DESCRIPTION
## What
- Initialize response in openvasd_get_scan_status() 
- Do not free the customheader in the openvasd_send_request(), since it must be free by the caller function.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Crashes
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [] Tests


