### PR TITLE
Require CMake >= 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 message ("-- Configuring the Greenbone Vulnerability Management Libraries...")
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ some supported platforms.
 General build environment:
 
 * a C compiler (e.g. gcc)
-* cmake >= 3.0
+* cmake >= 3.5
 * pkg-config
 
 Specific development libraries:


### PR DESCRIPTION


## What

Require CMake >= 3.5

## Why

CMake 4.0 drops support for CMake < 3.5. Therefore require CMake 3.5 as minimum version to allow using CMake 4.0. All our supported platforms already provide CMake >= 3.5

## References

Fixes #910



