### PR TITLE
add: agent_controller helper to build create-scan payload

### DIFF
--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -236,4 +236,11 @@ agent_controller_convert_scan_agent_config_string (
 agent_controller_scan_agent_config_t
 agent_controller_parse_scan_agent_config_string (const gchar *config);
 
+gchar *
+agent_controller_build_create_scan_payload (
+  agent_controller_agent_list_t agents);
+
+gchar *
+agent_controller_get_scan_id (const gchar *body);
+
 #endif // AGENT_CONTROLLER_H


### PR DESCRIPTION
## What

Added a new helper function `agent_controller_build_create_scan_payload()` that builds the JSON payload for creating a scan in the agent controller.  

## Why

This is required when using the `http_scanner` API, since it expects a properly create-scan payload.  

## References

GEA-1258

## Checklist

- [x] Tests


