### PR TITLE
Don't run codecov upload and container image builds on forks

### DIFF
--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           CTEST_OUTPUT_ON_FAILURE=1 cmake --build build -- tests test coverage-xml
       - name: Upload test coverage to Codecov
+        if: github.repository == 'greenbone/gvm-libs'
         uses: codecov/codecov-action@v5
         with:
           files: build/coverage/coverage.xml

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   build-push-debian-stable-container:
+    if: github.repository == 'greenbone/gvm-libs'
     name: Build and Push debian:stable to Greenbone Registry
     uses: greenbone/workflows/.github/workflows/container-build-push-2nd-gen.yml@main
     with:


### PR DESCRIPTION


## What

Don't run codecov upload and container image builds on forks

## Why

These workflows are intended to be run only on the main repo.