### PR TITLE
Fix gcc errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.5)
 message("-- Configuring the Greenbone Vulnerability Management Libraries...")
 
 # VERSION: Always include major, minor and patch level.
-project(gvm-libs VERSION 22.22.0 LANGUAGES C)
+project(gvm-libs VERSION 22.22.1 LANGUAGES C)
 
 if(POLICY CMP0005)
   cmake_policy(SET CMP0005 NEW)
@@ -70,7 +70,7 @@ endif(NOT CMAKE_BUILD_TYPE MATCHES "Release")
 
 # Set dev version if this is a development version and not a full release,
 # unset (put value 0 or delete line) before a full release and reset after.
-set(PROJECT_DEV_VERSION 0)
+set(PROJECT_DEV_VERSION 1)
 
 # If PROJECT_DEV_VERSION is set, the version string will be set to:
 #   "major.minor.patch~dev${PROJECT_DEV_VERSION}${GIT_REVISION}"

--- a/util/compressutils_tests.c
+++ b/util/compressutils_tests.c
@@ -22,7 +22,7 @@ Ensure (compressutils, can_compress_and_uncompress_without_header)
 {
   const char *testdata = "TEST-12345-12345-TEST";
 
-  unsigned long compressed_len=0;
+  unsigned long compressed_len = 0;
   char *compressed =
     gvm_compress (testdata, strlen (testdata) + 1, &compressed_len);
   assert_that (compressed_len, is_greater_than (0));
@@ -67,14 +67,14 @@ Ensure (compressutils, can_uncompress_using_reader)
 
   char compressed_filename[35] = "/tmp/gvm_gzip_test_XXXXXX";
   int compressed_fd = mkstemp (compressed_filename);
-  (void)!write (compressed_fd, compressed, compressed_len);
+  (void) !write (compressed_fd, compressed, compressed_len);
   close (compressed_fd);
 
   FILE *stream = gvm_gzip_open_file_reader (compressed_filename);
   assert_that (stream, is_not_null);
 
   gchar *uncompressed = g_malloc0 (30);
-  (void)!fread (uncompressed, 1, 30, stream);
+  (void) !fread (uncompressed, 1, 30, stream);
   assert_that (uncompressed, is_equal_to_string (testdata));
 
   assert_that (fclose (stream), is_equal_to (0));
@@ -89,7 +89,7 @@ Ensure (compressutils, can_uncompress_using_fd_reader)
 
   char compressed_filename[35] = "/tmp/gvm_gzip_test_XXXXXX";
   int compressed_fd = mkstemp (compressed_filename);
-  (void)!write (compressed_fd, compressed, compressed_len);
+  (void) !write (compressed_fd, compressed, compressed_len);
   close (compressed_fd);
 
   compressed_fd = open (compressed_filename, O_RDONLY);
@@ -98,7 +98,7 @@ Ensure (compressutils, can_uncompress_using_fd_reader)
   assert_that (stream, is_not_null);
 
   gchar *uncompressed = g_malloc0 (30);
-  (void)!fread (uncompressed, 1, 30, stream);
+  (void) !fread (uncompressed, 1, 30, stream);
   assert_that (uncompressed, is_equal_to_string (testdata));
 
   assert_that (fclose (stream), is_equal_to (0));

--- a/util/compressutils_tests.c
+++ b/util/compressutils_tests.c
@@ -22,7 +22,7 @@ Ensure (compressutils, can_compress_and_uncompress_without_header)
 {
   const char *testdata = "TEST-12345-12345-TEST";
 
-  unsigned long compressed_len;
+  unsigned long compressed_len=0;
   char *compressed =
     gvm_compress (testdata, strlen (testdata) + 1, &compressed_len);
   assert_that (compressed_len, is_greater_than (0));
@@ -67,14 +67,14 @@ Ensure (compressutils, can_uncompress_using_reader)
 
   char compressed_filename[35] = "/tmp/gvm_gzip_test_XXXXXX";
   int compressed_fd = mkstemp (compressed_filename);
-  write (compressed_fd, compressed, compressed_len);
+  (void)!write (compressed_fd, compressed, compressed_len);
   close (compressed_fd);
 
   FILE *stream = gvm_gzip_open_file_reader (compressed_filename);
   assert_that (stream, is_not_null);
 
   gchar *uncompressed = g_malloc0 (30);
-  fread (uncompressed, 1, 30, stream);
+  (void)!fread (uncompressed, 1, 30, stream);
   assert_that (uncompressed, is_equal_to_string (testdata));
 
   assert_that (fclose (stream), is_equal_to (0));
@@ -89,7 +89,7 @@ Ensure (compressutils, can_uncompress_using_fd_reader)
 
   char compressed_filename[35] = "/tmp/gvm_gzip_test_XXXXXX";
   int compressed_fd = mkstemp (compressed_filename);
-  write (compressed_fd, compressed, compressed_len);
+  (void)!write (compressed_fd, compressed, compressed_len);
   close (compressed_fd);
 
   compressed_fd = open (compressed_filename, O_RDONLY);
@@ -98,7 +98,7 @@ Ensure (compressutils, can_uncompress_using_fd_reader)
   assert_that (stream, is_not_null);
 
   gchar *uncompressed = g_malloc0 (30);
-  fread (uncompressed, 1, 30, stream);
+  (void)!fread (uncompressed, 1, 30, stream);
   assert_that (uncompressed, is_equal_to_string (testdata));
 
   assert_that (fclose (stream), is_equal_to (0));

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -97,7 +97,7 @@ Ensure (json, gvm_json_obj_check_str_1_when_int)
 Ensure (json, gvm_json_obj_check_str_0_and_val_when_has)
 {
   cJSON *json;
-  gchar *ret=NULL;
+  gchar *ret = NULL;
 
   json = cJSON_Parse ("{ \"eg\": \"abc\" }");
   assert_that (json, is_not_null);
@@ -205,7 +205,7 @@ Ensure (json, gvm_json_obj_check_int_1_when_str)
 Ensure (json, gvm_json_obj_check_int_0_and_val_when_has)
 {
   cJSON *json;
-  int ret=-1;
+  int ret = -1;
 
   json = cJSON_Parse ("{ \"eg\": 33 }");
   assert_that (json, is_not_null);

--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -97,7 +97,7 @@ Ensure (json, gvm_json_obj_check_str_1_when_int)
 Ensure (json, gvm_json_obj_check_str_0_and_val_when_has)
 {
   cJSON *json;
-  gchar *ret;
+  gchar *ret=NULL;
 
   json = cJSON_Parse ("{ \"eg\": \"abc\" }");
   assert_that (json, is_not_null);
@@ -205,7 +205,7 @@ Ensure (json, gvm_json_obj_check_int_1_when_str)
 Ensure (json, gvm_json_obj_check_int_0_and_val_when_has)
 {
   cJSON *json;
-  int ret;
+  int ret=-1;
 
   json = cJSON_Parse ("{ \"eg\": 33 }");
   assert_that (json, is_not_null);


### PR DESCRIPTION
The tests will fails because of:

- error: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Werror=unused-result]
- error: 'ret' may be used uninitialized in this function [-Werror=maybe-uninitialized]
