### PR TITLE
 Chore: set fix debian codename in /etc/apt/*.sources

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -20,5 +20,9 @@ RUN --mount=type=bind,source=.github,target=/source/ \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /install/ /
+# we set the VERSION_CODENAME instead of stable to prevent accidental
+# distribution upgrades
+RUN  . /etc/os-release && \
+  sed -i "s/stable/$VERSION_CODENAME/g" /etc/apt/sources.list.d/*.sources
 
 RUN ldconfig


### PR DESCRIPTION
To prevent accidental distribution upgrades, e.g. when using gvm-libs as
a base, we should set the codename instead of rolling release.

This minimizes the effort of keeping track of debian releases manually,
checking always for whatever is stable while having a safe guard for
underlying images or runtime environments.

Depends on: https://github.com/greenbone/gvm-libs/pull/945
