### PR TITLE
Fix: change comment of the agent_controller_convert_scan_agent_config_string

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -1004,7 +1004,7 @@ agent_controller_delete_agents (agent_controller_connector_t conn,
  *
  * @return Newly allocated, unformatted JSON string on success; NULL on failure
  *         The caller owns the returned string and must free it with
- *         g_free().
+ *         cJSON_free().
  */
 gchar *
 agent_controller_convert_scan_agent_config_string (


### PR DESCRIPTION
## What

Replaced `cJSON_free` with `g_free` when releasing the payload to ensure the correct memory deallocation function is used. 


## Why

Using `cJSON_free` for memory allocated with GLib functions caused a mismatch in allocation/free.

## References

GEA-1126




