### PR TITLE
Repair allocation size of stream_resp in openvasd_connector_free

### DIFF
--- a/openvasd/openvasd_tests.c
+++ b/openvasd/openvasd_tests.c
@@ -227,7 +227,6 @@ Ensure (openvasd, openvasd_connector_free)
   conn->protocol = g_strdup ("https");
   conn->host = g_strdup ("localhost");
   conn->scan_id = g_strdup ("scan-uuid");
-  conn->stream_resp = g_malloc0 (sizeof (struct gvm_http_response_stream));
 
   openvasd_error_t result = openvasd_connector_free (conn);
 


### PR DESCRIPTION
This is a bit out of my comfort zone so please review carefully.

## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Repair allocation size of stream_resp in openvasd_connector_free

## Why

<!-- Describe why are these changes necessary? -->

Without this gcc complains about allocation of insuffiicent size.

```
cd /builds/gvm-libs/rpmbuild/BUILD/gvm-libs-22.23.0/redhat-linux-build/openvasd && /usr/bin/gcc -DGVM_LIBS_VERSION=\"22.23.0\" -DREDIS_SOCKET_PATH=\"/run/redis/redis.sock\" -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2      -std=c11     -Wall     -Wextra     -Werror     -Wpedantic     -Wmissing-prototypes     -Wshadow     -Wsequence-point     -D_ISOC11_SOURCE     -D_DEFAULT_SOURCE -DNDEBUG -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector  -std=gnu11 -MD -MT openvasd/CMakeFiles/openvasd-test.dir/openvasd_tests.c.o -MF CMakeFiles/openvasd-test.dir/openvasd_tests.c.o.d -o CMakeFiles/openvasd-test.dir/openvasd_tests.c.o -c /builds/gvm-libs/rpmbuild/BUILD/gvm-libs-22.23.0/openvasd/openvasd_tests.c
/builds/gvm-libs/rpmbuild/BUILD/gvm-libs-22.23.0/openvasd/openvasd_tests.c: In function ‘openvasd__openvasd_connector_free’:
/builds/gvm-libs/rpmbuild/BUILD/gvm-libs-22.23.0/openvasd/openvasd_tests.c:230:21: error: allocation of insufficient size ‘8’ for type ‘struct gvm_http_response_stream’ with size ‘24’ [-Werror=alloc-size]
  230 |   conn->stream_resp = g_malloc0 (sizeof (gvm_http_response_stream_t));
      |                     ^
```