### PR TITLE
Fix: always build tests with `-fsanitize=address`

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -433,7 +433,10 @@ is_hostname (const char *str)
           while (*last && isdigit (*last))
             last++;
           if (*last == '\0')
-            return 0;
+            {
+              g_strfreev (split);
+              return 0;
+            }
         }
     }
 

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1324,7 +1324,7 @@ gvm_hosts_next (gvm_hosts_t *hosts)
  * the end of the hosts list.
  *
  * @param[in,out]   hosts     gvm_hosts_t structure which hosts must be
- * rearange. The hosts->current index points to the last used hosts and
+ * rearange. The hosts->current index points to the last used host and
  * gvm_hosts_next() must be called to get the next host in the list.
  *
  */
@@ -1337,18 +1337,31 @@ gvm_hosts_move_current_host_to_end (gvm_hosts_t *hosts)
   if (!hosts)
     return;
 
+  // Keep in mind that gvm_hosts_next will return the current host and then
+  // increment hosts->current.
+
   if (hosts->current == hosts->count)
     {
+      // We're on the last host, just make the previous host current.
+      // TODO what happens when current is 0?
       hosts->current -= 1;
       return;
     }
 
+  // Make the previous host current. This makes sure that gvm_hosts_next will
+  // return the host that has replaced the current host.
+  // TODO what happens when current is 0?
   hosts->current -= 1;
+  // Get the host to be moved.
   host_tmp = hosts->hosts[hosts->current];
 
-  for (i = hosts->current; i < hosts->count; i++)
+  // Shift all the others down. Start from current + 1 because we're assigning into
+  // the previous slot (i - 1).
+  // It's safe to do this because we already checked if current == count above.
+  for (i = hosts->current + 1; i < hosts->count; i++)
     hosts->hosts[i - 1] = hosts->hosts[i];
 
+  // Put the moved host on the end.
   hosts->hosts[hosts->count - 1] = host_tmp;
 }
 

--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1355,9 +1355,9 @@ gvm_hosts_move_current_host_to_end (gvm_hosts_t *hosts)
   // Get the host to be moved.
   host_tmp = hosts->hosts[hosts->current];
 
-  // Shift all the others down. Start from current + 1 because we're assigning into
-  // the previous slot (i - 1).
-  // It's safe to do this because we already checked if current == count above.
+  // Shift all the others down. Start from current + 1 because we're assigning
+  // into the previous slot (i - 1). It's safe to do this because we already
+  // checked if current == count above.
   for (i = hosts->current + 1; i < hosts->count; i++)
     hosts->hosts[i - 1] = hosts->hosts[i];
 

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -21,9 +21,19 @@ AfterEach (hosts)
 
 Ensure (hosts, gvm_hosts_new_never_returns_null)
 {
-  assert_that (gvm_hosts_new (""), is_not_null);
-  assert_that (gvm_hosts_new ("172.10.1.1"), is_not_null);
-  assert_that (gvm_hosts_new ("172.10.1.1/24"), is_not_null);
+  gvm_hosts_t *hosts;
+
+  hosts = gvm_hosts_new ("");
+  assert_that (hosts, is_not_null);
+  gvm_hosts_free (hosts);
+
+  hosts = gvm_hosts_new ("172.10.1.1");
+  assert_that (hosts, is_not_null);
+  gvm_hosts_free (hosts);
+
+  hosts = gvm_hosts_new ("172.10.1.1/24");
+  assert_that (hosts, is_not_null);
+  gvm_hosts_free (hosts);
 }
 
 Ensure (hosts, gvm_get_host_type_returns_host_type_ipv4)

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -226,15 +226,15 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
 }
 
 // This is a macro so the line number below is clear on failure.
-#define ASSERT_HOST_EQUALS(hosts, i, string)                                \
-{                                                                           \
-  gchar *value;                                                             \
-                                                                            \
-  value = gvm_host_value_str (hosts->hosts[i]);                             \
-  assert_true_with_message (                                                \
-     g_strcmp0 (value, string) == 0,                                        \
-     "Expected hosts->hosts[%d] to be %s but it was %s", i, string, value); \
-  g_free (value);                                                           \
+#define ASSERT_HOST_EQUALS(hosts, i, string)                               \
+{                                                                          \
+  gchar *value;                                                            \
+                                                                           \
+  value = gvm_host_value_str (hosts->hosts[i]);                            \
+  assert_true_with_message (                                               \
+    g_strcmp0 (value, string) == 0,                                        \
+    "Expected hosts->hosts[%d] to be %s but it was %s", i, string, value); \
+  g_free (value);                                                          \
 }
 
 static int

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -226,15 +226,15 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
 }
 
 // This is a macro so the line number below is clear on failure.
-#define ASSERT_HOST_EQUALS(hosts, i, string)                                     \
-{                                                                                \
-  gchar *value;                                                                  \
-                                                                                 \
-  value = gvm_host_value_str (hosts->hosts[i]);                                  \
-  assert_true_with_message (g_strcmp0 (value, string) == 0,                      \
-                            "Expected hosts->hosts[%d] to be %s but it was %s",  \
-                            i, string, value);                                   \
-  g_free (value);                                                                \
+#define ASSERT_HOST_EQUALS(hosts, i, string)                                \
+{                                                                           \
+  gchar *value;                                                             \
+                                                                            \
+  value = gvm_host_value_str (hosts->hosts[i]);                             \
+  assert_true_with_message (                                                \
+     g_strcmp0 (value, string) == 0,                                        \
+     "Expected hosts->hosts[%d] to be %s but it was %s", i, string, value); \
+  g_free (value);                                                           \
 }
 
 static int
@@ -283,18 +283,15 @@ Ensure (hosts, gvm_hosts_move_host_to_end)
     {
       host = gvm_hosts_next (hosts);
     }
-  assert_that (host_value_eq (host, "192.168.0.9"),
-               is_equal_to (0));
+  assert_that (host_value_eq (host, "192.168.0.9"), is_equal_to (0));
 
   current = hosts->current;
   gvm_hosts_move_current_host_to_end (hosts);
   assert_that (hosts->current, is_equal_to (current - 1));
 
   host = gvm_hosts_next (hosts);
-  assert_that (host_value_eq (host, "192.168.0.10"),
-               is_equal_to (0));
-  assert_that (host_value_eq (hosts->hosts[totalhosts - 1],
-                              "192.168.0.9"),
+  assert_that (host_value_eq (host, "192.168.0.10"), is_equal_to (0));
+  assert_that (host_value_eq (hosts->hosts[totalhosts - 1], "192.168.0.9"),
                is_equal_to (0));
 
   ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
@@ -343,8 +340,7 @@ Ensure (hosts, gvm_hosts_allowed_only)
 
   host = gvm_hosts_next (hosts);
   value = gvm_host_value_str (host);
-  assert_that (g_strcmp0 (value, "192.168.0.3"),
-               is_equal_to (0));
+  assert_that (g_strcmp0 (value, "192.168.0.3"), is_equal_to (0));
   g_free (value);
 
   gvm_hosts_free (hosts);

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -193,10 +193,23 @@ Ensure (hosts, gvm_get_host_type_returns_error)
 
 Ensure (hosts, gvm_hosts_new_with_max_returns_success)
 {
-  assert_that (gvm_hosts_new_with_max ("127.0.0.1", 1), is_not_null);
-  assert_that (gvm_hosts_new_with_max ("127.0.0.1", 2000), is_not_null);
-  assert_that (gvm_hosts_new_with_max ("127.0.0.1,127.0.0.2", 2), is_not_null);
-  assert_that (gvm_hosts_new_with_max ("127.0.0.1, 127.0.0.2", 2), is_not_null);
+  gvm_hosts_t *hosts;
+
+  hosts = gvm_hosts_new_with_max ("127.0.0.1", 1);
+  assert_that (hosts, is_not_null);
+  gvm_hosts_free (hosts);
+
+  hosts = gvm_hosts_new_with_max ("127.0.0.1", 2000);
+  assert_that (hosts, is_not_null);
+  gvm_hosts_free (hosts);
+
+  hosts = gvm_hosts_new_with_max ("127.0.0.1,127.0.0.2", 2);
+  assert_that (hosts, is_not_null);
+  gvm_hosts_free (hosts);
+
+  hosts = gvm_hosts_new_with_max ("127.0.0.1, 127.0.0.2", 2);
+  assert_that (hosts, is_not_null);
+  gvm_hosts_free (hosts);
 }
 
 Ensure (hosts, gvm_hosts_new_with_max_returns_error)

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -237,6 +237,18 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
   g_free (value);                                                                \
 }
 
+static int
+host_value_eq (gvm_host_t *host, gchar *string)
+{
+  int ret;
+  gchar *value;
+
+  value = gvm_host_value_str (host);
+  ret = g_strcmp0 (value, string);
+  g_free (value);
+  return ret;
+}
+
 Ensure (hosts, gvm_hosts_move_host_to_end)
 {
   gvm_hosts_t *hosts = NULL;
@@ -267,11 +279,11 @@ Ensure (hosts, gvm_hosts_move_host_to_end)
   totalhosts = gvm_hosts_count (hosts);
   assert_that (totalhosts, is_equal_to (14));
 
-  while (g_strcmp0 (gvm_host_value_str (host), "192.168.0.9"))
+  while (host_value_eq (host, "192.168.0.9"))
     {
       host = gvm_hosts_next (hosts);
     }
-  assert_that (g_strcmp0 (gvm_host_value_str (host), "192.168.0.9"),
+  assert_that (host_value_eq (host, "192.168.0.9"),
                is_equal_to (0));
 
   current = hosts->current;
@@ -279,10 +291,10 @@ Ensure (hosts, gvm_hosts_move_host_to_end)
   assert_that (hosts->current, is_equal_to (current - 1));
 
   host = gvm_hosts_next (hosts);
-  assert_that (g_strcmp0 (gvm_host_value_str (host), "192.168.0.10"),
+  assert_that (host_value_eq (host, "192.168.0.10"),
                is_equal_to (0));
-  assert_that (g_strcmp0 (gvm_host_value_str (hosts->hosts[totalhosts - 1]),
-                          "192.168.0.9"),
+  assert_that (host_value_eq (hosts->hosts[totalhosts - 1],
+                              "192.168.0.9"),
                is_equal_to (0));
 
   ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -225,6 +225,18 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
   assert_that (gvm_hosts_new_with_max ("127.0.0.1|127.0.0.2", 2), is_null);
 }
 
+// This is a macro so the line number below is clear on failure.
+#define ASSERT_HOST_EQUALS(hosts, i, string)                                     \
+{                                                                                \
+  gchar *value;                                                                  \
+                                                                                 \
+  value = gvm_host_value_str (hosts->hosts[i]);                                  \
+  assert_true_with_message (g_strcmp0 (value, string) == 0,                      \
+                            "Expected hosts->hosts[%d] to be %s but it was %s",  \
+                            i, string, value);                                   \
+  g_free (value);                                                                \
+}
+
 Ensure (hosts, gvm_hosts_move_host_to_end)
 {
   gvm_hosts_t *hosts = NULL;
@@ -233,6 +245,21 @@ Ensure (hosts, gvm_hosts_move_host_to_end)
   size_t current;
 
   hosts = gvm_hosts_new ("192.168.0.0/28");
+
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
+  ASSERT_HOST_EQUALS (hosts, 1, "192.168.0.2");
+  ASSERT_HOST_EQUALS (hosts, 2, "192.168.0.3");
+  ASSERT_HOST_EQUALS (hosts, 3, "192.168.0.4");
+  ASSERT_HOST_EQUALS (hosts, 4, "192.168.0.5");
+  ASSERT_HOST_EQUALS (hosts, 5, "192.168.0.6");
+  ASSERT_HOST_EQUALS (hosts, 6, "192.168.0.7");
+  ASSERT_HOST_EQUALS (hosts, 7, "192.168.0.8");
+  ASSERT_HOST_EQUALS (hosts, 8, "192.168.0.9");
+  ASSERT_HOST_EQUALS (hosts, 9, "192.168.0.10");
+  ASSERT_HOST_EQUALS (hosts, 10, "192.168.0.11");
+  ASSERT_HOST_EQUALS (hosts, 11, "192.168.0.12");
+  ASSERT_HOST_EQUALS (hosts, 12, "192.168.0.13");
+  ASSERT_HOST_EQUALS (hosts, 13, "192.168.0.14");
 
   // Get first host
   host = gvm_hosts_next (hosts);
@@ -257,6 +284,21 @@ Ensure (hosts, gvm_hosts_move_host_to_end)
   assert_that (g_strcmp0 (gvm_host_value_str (hosts->hosts[totalhosts - 1]),
                           "192.168.0.9"),
                is_equal_to (0));
+
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
+  ASSERT_HOST_EQUALS (hosts, 1, "192.168.0.2");
+  ASSERT_HOST_EQUALS (hosts, 2, "192.168.0.3");
+  ASSERT_HOST_EQUALS (hosts, 3, "192.168.0.4");
+  ASSERT_HOST_EQUALS (hosts, 4, "192.168.0.5");
+  ASSERT_HOST_EQUALS (hosts, 5, "192.168.0.6");
+  ASSERT_HOST_EQUALS (hosts, 6, "192.168.0.7");
+  ASSERT_HOST_EQUALS (hosts, 7, "192.168.0.8");
+  ASSERT_HOST_EQUALS (hosts, 8, "192.168.0.10");
+  ASSERT_HOST_EQUALS (hosts, 9, "192.168.0.11");
+  ASSERT_HOST_EQUALS (hosts, 10, "192.168.0.12");
+  ASSERT_HOST_EQUALS (hosts, 11, "192.168.0.13");
+  ASSERT_HOST_EQUALS (hosts, 12, "192.168.0.14");
+  ASSERT_HOST_EQUALS (hosts, 13, "192.168.0.9");
 
   gvm_hosts_free (hosts);
 }

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -267,6 +267,7 @@ Ensure (hosts, gvm_hosts_allowed_only)
   gvm_host_t *host = NULL;
   int totalhosts;
   GSList *removed = NULL;
+  gchar *value;
 
   hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
 
@@ -287,8 +288,10 @@ Ensure (hosts, gvm_hosts_allowed_only)
   g_slist_free_full (removed, g_free);
 
   host = gvm_hosts_next (hosts);
-  assert_that (g_strcmp0 (gvm_host_value_str (host), "192.168.0.3"),
+  value = gvm_host_value_str (host);
+  assert_that (g_strcmp0 (value, "192.168.0.3"),
                is_equal_to (0));
+  g_free (value);
 
   gvm_hosts_free (hosts);
 }

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -226,16 +226,16 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
 }
 
 // This is a macro so the line number below is clear on failure.
-#define ASSERT_HOST_EQUALS(hosts, i, string)                               \
-{                                                                          \
-  gchar *value;                                                            \
-                                                                           \
-  value = gvm_host_value_str (hosts->hosts[i]);                            \
-  assert_true_with_message (                                               \
-    g_strcmp0 (value, string) == 0,                                        \
-    "Expected hosts->hosts[%d] to be %s but it was %s", i, string, value); \
-  g_free (value);                                                          \
-}
+#define ASSERT_HOST_EQUALS(hosts, i, string)                                 \
+  {                                                                          \
+    gchar *value;                                                            \
+                                                                             \
+    value = gvm_host_value_str (hosts->hosts[i]);                            \
+    assert_true_with_message (                                               \
+      g_strcmp0 (value, string) == 0,                                        \
+      "Expected hosts->hosts[%d] to be %s but it was %s", i, string, value); \
+    g_free (value);                                                          \
+  }
 
 static int
 host_value_eq (gvm_host_t *host, gchar *string)

--- a/cmake/MacroAddUnitTest.cmake
+++ b/cmake/MacroAddUnitTest.cmake
@@ -7,6 +7,7 @@ macro(add_unit_test _testName _testSource)
   add_test(NAME ${_testName} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
   set_tests_properties(
     ${_testName}
-    PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:abort_on_error=1"
+    PROPERTIES
+      ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:abort_on_error=1"
   )
 endmacro()

--- a/cmake/MacroAddUnitTest.cmake
+++ b/cmake/MacroAddUnitTest.cmake
@@ -2,5 +2,11 @@ macro(add_unit_test _testName _testSource)
   add_executable(${_testName} ${_testSource})
   target_link_libraries(${_testName} ${CGREEN_LIBRARIES} ${ARGN})
   target_include_directories(${_testName} PRIVATE ${CGREEN_INCLUDE_DIRS})
+  target_compile_options(${_testName} PRIVATE "-fsanitize=address")
+  target_link_options(${_testName} PRIVATE "-fsanitize=address")
   add_test(NAME ${_testName} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
+  set_tests_properties(
+    ${_testName}
+    PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:abort_on_error=1"
+  )
 endmacro()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -216,12 +216,6 @@ endif(BUILD_SHARED)
 if(BUILD_TESTS)
   add_unit_test(json-test json_tests.c ${GLIB_LDFLAGS} ${CJSON_LDFLAGS})
   add_unit_test(jsonpull-test jsonpull_tests.c ${GLIB_LDFLAGS} ${CJSON_LDFLAGS})
-  target_compile_options(jsonpull-test PRIVATE "-fsanitize=address")
-  target_link_options(jsonpull-test PRIVATE "-fsanitize=address")
-  set_tests_properties(
-    jsonpull-test
-    PROPERTIES ENVIRONMENT "ASAN_OPTIONS=halt_on_error=1:abort_on_error=1"
-  )
   add_unit_test(
     passwordbasedauthentication-test
     passwordbasedauthentication_tests.c


### PR DESCRIPTION
## What

Always build and run tests with the address sanitizer. This includes:
 - fixing a leak in `is_hostname`
 - correcting an overwriting error in `gvm_hosts_move_current_host_to_end` that was presenting as a leak
 - making sure the tests themselves always free memory. 

## Why

It's good to see when something is leaking memory. And this can show up other errors.

## References

Follows /pull/939.