### PR TITLE
Fix: allocate response before use in openvasd_stop_scan and openvasd_delete_scan

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -612,7 +612,7 @@ openvasd_start_scan (openvasd_connector_t conn, gchar *data)
 openvasd_resp_t
 openvasd_stop_scan (openvasd_connector_t conn)
 {
-  openvasd_resp_t response = NULL;
+  openvasd_resp_t response;
   GString *path;
 
   // Stop the scan
@@ -624,6 +624,7 @@ openvasd_stop_scan (openvasd_connector_t conn)
     }
   else
     {
+      response = g_malloc0 (sizeof (struct openvasd_response));
       response->code = RESP_CODE_ERR;
       response->body = g_strdup ("{\"error\": \"Missing scan ID\"}");
       g_string_free (path, TRUE);
@@ -1126,7 +1127,7 @@ openvasd_parsed_scan_status (openvasd_connector_t conn)
 openvasd_resp_t
 openvasd_delete_scan (openvasd_connector_t conn)
 {
-  openvasd_resp_t response = NULL;
+  openvasd_resp_t response;
   GString *path;
 
   // Stop the scan
@@ -1138,6 +1139,7 @@ openvasd_delete_scan (openvasd_connector_t conn)
     }
   else
     {
+      response = g_malloc0 (sizeof (struct openvasd_response));
       response->code = RESP_CODE_ERR;
       response->body = g_strdup ("{\"error\": \"Missing scan ID\"}");
       g_string_free (path, TRUE);

--- a/openvasd/openvasd_tests.c
+++ b/openvasd/openvasd_tests.c
@@ -20,6 +20,21 @@ AfterEach (openvasd)
 {
 }
 
+/* openvasd_stop_scan */
+
+Ensure (openvasd, openvasd_stop_scan_works_with_missing_id)
+{
+  openvasd_resp_t resp;
+  openvasd_connector_t conn;
+
+  conn = openvasd_connector_new ();
+  resp = openvasd_stop_scan (conn);
+  assert_that (resp, is_not_null);
+  assert_that (resp->code, is_equal_to (RESP_CODE_ERR));
+  assert_that (resp->body, is_equal_to_string ("{\"error\": \"Missing scan ID\"}"));
+  openvasd_response_cleanup (resp);
+}
+
 /* parse_results */
 
 Ensure (openvasd, parse_results_handles_details)
@@ -220,6 +235,8 @@ main (int argc, char **argv)
                          openvasd_connector_free);
   add_test_with_context (suite, openvasd,
                          openvasd_connector_builder_invalid_protocol);
+  add_test_with_context (suite, openvasd,
+                         openvasd_stop_scan_works_with_missing_id);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());

--- a/openvasd/openvasd_tests.c
+++ b/openvasd/openvasd_tests.c
@@ -20,6 +20,21 @@ AfterEach (openvasd)
 {
 }
 
+/* openvasd_delete_scan */
+
+Ensure (openvasd, openvasd_delete_scan_works_with_missing_id)
+{
+  openvasd_resp_t resp;
+  openvasd_connector_t conn;
+
+  conn = openvasd_connector_new ();
+  resp = openvasd_delete_scan (conn);
+  assert_that (resp, is_not_null);
+  assert_that (resp->code, is_equal_to (RESP_CODE_ERR));
+  assert_that (resp->body, is_equal_to_string ("{\"error\": \"Missing scan ID\"}"));
+  openvasd_response_cleanup (resp);
+}
+
 /* openvasd_stop_scan */
 
 Ensure (openvasd, openvasd_stop_scan_works_with_missing_id)
@@ -225,6 +240,7 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, openvasd, parse_results_handles_details);
   add_test_with_context (suite, openvasd, parse_status_start_end_time);
+
   add_test_with_context (suite, openvasd,
                          openvasd_connector_builder_all_valid_fields);
   add_test_with_context (suite, openvasd,
@@ -235,8 +251,11 @@ main (int argc, char **argv)
                          openvasd_connector_free);
   add_test_with_context (suite, openvasd,
                          openvasd_connector_builder_invalid_protocol);
+
   add_test_with_context (suite, openvasd,
                          openvasd_stop_scan_works_with_missing_id);
+  add_test_with_context (suite, openvasd,
+                         openvasd_delete_scan_works_with_missing_id);
 
   if (argc > 1)
     return run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

Allocate `response` before assigning to `response->code`.

## Why

Otherwise a segfault happens when the ID is missing.

Note that these errors would have been shown by the compiler, like this:
```
/home/user/openvasd/openvasd.c:627:22: error: ‘response’ may be used uninitialized [-Werror=maybe-uninitialized]
  627 |       response->code = RESP_CODE_ERR;
```
but people have started always initializing variables to NULL in the variable declaration (even when the intention is to initialize the variable later), so we lose these kind of warnings.

## References

First seen for `openvasd_start_scan` in /pull/907.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


