### PR TITLE
Fix: check error_msg_entity in osp_check_feed

### DIFF
--- a/osp/osp.c
+++ b/osp/osp.c
@@ -376,7 +376,7 @@ osp_check_feed (osp_connection_t *connection, int *lockfile_in_use,
 
   if (self_test_error_msg)
     {
-      if (self_test_error_msg)
+      if (error_msg_entity)
         {
           if (entity_text (error_msg_entity))
             *self_test_error_msg = g_strdup (entity_text (error_msg_entity));


### PR DESCRIPTION
## What

Check that `error_msg_entity` exists in `osp_check_feed`.

## Why

There was a duplicate `if` condition, and the warning was missing when `error_msg_entity` was missing.

## Tests

I explored writing a test but the cgreen swallows stdout, so it's a little tricky. I confirmed by adding an abort where the warning would be.

Note that even a simple test of `osp_check_feed` needs some intrusive changes (see test patch below) so I'll leave that out for now.
<details>
  <summary>Test Patch</summary>

```patch
diff --git a/cmake/MacroAddUnitTest.cmake b/cmake/MacroAddUnitTest.cmake
index d46739bc..8d88696d 100644
--- a/cmake/MacroAddUnitTest.cmake
+++ b/cmake/MacroAddUnitTest.cmake
@@ -2,5 +2,6 @@ macro(add_unit_test _testName _testSource)
   add_executable(${_testName} ${_testSource})
   target_link_libraries(${_testName} ${CGREEN_LIBRARIES} ${ARGN})
   target_include_directories(${_testName} PRIVATE ${CGREEN_INCLUDE_DIRS})
+  target_compile_options(${_testName} PRIVATE -DBUILDING_TEST)
   add_test(NAME ${_testName} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
 endmacro()
diff --git a/osp/osp.c b/osp/osp.c
index 601a6cac..7440ed01 100644
--- a/osp/osp.c
+++ b/osp/osp.c
@@ -9,6 +9,7 @@
  */
 
 #include "osp.h"
+#include "osp_internals.h"
 
 #include "../base/hosts.h"       /* for gvm_get_host_type */
 #include "../util/serverutils.h" /* for gvm_server_close, gvm_server_open_w... */
@@ -29,80 +30,6 @@
  */
 #define G_LOG_DOMAIN "libgvm osp"
 
-/**
- * @brief Struct holding options for OSP connection.
- */
-struct osp_connection
-{
-  gnutls_session_t session; /**< Pointer to GNUTLS Session. */
-  int socket;               /**< Socket. */
-  char *host;               /**< Host. */
-  int port;                 /**< Port. */
-};
-
-/**
- * @brief Struct holding options for OSP parameters.
- */
-struct osp_param
-{
-  char *id;              /**< Parameter id. */
-  char *name;            /**< Parameter name. */
-  char *desc;            /**< Parameter description. */
-  char *def;             /**< Default value. */
-  osp_param_type_t type; /**< Parameter type. */
-  int mandatory;         /**< If mandatory or not. */
-};
-
-/**
- * @brief Struct credential information for OSP.
- */
-struct osp_credential
-{
-  gchar *type;           /**< Credential type */
-  gchar *service;        /**< Service the credential is for */
-  gchar *port;           /**< Port the credential is for */
-  GHashTable *auth_data; /**< Authentication data (username, password, etc.)*/
-};
-
-/**
- * @brief Struct holding target information.
- */
-struct osp_target
-{
-  GSList *credentials;   /** Credentials to use in the scan */
-  gchar *exclude_hosts;  /** String defining one or many hosts to exclude */
-  gchar *hosts;          /** String defining one or many hosts to scan */
-  gchar *ports;          /** String defining the ports to scan */
-  gchar *finished_hosts; /** String defining hosts to exclude as finished */
-  /* Alive test methods can be specified either as bitfield or via selection of
-  individual methods */
-  int alive_test; /** Value defining an alive test method */
-  gboolean icmp;
-  gboolean tcp_syn;
-  gboolean tcp_ack;
-  gboolean arp;
-  gboolean consider_alive;
-  int reverse_lookup_unify; /** Value defining reverse_lookup_unify opt */
-  int reverse_lookup_only;  /** Value defining reverse_lookup_only opt */
-};
-
-/**
- * @brief Struct holding vt_group information
- */
-struct osp_vt_group
-{
-  gchar *filter;
-};
-
-/**
- * @brief Struct holding vt_group information
- */
-struct osp_vt_single
-{
-  gchar *vt_id;
-  GHashTable *vt_values;
-};
-
 static int
 osp_send_command (osp_connection_t *, entity_t *, const char *, ...)
   __attribute__ ((__format__ (__printf__, 3, 4)));
@@ -183,6 +110,8 @@ osp_connection_new (const char *host, int port, const char *cacert,
   return connection;
 }
 
+#ifdef BUILDING_TEST
+#else
 /**
  * @brief Send a command to an OSP server.
  *
@@ -226,6 +155,7 @@ out:
 
   return rc;
 }
+#endif
 
 /**
  * @brief Send a command to an OSP server.
diff --git a/osp/osp_tests.c b/osp/osp_tests.c
index 75504f13..3b6b7dc5 100644
--- a/osp/osp_tests.c
+++ b/osp/osp_tests.c
@@ -16,6 +16,39 @@ AfterEach (osp)
 {
 }
 
+static int
+osp_send_command (__attribute__ ((unused)) osp_connection_t *connection,
+                  entity_t *response,
+                  const char *fmt, ...)
+{
+  if (strcmp (fmt, "<check_feed/>"))
+    return 1;
+  if (response
+      && parse_entity ("<test>"
+                       "<feed>"
+                       "<self_test_error_msg>ABC</self_test_error_msg>"
+                       "</feed>"
+                       "</test>",
+                       response)) {
+    return 1;
+  }
+  return 0;
+}
+
+Ensure (osp, osp_check_feed_sets_err_msg)
+{
+  int ret;
+  char *msg;
+  osp_connection_t conn;
+
+  msg = NULL;
+  ret = osp_check_feed (&conn, NULL, NULL, &msg, NULL);
+  assert_that (ret, is_equal_to (0));
+  assert_that (msg, is_not_null);
+  assert_that (msg, is_equal_to_string ("ABC"));
+  g_free (msg);
+}
+
 Ensure (osp, osp_new_target_never_returns_null)
 {
   assert_that (osp_target_new (NULL, NULL, NULL, 0, 0, 0), is_not_null);
@@ -93,6 +126,7 @@ main (int argc, char **argv)
 
   suite = create_test_suite ();
 
+  add_test_with_context (suite, osp, osp_check_feed_sets_err_msg);
   add_test_with_context (suite, osp, osp_new_target_never_returns_null);
   add_test_with_context (suite, osp, osp_get_vts_no_conn_ret_error);
   add_test_with_context (suite, osp, osp_get_vts_no_vts_ret_error);
```

</details>