### PR TITLE
Change: Revert openvasd scan progress calculation

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -1006,26 +1006,7 @@ openvasd_get_scan_progress_ext (openvasd_connector_t conn,
       cJSON *host = scanning->child;
       while (host)
         {
-          int finished_tests, total_tests, single_host_progress;
-
-          if (!cJSON_IsObject (host))
-            {
-              progress = 0;
-              goto cleanup;
-            }
-
-          finished_tests = get_member_value_or_fail (host, "finished_tests");
-          total_tests = get_member_value_or_fail (host, "total_tests");
-
-          if (total_tests <= 0 || finished_tests < 0)
-            {
-              progress = 0;
-              goto cleanup;
-            }
-
-          single_host_progress = (100 * finished_tests / total_tests);
-
-          running_hosts_progress_sum += single_host_progress;
+          running_hosts_progress_sum += cJSON_GetNumberValue (host);
           host = host->next;
         }
     }


### PR DESCRIPTION
## What

This PR reverts the recent changes to the scan progress calculation logic in openvasd.

## Why

The previous implementation was inaccurate and always reported the scan progress as 0%.

## References

GEA-937



