### PR TITLE
Fix: port field in result

### DIFF
--- a/openvasd/openvasd.h
+++ b/openvasd/openvasd.h
@@ -26,8 +26,7 @@ struct openvasd_result
   gchar *ip_address;
   gchar *hostname;
   gchar *oid;
-  int port;
-  gchar *protocol;
+  gchar *port;
   gchar *message;
   gchar *detail_name;
   gchar *detail_value;
@@ -65,7 +64,7 @@ enum OPENVASD_RESULT_MEMBER_STRING
   IP_ADDRESS,
   HOSTNAME,
   OID,
-  PROTOCOL,
+  PORT,
   MESSAGE,
   DETAIL_NAME,
   DETAIL_VALUE,
@@ -77,7 +76,6 @@ enum OPENVASD_RESULT_MEMBER_STRING
 enum OPENVASD_RESULT_MEMBER_INT
 {
   ID,
-  PORT,
 };
 
 /**
@@ -112,8 +110,8 @@ struct openvasd_scan_status
 
 typedef struct
 {
-  int start;    /**< Start interval. */
-  int end;      /**< End interval. */
+  int start;           /**< Start interval. */
+  int end;             /**< End interval. */
   const gchar *titles; /**< Graph title. */
 } openvasd_get_performance_opts_t;
 
@@ -161,7 +159,7 @@ openvasd_resp_t
 openvasd_get_scan_results (openvasd_connector_t, long, long);
 
 openvasd_result_t
-openvasd_result_new (unsigned long, gchar *, gchar *, gchar *, gchar *, int,
+openvasd_result_new (unsigned long, gchar *, gchar *, gchar *, gchar *, gchar *,
                      gchar *, gchar *, gchar *, gchar *, gchar *, gchar *,
                      gchar *);
 


### PR DESCRIPTION
## What
Fix: port field in result
Jira: SC-1294

Also, fix format with clang-format
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
While openvasd only handle ports as integers, gvmd still waits for general/Host_Details, general/tcp or general/udp.
 This patch handles all these possibilities and set the result port field correctly.

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


