### PR TITLE
Fix: close leaks in jsonpull

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -216,6 +216,12 @@ endif(BUILD_SHARED)
 if(BUILD_TESTS)
   add_unit_test(json-test json_tests.c ${GLIB_LDFLAGS} ${CJSON_LDFLAGS})
   add_unit_test(jsonpull-test jsonpull_tests.c ${GLIB_LDFLAGS} ${CJSON_LDFLAGS})
+  target_compile_options(jsonpull-test PRIVATE "-fsanitize=address")
+  target_link_options(jsonpull-test PRIVATE "-fsanitize=address")
+  set_tests_properties(
+    jsonpull-test PROPERTIES
+    ENVIRONMENT "ASAN_OPTIONS=halt_on_error=1:abort_on_error=1"
+  )
   add_unit_test(
     passwordbasedauthentication-test
     passwordbasedauthentication_tests.c

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -219,8 +219,8 @@ if(BUILD_TESTS)
   target_compile_options(jsonpull-test PRIVATE "-fsanitize=address")
   target_link_options(jsonpull-test PRIVATE "-fsanitize=address")
   set_tests_properties(
-    jsonpull-test PROPERTIES
-    ENVIRONMENT "ASAN_OPTIONS=halt_on_error=1:abort_on_error=1"
+    jsonpull-test
+    PROPERTIES ENVIRONMENT "ASAN_OPTIONS=halt_on_error=1:abort_on_error=1"
   )
   add_unit_test(
     passwordbasedauthentication-test

--- a/util/jsonpull.c
+++ b/util/jsonpull.c
@@ -695,20 +695,22 @@ gvm_json_pull_parser_next (gvm_json_pull_parser_t *parser,
   // Check for expected end of file
   if (parser->expect == GVM_JSON_PULL_EXPECT_EOF)
     {
-      gvm_json_pull_skip_space (parser, event, TRUE);
-
-      if (parser->last_read_char == GVM_JSON_CHAR_ERROR)
+      if (gvm_json_pull_skip_space (parser, event, TRUE))
         {
-          event->type = GVM_JSON_PULL_EVENT_ERROR;
-          event->error_message = gvm_json_read_stream_error_str ();
-        }
-      else if (parser->last_read_char != GVM_JSON_CHAR_EOF)
-        {
-          event->type = GVM_JSON_PULL_EVENT_ERROR;
-          event->error_message = g_strdup_printf (
-            "unexpected character at end of file (%d)", parser->last_read_char);
+          // EOF was reached, or an error occurred.
+          // The event type is already set, and if an error occurred, then
+          // error_message is also already set.
           return;
         }
+
+      // Skipping space succeeded. Check for unexpected characters at EOF.
+
+      if (parser->last_read_char == GVM_JSON_CHAR_EOF)
+        return;
+
+      event->type = GVM_JSON_PULL_EVENT_ERROR;
+      event->error_message = g_strdup_printf (
+        "unexpected character at end of file (%d)", parser->last_read_char);
       return;
     }
 

--- a/util/jsonpull.c
+++ b/util/jsonpull.c
@@ -60,7 +60,7 @@ gvm_json_pull_event_init (gvm_json_pull_event_t *event)
 void
 gvm_json_pull_event_cleanup (gvm_json_pull_event_t *event)
 {
-  cJSON_free (event->value);
+  cJSON_Delete (event->value);
   if (event->error_message)
     g_free (event->error_message);
   memset (event, 0, sizeof (gvm_json_pull_event_t));
@@ -439,7 +439,7 @@ gvm_json_pull_parse_key (gvm_json_pull_parser_t *parser,
       if (gvm_json_pull_parse_string (parser, event, &key_cjson))
         return 1;
       key_str = g_strdup (key_cjson->valuestring);
-      cJSON_free (key_cjson);
+      cJSON_Delete (key_cjson);
 
       // Expect colon:
       if (gvm_json_pull_skip_space (parser, event, FALSE))
@@ -830,6 +830,8 @@ gvm_json_pull_expand_container (gvm_json_pull_parser_t *parser,
                 }
               if (path_tail->depth == start_depth)
                 in_expanded_container = FALSE;
+
+              gvm_json_pull_path_elem_free (path_tail);
               break;
             case '}':
               path_tail = g_queue_pop_tail (parser->path);
@@ -842,6 +844,8 @@ gvm_json_pull_expand_container (gvm_json_pull_parser_t *parser,
                 }
               if (path_tail->depth == start_depth)
                 in_expanded_container = FALSE;
+
+              gvm_json_pull_path_elem_free (path_tail);
               break;
             }
         }

--- a/util/jsonpull.c
+++ b/util/jsonpull.c
@@ -826,6 +826,7 @@ gvm_json_pull_expand_container (gvm_json_pull_parser_t *parser,
                   if (error_message)
                     *error_message =
                       g_strdup ("unexpected closing square bracket");
+                  gvm_json_pull_path_elem_free (path_tail);
                   return NULL;
                 }
               if (path_tail->depth == start_depth)
@@ -840,6 +841,7 @@ gvm_json_pull_expand_container (gvm_json_pull_parser_t *parser,
                   if (error_message)
                     *error_message =
                       g_strdup ("unexpected closing curly brace");
+                  gvm_json_pull_path_elem_free (path_tail);
                   return NULL;
                 }
               if (path_tail->depth == start_depth)

--- a/util/jsonpull_tests.c
+++ b/util/jsonpull_tests.c
@@ -1110,6 +1110,7 @@ Ensure (jsonpull, fails_for_expand_read_error)
 int
 main (int argc, char **argv)
 {
+  int ret;
   TestSuite *suite;
 
   suite = create_test_suite ();
@@ -1200,6 +1201,10 @@ main (int argc, char **argv)
   add_test_with_context (suite, jsonpull, fails_for_expand_eof);
 
   if (argc > 1)
-    return run_single_test (suite, argv[1], create_text_reporter ());
-  return run_test_suite (suite, create_text_reporter ());
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  ret = run_test_suite (suite, create_text_reporter ());
+
+  destroy_test_suite (suite);
+
+  return ret;
 }

--- a/util/jsonpull_tests.c
+++ b/util/jsonpull_tests.c
@@ -984,6 +984,7 @@ Ensure (jsonpull, fails_for_expand_before_container)
   assert_that (error_message, is_equal_to_string ("can only expand after"
                                                   " array or object start"));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 
@@ -1003,6 +1004,7 @@ Ensure (jsonpull, fails_for_expand_after_value)
   assert_that (error_message, is_equal_to_string ("can only expand after"
                                                   " array or object start"));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 
@@ -1020,6 +1022,7 @@ Ensure (jsonpull, fails_for_expand_invalid_content)
   assert_that (error_message,
                is_equal_to_string ("could not parse expanded container"));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 
@@ -1038,6 +1041,7 @@ Ensure (jsonpull, fails_for_expand_overlong)
   assert_that (error_message,
                is_equal_to_string ("container exceeds size limit of 10 bytes"));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 
@@ -1055,6 +1059,7 @@ Ensure (jsonpull, fails_for_expand_unexpected_curly_brace)
   assert_that (error_message,
                is_equal_to_string ("unexpected closing curly brace"));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 
@@ -1072,6 +1077,7 @@ Ensure (jsonpull, fails_for_expand_unexpected_square_bracket)
   assert_that (error_message,
                is_equal_to_string ("unexpected closing square bracket"));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 
@@ -1088,6 +1094,7 @@ Ensure (jsonpull, fails_for_expand_eof)
   assert_that (cjson_value, is_null);
   assert_that (error_message, is_equal_to_string ("unexpected EOF"));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 
@@ -1104,6 +1111,7 @@ Ensure (jsonpull, fails_for_expand_read_error)
   assert_that (cjson_value, is_null);
   assert_that (error_message, is_equal_to_string (JSON_READ_ERROR));
 
+  g_free (error_message);
   CLEANUP_JSON_PARSER;
 }
 

--- a/util/jsonpull_tests.c
+++ b/util/jsonpull_tests.c
@@ -401,7 +401,7 @@ Ensure (jsonpull, can_expand_arrays)
   assert_that (expanded, is_not_null);
   assert_that (cJSON_IsArray (expanded), is_true);
   assert_that (expanded->child, is_null);
-  cJSON_free (expanded);
+  cJSON_Delete (expanded);
 
   // single-element array
   gvm_json_pull_parser_next (&parser, &event);
@@ -417,7 +417,7 @@ Ensure (jsonpull, can_expand_arrays)
   assert_that (child->valueint, is_equal_to (1));
   child = child->next;
   assert_that (child, is_null);
-  cJSON_free (expanded);
+  cJSON_Delete (expanded);
 
   // multi-element array
   gvm_json_pull_parser_next (&parser, &event);
@@ -435,7 +435,7 @@ Ensure (jsonpull, can_expand_arrays)
   assert_that (child, is_not_null);
   assert_that (cJSON_IsArray (child), is_true);
   assert_that (child->child->valueint, is_equal_to (3));
-  cJSON_free (expanded);
+  cJSON_Delete (expanded);
 
   // string array
   gvm_json_pull_parser_next (&parser, &event);
@@ -453,7 +453,7 @@ Ensure (jsonpull, can_expand_arrays)
   assert_that (child, is_not_null);
   assert_that (cJSON_IsString (child), is_true);
   assert_that (child->valuestring, is_equal_to_string ("\"B]"));
-  cJSON_free (expanded);
+  cJSON_Delete (expanded);
 
   // array end and EOF
   gvm_json_pull_parser_next (&parser, &event);
@@ -483,7 +483,7 @@ Ensure (jsonpull, can_expand_objects)
   assert_that (error_message, is_null);
   assert_that (cJSON_IsObject (expanded), is_true);
   assert_that (expanded->child, is_null);
-  cJSON_free (expanded);
+  cJSON_Delete (expanded);
 
   gvm_json_pull_parser_next (&parser, &event);
   assert_that (event.type, is_equal_to (GVM_JSON_PULL_EVENT_OBJECT_START));
@@ -506,7 +506,7 @@ Ensure (jsonpull, can_expand_objects)
   assert_that (cJSON_IsObject (child), is_true);
   assert_that (child->string, is_equal_to_string ("F"));
   assert_that (child->child, is_null);
-  cJSON_free (expanded);
+  cJSON_Delete (expanded);
 
   // object end and EOF
   gvm_json_pull_parser_next (&parser, &event);

--- a/util/jsonpull_tests.c
+++ b/util/jsonpull_tests.c
@@ -84,6 +84,7 @@ Ensure (jsonpull, can_init_parser_with_defaults)
                is_equal_to (GVM_JSON_PULL_PARSE_BUFFER_LIMIT));
   assert_that (parser.read_buffer_size,
                is_equal_to (GVM_JSON_PULL_READ_BUFFER_SIZE));
+  gvm_json_pull_parser_cleanup (&parser);
 }
 
 Ensure (jsonpull, can_parse_false)


### PR DESCRIPTION
## What

Close leaks in `utils/jsonpull`.

Add the `-fsanitize=address` flag to `jsonpull-test`.

## Why

Leaks.

Note that the leaks are only reported when I run `BUILD/util/jsonpull-test` directly. If I run `cmake test` they are missed. Something to do with ENV vars for `make test` perhaps. But the idea is to add `-fsanitize=address` for all tests, so that can wait.

## References

Closes #935 

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


