### PR TITLE
Add scan agent config support

### DIFF
--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -74,14 +74,14 @@ struct agent_controller_agent
   gchar **ip_addresses;     ///< List of IP addresses
   int ip_address_count;     ///< Number of IP addresses
   time_t last_update; ///< Timestamp of the last update (seconds since epoch)
-  gchar *config;                ///< JSON string for config (store raw as-is)
+  gchar *config;      ///< JSON string for config (store raw as-is)
 
-  gchar *updater_version;       ///< Updater version string (may be empty)
-  gchar *agent_version;         ///< Agent version string (may be empty)
-  gchar *operating_system;      ///< OS string (may be empty)
-  gchar *architecture;          ///< Architecture string (e.g., "amd64", may be empty)
+  gchar *updater_version;  ///< Updater version string (may be empty)
+  gchar *agent_version;    ///< Agent version string (may be empty)
+  gchar *operating_system; ///< OS string (may be empty)
+  gchar *architecture; ///< Architecture string (e.g., "amd64", may be empty)
 
-  int update_to_latest;         ///< 1: update to latest, 0: do not
+  int update_to_latest; ///< 1: update to latest, 0: do not
 };
 typedef struct agent_controller_agent *agent_controller_agent_t;
 
@@ -103,7 +103,7 @@ struct agent_controller_agent_update
   int authorized;         ///< Authorization status for update
   int min_interval;       ///< New minimum interval
   int heartbeat_interval; ///< New heartbeat interval
-  gchar *config; ///< The Agent scan configuration
+  gchar *config;          ///< The Agent scan configuration
 };
 typedef struct agent_controller_agent_update *agent_controller_agent_update_t;
 
@@ -117,9 +117,10 @@ typedef struct agent_controller_connector *agent_controller_connector_t;
  */
 struct agent_controller_retry_cfg
 {
- int attempts;
- int delay_in_seconds;
- int max_jitter_in_seconds;
+  int attempts;         ///< Max retry attempts before giving up (e.g., 5)
+  int delay_in_seconds; ///< Base delay between retries in seconds (e.g., 60)
+  int max_jitter_in_seconds; ///< Random jitter added to delay to avoid
+                             ///< stampedes (0..max)
 };
 
 /**
@@ -127,7 +128,7 @@ struct agent_controller_retry_cfg
  */
 struct agent_controller_agent_control_cfg
 {
- struct agent_controller_retry_cfg retry;
+  struct agent_controller_retry_cfg retry; ///< Retry/backoff policy
 };
 
 /**
@@ -135,13 +136,17 @@ struct agent_controller_agent_control_cfg
  */
 struct agent_controller_script_exec_cfg
 {
- int   bulk_size;
- int   bulk_throttle_time_in_ms;
- int   indexer_dir_depth;
- int   period_in_seconds;
+  int bulk_size;                ///< Number of scripts/tasks processed per batch
+  int bulk_throttle_time_in_ms; ///< Throttle/sleep between batches in
+                                ///< milliseconds
+  int indexer_dir_depth;        ///< Max directory depth to scan/index
+  int period_in_seconds;        ///< Periodic run interval in seconds
 
- gchar **scheduler_cron_time;   ///< Array of cron expressions
- int     scheduler_cron_time_count;
+  gchar **scheduler_cron_time;   ///< Optional list of cron expressions
+                                 ///< Format: standard 5-field cron like
+                                 /// "0 23 * * *"
+  int scheduler_cron_time_count; ///< Number of cron expressions in
+                                 ///< scheduler_cron_time
 };
 
 /**
@@ -149,21 +154,25 @@ struct agent_controller_script_exec_cfg
  */
 struct agent_controller_heartbeat_cfg
 {
- int interval_in_seconds;
- int miss_until_inactive;
+  int interval_in_seconds; ///< Agent heartbeat interval in seconds (e.g., 600)
+  int miss_until_inactive; ///< Missed heartbeats before marking agent inactive
+                           ///< (e.g., 1)
 };
 
 /**
  * @brief Top-level scan agent config.
+ *
+ * Groups all configuration sections for the scan agent service.
  */
 struct agent_controller_scan_agent_config
 {
- struct agent_controller_agent_control_cfg   agent_control;
- struct agent_controller_script_exec_cfg     agent_script_executor;
- struct agent_controller_heartbeat_cfg       heartbeat;
+  struct agent_controller_agent_control_cfg agent_control;
+  struct agent_controller_script_exec_cfg agent_script_executor;
+  struct agent_controller_heartbeat_cfg heartbeat;
 };
 
-typedef struct agent_controller_scan_agent_config *agent_controller_scan_agent_config_t;
+typedef struct agent_controller_scan_agent_config
+  *agent_controller_scan_agent_config_t;
 
 agent_controller_connector_t
 agent_controller_connector_new (void);
@@ -198,7 +207,8 @@ agent_controller_scan_agent_config_t
 agent_controller_scan_agent_config_new (void);
 
 void
-agent_controller_scan_agent_config_free (agent_controller_scan_agent_config_t cfg);
+agent_controller_scan_agent_config_free (
+  agent_controller_scan_agent_config_t cfg);
 
 agent_controller_agent_list_t
 agent_controller_get_agents (agent_controller_connector_t conn);
@@ -222,5 +232,8 @@ agent_controller_get_scan_agent_config (agent_controller_connector_t conn);
 int
 agent_controller_update_scan_agent_config (
   agent_controller_connector_t conn, agent_controller_scan_agent_config_t cfg);
+
+agent_controller_agent_list_t
+agent_controller_get_agents_with_updates (agent_controller_connector_t conn);
 
 #endif // AGENT_CONTROLLER_H


### PR DESCRIPTION
## What

- Extended the agent parsing to include `updater_version`, `agent_version`, `operating_system`, `architecture`, and the boolean `update_to_latest`. 
- Added admin endpoints for the global scan-agent config (GET/PUT /api/v1/admin/scan-agent-config) with a new config type and helpers. 
- Implemented GET /api/v1/admin/agents/updates to return only agents that have updates available (pre-filters JSON; no struct change).
-  Added unit tests.

## Why

- To support the new controller API: manage global scan-agent settings and easily find agents that need updates. 
- To extend agent parsing to include extra parameters provided by the agent-controller

## References

GEA-1126

## Checklist

- [x] Tests


