### PR TITLE
Add: New data stream validation utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ if(BUILD_TESTS AND NOT SKIP_SRC)
     nvti-test
     osp-test
     passwordbasedauthentication-test
+    streamvalidator-test
     test-hosts
     util-test
     version-test

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -296,6 +296,15 @@ if(BUILD_TESTS)
     ${LINKER_HARDENING_FLAGS}
   )
   add_unit_test(
+    streamvalidator-test
+    streamvalidator_tests.c
+    gvm_util_shared
+    gvm_base_shared
+    ${GLIB_LDFLAGS}
+    ${GCRYPT_LDFLAGS}
+    ${LINKER_HARDENING_FLAGS}
+  )
+  add_unit_test(
     versionutils-test
     versionutils_tests.c
     ${GLIB_LDFLAGS}

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -135,6 +135,7 @@ set(
   radiusutils.c
   serverutils.c
   sshutils.c
+  streamvalidator.c
   uuidutils.c
   versionutils.c
   vtparser.c
@@ -158,6 +159,7 @@ set(
   radiusutils.h
   serverutils.h
   sshutils.h
+  streamvalidator.h
   uuidutils.h
   versionutils.h
   vtparser.h

--- a/util/streamvalidator.c
+++ b/util/streamvalidator.c
@@ -35,7 +35,7 @@ struct gvm_stream_validator
  * @param[in]  value    The value to get a string representation of.
  *
  * @return Static string describing the return value
- *          or NULL on success.
+ *          or NULL if value is GVM_STREAM_VALIDATOR_OK.
  */
 const char *
 gvm_stream_validator_return_str (gvm_stream_validator_return_t value)
@@ -153,6 +153,8 @@ gvm_stream_validator_rewind (gvm_stream_validator_t validator)
 
 /**
  * @brief Free a stream validator and all of its fields.
+ *
+ * @param[in]  validator  The validator to free.
  */
 void
 gvm_stream_validator_free (gvm_stream_validator_t validator)

--- a/util/streamvalidator.c
+++ b/util/streamvalidator.c
@@ -3,24 +3,27 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#include <assert.h>
-#include <glib.h>
-#include <gcrypt.h>
-#include "authutils.h"
 #include "streamvalidator.h"
 
+#include "authutils.h"
+
+#include <assert.h>
+#include <gcrypt.h>
+#include <glib.h>
+
 /**
- * @file 
+ * @file
  * @brief Data stream validation.
  */
 
 /**
  * @brief Data stream validator structure.
  */
-struct gvm_stream_validator {
+struct gvm_stream_validator
+{
   gchar *expected_hash_str;  ///< Expected hash algorithm and hex string.
   gchar *expected_hash_hex;  ///< Expected hash value as hexadecimal string.
-  int   algorithm;           ///< The hash algorithm used.
+  int algorithm;             ///< The hash algorithm used.
   size_t expected_size;      ///< Expected amount of data to validate.
   size_t current_size;       ///< Current total amount of data received.
   gcry_md_hd_t gcrypt_md_hd; ///< gcrypt message digest handle.
@@ -28,9 +31,9 @@ struct gvm_stream_validator {
 
 /**
  * @brief Gets a string representation of a gvm_stream_validator_return_t
- * 
+ *
  * @param[in]  value    The value to get a string representation of.
- * 
+ *
  * @return Static string describing the return value
  *          or NULL on success.
  */
@@ -39,24 +42,24 @@ gvm_stream_validator_return_str (gvm_stream_validator_return_t value)
 {
   switch (value)
     {
-      case GVM_STREAM_VALIDATOR_INTERNAL_ERROR:
-        return "internal error";
-      case GVM_STREAM_VALIDATOR_OK:
-        return NULL;
-      case GVM_STREAM_VALIDATOR_DATA_TOO_SHORT:
-        return "too short";
-      case GVM_STREAM_VALIDATOR_DATA_TOO_LONG:
-        return "too long";
-      case GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX:
-        return "invalid hash syntax";
-      case GVM_STREAM_VALIDATOR_INVALID_HASH_ALGORITHM:
-        return "invalid or unsupported hash algorithm";
-      case GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE:
-        return "invalid hash value";
-      case GVM_STREAM_VALIDATOR_HASH_MISMATCH:
-        return "hash does not match";
-      default:
-        return "unknown error";
+    case GVM_STREAM_VALIDATOR_INTERNAL_ERROR:
+      return "internal error";
+    case GVM_STREAM_VALIDATOR_OK:
+      return NULL;
+    case GVM_STREAM_VALIDATOR_DATA_TOO_SHORT:
+      return "too short";
+    case GVM_STREAM_VALIDATOR_DATA_TOO_LONG:
+      return "too long";
+    case GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX:
+      return "invalid hash syntax";
+    case GVM_STREAM_VALIDATOR_INVALID_HASH_ALGORITHM:
+      return "invalid or unsupported hash algorithm";
+    case GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE:
+      return "invalid hash value";
+    case GVM_STREAM_VALIDATOR_HASH_MISMATCH:
+      return "hash does not match";
+    default:
+      return "unknown error";
     }
 }
 
@@ -70,19 +73,18 @@ gvm_stream_validator_return_str (gvm_stream_validator_return_t value)
  *                                 e.g. "md5:70165459812a0d38851a4a4c3e4124c9".
  * @param[in]  expected_size  The number of bytes expected to be sent.
  * @param[out] validator_out  Pointer to output location of the newly allocated
- *                             validator. 
+ *                             validator.
  *
  * @return A validator return code, returning a failure if the expeced hash
  *         string is invalid or uses an unsupported algorithm.
  */
 gvm_stream_validator_return_t
-gvm_stream_validator_new (const char *expected_hash_str,
-                          size_t expected_size,
+gvm_stream_validator_new (const char *expected_hash_str, size_t expected_size,
                           gvm_stream_validator_t *validator_out)
 {
   assert (validator_out);
 
-  static GRegex* hex_regex = NULL;
+  static GRegex *hex_regex = NULL;
   gchar **split_hash_str = g_strsplit (expected_hash_str, ":", 2);
   const char *algo_str, *hex_str;
   int algo;
@@ -90,10 +92,8 @@ gvm_stream_validator_new (const char *expected_hash_str,
   gcry_md_hd_t gcrypt_md_hd;
 
   if (hex_regex == NULL)
-    hex_regex = g_regex_new ("^(?:[0-9A-Fa-f][0-9A-Fa-f])+$",
-                             G_REGEX_DEFAULT,
-                             G_REGEX_MATCH_DEFAULT,
-                             NULL);
+    hex_regex = g_regex_new ("^(?:[0-9A-Fa-f][0-9A-Fa-f])+$", G_REGEX_DEFAULT,
+                             G_REGEX_MATCH_DEFAULT, NULL);
 
   *validator_out = NULL;
   if (g_strv_length (split_hash_str) != 2)
@@ -141,7 +141,7 @@ gvm_stream_validator_new (const char *expected_hash_str,
 /**
  * @brief Rewind the validation state of a stream validator while keeping the
  *        expected hash and data size.
- * 
+ *
  * @param[in]  validator  The validator to rewind.
  */
 void
@@ -171,13 +171,13 @@ gvm_stream_validator_free (gvm_stream_validator_t validator)
  * @param[in]  validator  The validator to handle the data
  * @param[in]  data       The data to write.
  * @param[in]  length     Length of the data.
- * 
+ *
  * @return Validator return code, either a "success" or "too long".
  */
 gvm_stream_validator_return_t
-gvm_stream_validator_write (gvm_stream_validator_t validator,
-                            const char *data, size_t length)
-{   
+gvm_stream_validator_write (gvm_stream_validator_t validator, const char *data,
+                            size_t length)
+{
   if (length > validator->expected_size - validator->current_size)
     return GVM_STREAM_VALIDATOR_DATA_TOO_LONG;
 
@@ -190,9 +190,9 @@ gvm_stream_validator_write (gvm_stream_validator_t validator,
 /**
  * @brief Signal the end of data input into a validator and produce the result
  *        of the validation.
- * 
+ *
  * @param[in]  validator  The validator to signal the end of data input of.
- * 
+ *
  * @return The validation result.
  */
 gvm_stream_validator_return_t
@@ -203,20 +203,19 @@ gvm_stream_validator_end (gvm_stream_validator_t validator)
 
   if (validator->current_size < validator->expected_size)
     return GVM_STREAM_VALIDATOR_DATA_TOO_SHORT;
-  
+
   if (validator->current_size > validator->expected_size)
     return GVM_STREAM_VALIDATOR_DATA_TOO_LONG;
-  
-  actual_hash_bin = gcry_md_read (validator->gcrypt_md_hd,
-                                  validator->algorithm);
-  actual_hash_hex = digest_hex (validator->algorithm,
-                                actual_hash_bin);
+
+  actual_hash_bin =
+    gcry_md_read (validator->gcrypt_md_hd, validator->algorithm);
+  actual_hash_hex = digest_hex (validator->algorithm, actual_hash_bin);
   if (strcasecmp (validator->expected_hash_hex, actual_hash_hex))
     {
       g_free (actual_hash_hex);
       return GVM_STREAM_VALIDATOR_HASH_MISMATCH;
     }
   g_free (actual_hash_hex);
-  
+
   return GVM_STREAM_VALIDATOR_OK;
 }

--- a/util/streamvalidator.c
+++ b/util/streamvalidator.c
@@ -1,0 +1,222 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <assert.h>
+#include <glib.h>
+#include <gcrypt.h>
+#include "authutils.h"
+#include "streamvalidator.h"
+
+/**
+ * @file 
+ * @brief Data stream validation.
+ */
+
+/**
+ * @brief Data stream validator structure.
+ */
+struct gvm_stream_validator {
+  gchar *expected_hash_str;  ///< Expected hash algorithm and hex string.
+  gchar *expected_hash_hex;  ///< Expected hash value as hexadecimal string.
+  int   algorithm;           ///< The hash algorithm used.
+  size_t expected_size;      ///< Expected amount of data to validate.
+  size_t current_size;       ///< Current total amount of data received.
+  gcry_md_hd_t gcrypt_md_hd; ///< gcrypt message digest handle.
+};
+
+/**
+ * @brief Gets a string representation of a gvm_stream_validator_return_t
+ * 
+ * @param[in]  value    The value to get a string representation of.
+ * 
+ * @return Static string describing the return value
+ *          or NULL on success.
+ */
+const char *
+gvm_stream_validator_return_str (gvm_stream_validator_return_t value)
+{
+  switch (value)
+    {
+      case GVM_STREAM_VALIDATOR_INTERNAL_ERROR:
+        return "internal error";
+      case GVM_STREAM_VALIDATOR_OK:
+        return NULL;
+      case GVM_STREAM_VALIDATOR_DATA_TOO_SHORT:
+        return "too short";
+      case GVM_STREAM_VALIDATOR_DATA_TOO_LONG:
+        return "too long";
+      case GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX:
+        return "invalid hash syntax";
+      case GVM_STREAM_VALIDATOR_INVALID_HASH_ALGORITHM:
+        return "invalid or unsupported hash algorithm";
+      case GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE:
+        return "invalid hash value";
+      case GVM_STREAM_VALIDATOR_HASH_MISMATCH:
+        return "hash does not match";
+      default:
+        return "unknown error";
+    }
+}
+
+/**
+ * @brief Allocate and initialize a new data stream validator.
+ *
+ * @param[in]  expected_hash_str  Expected hash / checksum string consisting of
+ *                                 an algorithm name or OID as recognized by
+ *                                 gcrypt, followed by a colon and the
+ *                                 hex-encoded hash,
+ *                                 e.g. "md5:70165459812a0d38851a4a4c3e4124c9".
+ * @param[in]  expected_size  The number of bytes expected to be sent.
+ * @param[out] validator_out  Pointer to output location of the newly allocated
+ *                             validator. 
+ *
+ * @return A validator return code, returning a failure if the expeced hash
+ *         string is invalid or uses an unsupported algorithm.
+ */
+gvm_stream_validator_return_t
+gvm_stream_validator_new (const char *expected_hash_str,
+                          size_t expected_size,
+                          gvm_stream_validator_t *validator_out)
+{
+  assert (validator_out);
+
+  static GRegex* hex_regex = NULL;
+  gchar **split_hash_str = g_strsplit (expected_hash_str, ":", 2);
+  const char *algo_str, *hex_str;
+  int algo;
+  unsigned int expected_hex_len;
+  gcry_md_hd_t gcrypt_md_hd;
+
+  if (hex_regex == NULL)
+    hex_regex = g_regex_new ("^(?:[0-9A-Fa-f][0-9A-Fa-f])+$",
+                             G_REGEX_DEFAULT,
+                             G_REGEX_MATCH_DEFAULT,
+                             NULL);
+
+  *validator_out = NULL;
+  if (g_strv_length (split_hash_str) != 2)
+    {
+      g_strfreev (split_hash_str);
+      return GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX;
+    }
+  algo_str = split_hash_str[0];
+  hex_str = split_hash_str[1];
+
+  algo = gcry_md_map_name (algo_str);
+  if (algo == GCRY_MD_NONE || gcry_md_test_algo (algo))
+    {
+      g_strfreev (split_hash_str);
+      return GVM_STREAM_VALIDATOR_INVALID_HASH_ALGORITHM;
+    }
+
+  expected_hex_len = gcry_md_get_algo_dlen (algo) * 2;
+  if (strlen (hex_str) != expected_hex_len
+      || g_regex_match (hex_regex, hex_str, 0, NULL) == FALSE)
+    {
+      g_strfreev (split_hash_str);
+      return GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE;
+    }
+
+  gcrypt_md_hd = NULL;
+  if (gcry_md_open (&gcrypt_md_hd, algo, 0))
+    {
+      g_strfreev (split_hash_str);
+      return GVM_STREAM_VALIDATOR_INTERNAL_ERROR;
+    }
+
+  *validator_out = g_malloc0 (sizeof (struct gvm_stream_validator));
+  (*validator_out)->algorithm = algo;
+  (*validator_out)->expected_size = expected_size;
+  (*validator_out)->expected_hash_str = g_strdup (expected_hash_str);
+  (*validator_out)->expected_hash_hex = g_strdup (hex_str);
+  (*validator_out)->gcrypt_md_hd = gcrypt_md_hd;
+
+  g_strfreev (split_hash_str);
+
+  return GVM_STREAM_VALIDATOR_OK;
+}
+
+/**
+ * @brief Rewind the validation state of a stream validator while keeping the
+ *        expected hash and data size.
+ * 
+ * @param[in]  validator  The validator to rewind.
+ */
+void
+gvm_stream_validator_rewind (gvm_stream_validator_t validator)
+{
+  gcry_md_reset (validator->gcrypt_md_hd);
+  validator->current_size = 0;
+}
+
+/**
+ * @brief Free a stream validator and all of its fields.
+ */
+void
+gvm_stream_validator_free (gvm_stream_validator_t validator)
+{
+  gcry_md_close (validator->gcrypt_md_hd);
+  g_free (validator->expected_hash_str);
+  g_free (validator->expected_hash_hex);
+  g_free (validator);
+}
+
+/**
+ * @brief Write data to a validator, updating the hash state and current size.
+ *
+ * Will fail if the total data size exceeds the expected size.
+ *
+ * @param[in]  validator  The validator to handle the data
+ * @param[in]  data       The data to write.
+ * @param[in]  length     Length of the data.
+ * 
+ * @return Validator return code, either a "success" or "too long".
+ */
+gvm_stream_validator_return_t
+gvm_stream_validator_write (gvm_stream_validator_t validator,
+                            const char *data, size_t length)
+{   
+  if (length > validator->expected_size - validator->current_size)
+    return GVM_STREAM_VALIDATOR_DATA_TOO_LONG;
+
+  gcry_md_write (validator->gcrypt_md_hd, data, length);
+  validator->current_size += length;
+
+  return GVM_STREAM_VALIDATOR_OK;
+}
+
+/**
+ * @brief Signal the end of data input into a validator and produce the result
+ *        of the validation.
+ * 
+ * @param[in]  validator  The validator to signal the end of data input of.
+ * 
+ * @return The validation result.
+ */
+gvm_stream_validator_return_t
+gvm_stream_validator_end (gvm_stream_validator_t validator)
+{
+  unsigned char *actual_hash_bin;
+  gchar *actual_hash_hex;
+
+  if (validator->current_size < validator->expected_size)
+    return GVM_STREAM_VALIDATOR_DATA_TOO_SHORT;
+  
+  if (validator->current_size > validator->expected_size)
+    return GVM_STREAM_VALIDATOR_DATA_TOO_LONG;
+  
+  actual_hash_bin = gcry_md_read (validator->gcrypt_md_hd,
+                                  validator->algorithm);
+  actual_hash_hex = digest_hex (validator->algorithm,
+                                actual_hash_bin);
+  if (strcasecmp (validator->expected_hash_hex, actual_hash_hex))
+    {
+      g_free (actual_hash_hex);
+      return GVM_STREAM_VALIDATOR_HASH_MISMATCH;
+    }
+  g_free (actual_hash_hex);
+  
+  return GVM_STREAM_VALIDATOR_OK;
+}

--- a/util/streamvalidator.h
+++ b/util/streamvalidator.h
@@ -1,0 +1,59 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef _GVM_STREAMVALIDATOR_H
+#define _GVM_STREAMVALIDATOR_H
+
+#include <stdio.h>
+
+/**
+ * @file
+ * @brief Data stream validation headers.
+ */
+
+typedef enum {
+  /** An internal error ocurred. */
+  GVM_STREAM_VALIDATOR_INTERNAL_ERROR = -1,
+  /** Action successful / data is valid. */
+  GVM_STREAM_VALIDATOR_OK = 0,
+  /** Not enough data received. */
+  GVM_STREAM_VALIDATOR_DATA_TOO_SHORT = 1,
+  /** Too much data received. */
+  GVM_STREAM_VALIDATOR_DATA_TOO_LONG,
+  /** Syntax error in hash string (not using "algo:hex" format). */
+  GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX,
+  /** Invalid or unsupported hash algorithm. */
+  GVM_STREAM_VALIDATOR_INVALID_HASH_ALGORITHM,
+  /** Hash value is not valid.
+   *  (e.g. not hexadecimal or length does not match algorithm) */
+  GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE,
+  /** Hash of received data does not match the expected hash */
+  GVM_STREAM_VALIDATOR_HASH_MISMATCH
+} gvm_stream_validator_return_t;
+
+/**
+ * @brief Pointer to an opaque stream validator data structure.
+ */
+typedef struct gvm_stream_validator* gvm_stream_validator_t;
+
+const char *
+gvm_stream_validator_return_str (gvm_stream_validator_return_t);
+
+gvm_stream_validator_return_t
+gvm_stream_validator_new (const char *, size_t, gvm_stream_validator_t*);
+
+void
+gvm_stream_validator_rewind (gvm_stream_validator_t);
+
+void
+gvm_stream_validator_free (gvm_stream_validator_t);
+
+gvm_stream_validator_return_t
+gvm_stream_validator_write (gvm_stream_validator_t, const char *, size_t);
+
+gvm_stream_validator_return_t
+gvm_stream_validator_end (gvm_stream_validator_t);
+
+#endif /* not _GVM_STREAMVALIDATOR_H */

--- a/util/streamvalidator.h
+++ b/util/streamvalidator.h
@@ -13,7 +13,8 @@
  * @brief Data stream validation headers.
  */
 
-typedef enum {
+typedef enum
+{
   /** An internal error ocurred. */
   GVM_STREAM_VALIDATOR_INTERNAL_ERROR = -1,
   /** Action successful / data is valid. */
@@ -36,24 +37,20 @@ typedef enum {
 /**
  * @brief Pointer to an opaque stream validator data structure.
  */
-typedef struct gvm_stream_validator* gvm_stream_validator_t;
+typedef struct gvm_stream_validator *gvm_stream_validator_t;
 
-const char *
-gvm_stream_validator_return_str (gvm_stream_validator_return_t);
+const char *gvm_stream_validator_return_str (gvm_stream_validator_return_t);
 
 gvm_stream_validator_return_t
-gvm_stream_validator_new (const char *, size_t, gvm_stream_validator_t*);
+gvm_stream_validator_new (const char *, size_t, gvm_stream_validator_t *);
 
-void
-gvm_stream_validator_rewind (gvm_stream_validator_t);
+void gvm_stream_validator_rewind (gvm_stream_validator_t);
 
-void
-gvm_stream_validator_free (gvm_stream_validator_t);
+void gvm_stream_validator_free (gvm_stream_validator_t);
 
 gvm_stream_validator_return_t
 gvm_stream_validator_write (gvm_stream_validator_t, const char *, size_t);
 
-gvm_stream_validator_return_t
-gvm_stream_validator_end (gvm_stream_validator_t);
+gvm_stream_validator_return_t gvm_stream_validator_end (gvm_stream_validator_t);
 
 #endif /* not _GVM_STREAMVALIDATOR_H */

--- a/util/streamvalidator_tests.c
+++ b/util/streamvalidator_tests.c
@@ -8,10 +8,10 @@
 #include <cgreen/cgreen.h>
 #include <cgreen/mocks.h>
 
-#define VALID_DATA      "This should be valid...."
-#define TOO_SHORT_DATA  "This is too short!"
-#define TOO_LONG_DATA   "This text is longer than expected!"
-#define INVALID_DATA    "This should'nt be valid!"
+#define VALID_DATA "This should be valid...."
+#define TOO_SHORT_DATA "This is too short!"
+#define TOO_LONG_DATA "This text is longer than expected!"
+#define INVALID_DATA "This should'nt be valid!"
 #define VALID_DATA_HASH "md5:36e8e66096b6d7f4d848ef2eb7b2ae4d"
 
 Describe (streamvalidator);
@@ -26,16 +26,13 @@ Ensure (streamvalidator, accepts_valid_data)
 {
   gvm_stream_validator_t validator = NULL;
 
-  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
-                                          strlen (VALID_DATA),
-                                          &validator),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            VALID_DATA,
-                                            strlen (VALID_DATA)),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_end (validator),
-                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (
+    gvm_stream_validator_new (VALID_DATA_HASH, strlen (VALID_DATA), &validator),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (
+    gvm_stream_validator_write (validator, VALID_DATA, strlen (VALID_DATA)),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator), GVM_STREAM_VALIDATOR_OK);
 
   gvm_stream_validator_free (validator);
 }
@@ -44,24 +41,17 @@ Ensure (streamvalidator, accepts_valid_data_after_multiple_writes)
 {
   gvm_stream_validator_t validator = NULL;
 
-  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
-                                          strlen (VALID_DATA),
-                                          &validator),
+  assert_equal (
+    gvm_stream_validator_new (VALID_DATA_HASH, strlen (VALID_DATA), &validator),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator, VALID_DATA, 5),
                 GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            VALID_DATA,
-                                            5),
+  assert_equal (gvm_stream_validator_write (validator, VALID_DATA + 5, 5),
                 GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            VALID_DATA + 5,
-                                            5),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            VALID_DATA + 10,
+  assert_equal (gvm_stream_validator_write (validator, VALID_DATA + 10,
                                             strlen (VALID_DATA) - 10),
                 GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_end (validator),
-                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator), GVM_STREAM_VALIDATOR_OK);
 
   gvm_stream_validator_free (validator);
 }
@@ -70,21 +60,17 @@ Ensure (streamvalidator, accepts_valid_data_after_rewind)
 {
   gvm_stream_validator_t validator = NULL;
 
-  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
-                                          strlen (VALID_DATA),
-                                          &validator),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            TOO_SHORT_DATA,
+  assert_equal (
+    gvm_stream_validator_new (VALID_DATA_HASH, strlen (VALID_DATA), &validator),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator, TOO_SHORT_DATA,
                                             strlen (TOO_SHORT_DATA)),
                 GVM_STREAM_VALIDATOR_OK);
   gvm_stream_validator_rewind (validator);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            VALID_DATA,
-                                            strlen (VALID_DATA)),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_end (validator),
-                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (
+    gvm_stream_validator_write (validator, VALID_DATA, strlen (VALID_DATA)),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator), GVM_STREAM_VALIDATOR_OK);
 
   gvm_stream_validator_free (validator);
 }
@@ -93,12 +79,10 @@ Ensure (streamvalidator, rejects_too_long_data)
 {
   gvm_stream_validator_t validator = NULL;
 
-  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
-                                          strlen (VALID_DATA),
-                                          &validator),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            TOO_LONG_DATA,
+  assert_equal (
+    gvm_stream_validator_new (VALID_DATA_HASH, strlen (VALID_DATA), &validator),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator, TOO_LONG_DATA,
                                             strlen (TOO_LONG_DATA)),
                 GVM_STREAM_VALIDATOR_DATA_TOO_LONG);
   assert_not_equal (gvm_stream_validator_end (validator),
@@ -111,12 +95,10 @@ Ensure (streamvalidator, rejects_too_short_data)
 {
   gvm_stream_validator_t validator = NULL;
 
-  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
-                                          strlen (VALID_DATA),
-                                          &validator),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            TOO_SHORT_DATA,
+  assert_equal (
+    gvm_stream_validator_new (VALID_DATA_HASH, strlen (VALID_DATA), &validator),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator, TOO_SHORT_DATA,
                                             strlen (TOO_SHORT_DATA)),
                 GVM_STREAM_VALIDATOR_OK);
   assert_equal (gvm_stream_validator_end (validator),
@@ -129,14 +111,12 @@ Ensure (streamvalidator, rejects_hash_mismatch)
 {
   gvm_stream_validator_t validator = NULL;
 
-  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
-                                          strlen (VALID_DATA),
-                                          &validator),
-                GVM_STREAM_VALIDATOR_OK);
-  assert_equal (gvm_stream_validator_write (validator,
-                                            INVALID_DATA,
-                                            strlen (INVALID_DATA)),
-                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (
+    gvm_stream_validator_new (VALID_DATA_HASH, strlen (VALID_DATA), &validator),
+    GVM_STREAM_VALIDATOR_OK);
+  assert_equal (
+    gvm_stream_validator_write (validator, INVALID_DATA, strlen (INVALID_DATA)),
+    GVM_STREAM_VALIDATOR_OK);
   assert_equal (gvm_stream_validator_end (validator),
                 GVM_STREAM_VALIDATOR_HASH_MISMATCH);
 
@@ -205,23 +185,18 @@ main (int argc, char **argv)
   TestSuite *suite;
 
   suite = create_test_suite ();
-  
-  add_test_with_context (suite, streamvalidator,
-                         accepts_valid_data);
+
+  add_test_with_context (suite, streamvalidator, accepts_valid_data);
   add_test_with_context (suite, streamvalidator,
                          accepts_valid_data_after_multiple_writes);
   add_test_with_context (suite, streamvalidator,
                          accepts_valid_data_after_rewind);
 
-  add_test_with_context (suite, streamvalidator,
-                         rejects_too_long_data);
-  add_test_with_context (suite, streamvalidator,
-                         rejects_too_short_data);
-  add_test_with_context (suite, streamvalidator,
-                         rejects_hash_mismatch);
+  add_test_with_context (suite, streamvalidator, rejects_too_long_data);
+  add_test_with_context (suite, streamvalidator, rejects_too_short_data);
+  add_test_with_context (suite, streamvalidator, rejects_hash_mismatch);
 
-  add_test_with_context (suite, streamvalidator,
-                         init_rejects_empty_hash);
+  add_test_with_context (suite, streamvalidator, init_rejects_empty_hash);
   add_test_with_context (suite, streamvalidator,
                          init_rejects_invalid_syntax_hashes);
   add_test_with_context (suite, streamvalidator,

--- a/util/streamvalidator_tests.c
+++ b/util/streamvalidator_tests.c
@@ -1,0 +1,234 @@
+/* SPDX-FileCopyrightText: 2019-2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "streamvalidator.h"
+
+#include <cgreen/cgreen.h>
+#include <cgreen/mocks.h>
+
+#define VALID_DATA      "This should be valid...."
+#define TOO_SHORT_DATA  "This is too short!"
+#define TOO_LONG_DATA   "This text is longer than expected!"
+#define INVALID_DATA    "This should'nt be valid!"
+#define VALID_DATA_HASH "md5:36e8e66096b6d7f4d848ef2eb7b2ae4d"
+
+Describe (streamvalidator);
+BeforeEach (streamvalidator)
+{
+}
+AfterEach (streamvalidator)
+{
+}
+
+Ensure (streamvalidator, accepts_valid_data)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
+                                          strlen (VALID_DATA),
+                                          &validator),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            VALID_DATA,
+                                            strlen (VALID_DATA)),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator),
+                GVM_STREAM_VALIDATOR_OK);
+
+  gvm_stream_validator_free (validator);
+}
+
+Ensure (streamvalidator, accepts_valid_data_after_multiple_writes)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
+                                          strlen (VALID_DATA),
+                                          &validator),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            VALID_DATA,
+                                            5),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            VALID_DATA + 5,
+                                            5),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            VALID_DATA + 10,
+                                            strlen (VALID_DATA) - 10),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator),
+                GVM_STREAM_VALIDATOR_OK);
+
+  gvm_stream_validator_free (validator);
+}
+
+Ensure (streamvalidator, accepts_valid_data_after_rewind)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
+                                          strlen (VALID_DATA),
+                                          &validator),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            TOO_SHORT_DATA,
+                                            strlen (TOO_SHORT_DATA)),
+                GVM_STREAM_VALIDATOR_OK);
+  gvm_stream_validator_rewind (validator);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            VALID_DATA,
+                                            strlen (VALID_DATA)),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator),
+                GVM_STREAM_VALIDATOR_OK);
+
+  gvm_stream_validator_free (validator);
+}
+
+Ensure (streamvalidator, rejects_too_long_data)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
+                                          strlen (VALID_DATA),
+                                          &validator),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            TOO_LONG_DATA,
+                                            strlen (TOO_LONG_DATA)),
+                GVM_STREAM_VALIDATOR_DATA_TOO_LONG);
+  assert_not_equal (gvm_stream_validator_end (validator),
+                    GVM_STREAM_VALIDATOR_OK);
+
+  gvm_stream_validator_free (validator);
+}
+
+Ensure (streamvalidator, rejects_too_short_data)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
+                                          strlen (VALID_DATA),
+                                          &validator),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            TOO_SHORT_DATA,
+                                            strlen (TOO_SHORT_DATA)),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator),
+                GVM_STREAM_VALIDATOR_DATA_TOO_SHORT);
+
+  gvm_stream_validator_free (validator);
+}
+
+Ensure (streamvalidator, rejects_hash_mismatch)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new (VALID_DATA_HASH,
+                                          strlen (VALID_DATA),
+                                          &validator),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_write (validator,
+                                            INVALID_DATA,
+                                            strlen (INVALID_DATA)),
+                GVM_STREAM_VALIDATOR_OK);
+  assert_equal (gvm_stream_validator_end (validator),
+                GVM_STREAM_VALIDATOR_HASH_MISMATCH);
+
+  gvm_stream_validator_free (validator);
+}
+
+Ensure (streamvalidator, init_rejects_empty_hash)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new ("", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX);
+  assert_equal (validator, NULL);
+}
+
+Ensure (streamvalidator, init_rejects_invalid_syntax_hashes)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new ("0123", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX);
+  assert_equal (validator, NULL);
+
+  assert_equal (gvm_stream_validator_new ("sha256", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_SYNTAX);
+  assert_equal (validator, NULL);
+}
+
+Ensure (streamvalidator, init_rejects_invalid_algo_hashes)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new (":0123", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_ALGORITHM);
+  assert_equal (validator, NULL);
+
+  assert_equal (gvm_stream_validator_new ("xyz:0123", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_ALGORITHM);
+  assert_equal (validator, NULL);
+}
+
+Ensure (streamvalidator, init_rejects_invalid_value_hashes)
+{
+  gvm_stream_validator_t validator = NULL;
+
+  assert_equal (gvm_stream_validator_new ("md5:", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
+  assert_equal (validator, NULL);
+
+  assert_equal (gvm_stream_validator_new ("md5:xyz", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
+  assert_equal (validator, NULL);
+
+  assert_equal (gvm_stream_validator_new ("md5:123", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
+  assert_equal (validator, NULL);
+
+  assert_equal (gvm_stream_validator_new ("md5:0123ab", 123, &validator),
+                GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
+  assert_equal (validator, NULL);
+}
+
+int
+main (int argc, char **argv)
+{
+  TestSuite *suite;
+
+  suite = create_test_suite ();
+  
+  add_test_with_context (suite, streamvalidator,
+                         accepts_valid_data);
+  add_test_with_context (suite, streamvalidator,
+                         accepts_valid_data_after_multiple_writes);
+  add_test_with_context (suite, streamvalidator,
+                         accepts_valid_data_after_rewind);
+
+  add_test_with_context (suite, streamvalidator,
+                         rejects_too_long_data);
+  add_test_with_context (suite, streamvalidator,
+                         rejects_too_short_data);
+  add_test_with_context (suite, streamvalidator,
+                         rejects_hash_mismatch);
+
+  add_test_with_context (suite, streamvalidator,
+                         init_rejects_empty_hash);
+  add_test_with_context (suite, streamvalidator,
+                         init_rejects_invalid_syntax_hashes);
+  add_test_with_context (suite, streamvalidator,
+                         init_rejects_invalid_algo_hashes);
+  add_test_with_context (suite, streamvalidator,
+                         init_rejects_invalid_value_hashes);
+  if (argc > 1)
+    return run_single_test (suite, argv[1], create_text_reporter ());
+  return run_test_suite (suite, create_text_reporter ());
+}

--- a/util/streamvalidator_tests.c
+++ b/util/streamvalidator_tests.c
@@ -11,8 +11,9 @@
 #define VALID_DATA "This should be valid...."
 #define TOO_SHORT_DATA "This is too short!"
 #define TOO_LONG_DATA "This text is longer than expected!"
-#define INVALID_DATA "This should'nt be valid!"
-#define VALID_DATA_HASH "md5:36e8e66096b6d7f4d848ef2eb7b2ae4d"
+#define INVALID_DATA "This shouldn't be valid!"
+#define VALID_DATA_HASH \
+  "sha256:4ae8f10c9e9551173520b7a675e9caba163007edf04dbbd06022bf61ad3fe4fb"
 
 Describe (streamvalidator);
 BeforeEach (streamvalidator)
@@ -162,19 +163,19 @@ Ensure (streamvalidator, init_rejects_invalid_value_hashes)
 {
   gvm_stream_validator_t validator = NULL;
 
-  assert_equal (gvm_stream_validator_new ("md5:", 123, &validator),
+  assert_equal (gvm_stream_validator_new ("sha256:", 123, &validator),
                 GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
   assert_equal (validator, NULL);
 
-  assert_equal (gvm_stream_validator_new ("md5:xyz", 123, &validator),
+  assert_equal (gvm_stream_validator_new ("sha256:xyz", 123, &validator),
                 GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
   assert_equal (validator, NULL);
 
-  assert_equal (gvm_stream_validator_new ("md5:123", 123, &validator),
+  assert_equal (gvm_stream_validator_new ("sha256:123", 123, &validator),
                 GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
   assert_equal (validator, NULL);
 
-  assert_equal (gvm_stream_validator_new ("md5:0123ab", 123, &validator),
+  assert_equal (gvm_stream_validator_new ("sha256:0123ab", 123, &validator),
                 GVM_STREAM_VALIDATOR_INVALID_HASH_VALUE);
   assert_equal (validator, NULL);
 }


### PR DESCRIPTION
## What
New utility functions have been added to allow validating the size and checksum / hash of contents of a data stream like a file being read.

## Why
This is to be used for validating the integrity of agent installer files.

## References
GEA-963

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


