### PR TITLE
Fix: close some leaks shown by the logging tests

### DIFF
--- a/base/logging.c
+++ b/base/logging.c
@@ -888,6 +888,8 @@ check_log_file (gvm_logging_domain_t *log_domain_entry)
       if (!channel)
         return -1;
     }
+  g_io_channel_shutdown (channel, TRUE, NULL);
+  g_io_channel_unref (channel);
   return 0;
 }
 

--- a/base/logging.c
+++ b/base/logging.c
@@ -853,7 +853,6 @@ static int
 check_log_file (gvm_logging_domain_t *log_domain_entry)
 {
   GIOChannel *channel = NULL;
-  GError *error = NULL;
   const gchar *log_file;
 
   log_file = gvm_logging_domain_get_log_file (log_domain_entry);
@@ -868,7 +867,7 @@ check_log_file (gvm_logging_domain_t *log_domain_entry)
   if (g_ascii_strcasecmp (log_file, "syslog") == 0)
     return 0;
 
-  channel = g_io_channel_new_file (log_file, "a", &error);
+  channel = g_io_channel_new_file (log_file, "a", NULL);
   if (!channel)
     {
       gchar *log = g_strdup (log_file);
@@ -883,8 +882,7 @@ check_log_file (gvm_logging_domain_t *log_domain_entry)
       g_free (log);
 
       /* Try again. */
-      error = NULL;
-      channel = g_io_channel_new_file (log_file, "a", &error);
+      channel = g_io_channel_new_file (log_file, "a", NULL);
       if (!channel)
         return -1;
     }

--- a/base/logging_domain.c
+++ b/base/logging_domain.c
@@ -76,6 +76,7 @@ gvm_logging_domain_free (gvm_logging_domain_t *log_domain)
   g_free (log_domain->prepend_time_format);
   g_free (log_domain->log_file);
   g_free (log_domain->default_level);
+  g_free (log_domain->syslog_facility);
   g_free (log_domain->syslog_ident);
   g_free (log_domain->prepend_separator);
 


### PR DESCRIPTION
## What

Fix a few logging leaks.

## Why

Better to free.

Note that these were shown by `-fsanitize=address` but ctest still considers the test a pass, so they're slipping past the CI. I think this is because of the way Cgreen treats aborts, or because the aborts happen right at the end of the process.

## Testing

Ran `base/logging-test` directly and checked that the error messages were gone. Started gvmd and gsad, logging looked OK.


