### PR TITLE
Add: Add support for storing raw config JSON in agent struct

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -222,6 +222,9 @@ agent_controller_parse_agent (cJSON *item)
   cJSON *config_obj = cJSON_GetObjectItem (item, "config");
   if (config_obj && cJSON_IsObject (config_obj))
     {
+      // set raw config
+      agent->config = cJSON_PrintUnformatted(config_obj);
+
       // Parse "schedule"
       cJSON *schedule_obj = cJSON_GetObjectItem (config_obj, "schedule");
       if (schedule_obj && cJSON_IsObject (schedule_obj))
@@ -438,6 +441,7 @@ agent_controller_agent_free (agent_controller_agent_t agent)
   g_free (agent->agent_id);
   g_free (agent->hostname);
   g_free (agent->connection_status);
+  g_free (agent->config);
 
   if (agent->ip_addresses)
     {

--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -91,6 +91,7 @@ struct agent_controller_agent
   gchar **ip_addresses;              ///< List of IP addresses
   int ip_address_count;              ///< Number of IP addresses
   time_t last_update;                ///< Timestamp of the last update (seconds since epoch)
+  gchar *config;                     /// < Raw Config without Parsed
   agent_controller_config_schedule_t schedule_config; ///< Agent schedule configuration
   agent_controller_config_server_t server_config;     ///< Server configuration
                                                       ///< associated with the agent

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -198,6 +198,7 @@ Ensure (agent_controller, agent_free_handles_agent)
   agent->agent_id = g_strdup ("agent-001");
   agent->hostname = g_strdup ("localhost");
   agent->connection_status = g_strdup ("active");
+  agent->config = g_strdup ("{\"config\":{\"schedule\":{\"schedule\":\"@every 12h\"}}}");
 
   // IP addresses
   agent->ip_address_count = 2;
@@ -594,6 +595,8 @@ Ensure (agent_controller, parse_agent_with_config_and_server)
   assert_that (agent->server_config->agent_id, is_equal_to_string ("agent-ctrl"));
   assert_that (agent->server_config->token, is_equal_to_string ("xyz123"));
   assert_that (agent->server_config->server_cert_hash, is_equal_to_string ("abc123hash"));
+  assert_that (agent->config, is_not_null);
+  assert_that (strstr (agent->config, "\"schedule\":\"@every 5m\"") != NULL, is_true);
 
   agent_controller_agent_free (agent);
   cJSON_Delete (obj);


### PR DESCRIPTION
## What

Add support for storing raw config JSON in the agent struct

## Why

Storing the raw JSON config provides full traceability of configuration data and enables easier configuration migrations in gvmd.
## References

GEA-974

## Checklist

- [ ] Tests


