### PR TITLE
Change: Added return values on success/error/end when parsing vts.

### DIFF
--- a/openvasd/openvasd.h
+++ b/openvasd/openvasd.h
@@ -283,7 +283,8 @@ char *openvasd_vt_stream_str (openvasd_connector_t);
 
 size_t openvasd_vt_stream_len (openvasd_connector_t);
 
-nvti_t *
-openvasd_parse_vt (gvm_json_pull_parser_t *, gvm_json_pull_event_t *);
+int
+openvasd_parse_vt (gvm_json_pull_parser_t *, gvm_json_pull_event_t *,
+                   nvti_t **);
 
 #endif

--- a/openvasd/vtparser_tests.c
+++ b/openvasd/vtparser_tests.c
@@ -95,7 +95,7 @@ Ensure (vtparser, openvasd_parse_vt_parses_a_vt)
 
   gvm_json_pull_parser_next (&parser, &event);
 
-  nvt = openvasd_parse_vt (&parser, &event);
+  openvasd_parse_vt (&parser, &event, &nvt);
   assert_that (nvt, is_not_null);
   assert_that (nvti_name (nvt), is_equal_to_string (VT_NAME));
   assert_that (nvti_refs (nvt, NULL, NULL, 1),


### PR DESCRIPTION
## What
Added return values on success/error/end when parsing vts.

## Why
To differentiate between feed end and parsing errors.

## References
GEA-936


