### PR TITLE
Add: Add patch method support to httputils for agent controller

### DIFF
--- a/http/httputils.c
+++ b/http/httputils.c
@@ -202,6 +202,14 @@ gvm_http_new (const gchar *url, gvm_http_method_t method,
               curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE, strlen(payload));
             }
           break;
+      case PATCH:
+          if (payload && payload[0] != '\0')
+            {
+              curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+              curl_easy_setopt (curl, CURLOPT_POSTFIELDS, payload);
+              curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE, strlen(payload));
+            }
+          break;
       case DELETE:
           curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "DELETE");
           break;

--- a/http/httputils.h
+++ b/http/httputils.h
@@ -41,7 +41,8 @@ typedef enum {
   POST,
   PUT,
   DELETE,
-  HEAD
+  HEAD,
+  PATCH
 } gvm_http_method_t;
 
 typedef enum {


### PR DESCRIPTION
## What

Add patch method support to httputils for agent controller

## Why

The PATCH method is needed to update agent states via agent controller API.

## References

GEA-1046 



