### PR TITLE
Fix: link gvm_base_shared to resolve missing nvti symbols in libgvm_util

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -188,6 +188,7 @@ if(BUILD_SHARED)
   target_link_libraries(
     gvm_util_shared
     LINK_PRIVATE
+      gvm_base_shared
       ${LIBPAHO_LDFLAGS}
       ${GLIB_LDFLAGS}
       ${GIO_LDFLAGS}


### PR DESCRIPTION
## What

Link gvm_base_shared to gvm_util_shared to resolve missing nvti_* symbols during linking.

## Why

Some symbols like nvti_* functions were missing at link time when building gvm_util_shared and tests depending on it.
These functions are implemented in gvm_base_shared, so an explicit link was needed to fix the build.


## References


## Checklist


- [ ] Tests


