### PR TITLE
Fix: prevent warning about ascii64 buffer being too small

### DIFF
--- a/util/passwordbasedauthentication.c
+++ b/util/passwordbasedauthentication.c
@@ -41,7 +41,7 @@ is_prefix_supported (const char *id)
 #ifndef EXTERNAL_CRYPT_GENSALT_R
 
 // used printables within salt
-const char ascii64[64] =
+const char ascii64[] =
   "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 /* Tries to get BUFLEN random bytes into BUF; returns 0 on success. */


### PR DESCRIPTION
## What

Leave the size out of the `asci64` array declaration.

## Why

The compiler puts a NULL terminator on the string, so the ascii64 array was one too short. Leaving out the size lets the compiler sort it out.

## References

Closes #924.

