### PR TITLE
Fix: close leaks shown by the networking tests

### DIFF
--- a/base/networking.c
+++ b/base/networking.c
@@ -993,6 +993,7 @@ free_routes (GSList *routes)
       {
         if (((route_entry_t *) (routes_p->data))->interface)
           g_free (((route_entry_t *) (routes_p->data))->interface);
+        g_free (routes_p->data);
       }
     g_slist_free (routes);
   }

--- a/base/networking.c
+++ b/base/networking.c
@@ -987,17 +987,17 @@ static void
 free_routes (GSList *routes)
 {
   if (routes)
-  {
-    GSList *routes_p;
+    {
+      GSList *routes_p;
 
-    for (routes_p = routes; routes_p; routes_p = routes_p->next)
-      {
-        if (((route_entry_t *) (routes_p->data))->interface)
-          g_free (((route_entry_t *) (routes_p->data))->interface);
-        g_free (routes_p->data);
-      }
-    g_slist_free (routes);
-  }
+      for (routes_p = routes; routes_p; routes_p = routes_p->next)
+        {
+          if (((route_entry_t *) (routes_p->data))->interface)
+            g_free (((route_entry_t *) (routes_p->data))->interface);
+          g_free (routes_p->data);
+        }
+      g_slist_free (routes);
+    }
 }
 
 /**

--- a/base/networking.c
+++ b/base/networking.c
@@ -969,6 +969,7 @@ get_routes (void)
     }
 
   status = g_io_channel_shutdown (file_channel, TRUE, &err);
+  g_io_channel_unref (file_channel);
   if ((G_IO_STATUS_NORMAL != status) || err)
     g_warning ("%s: %s", __func__,
                err ? err->message

--- a/base/networking.c
+++ b/base/networking.c
@@ -978,6 +978,27 @@ get_routes (void)
 }
 
 /**
+ * @brief Free the list of routes.
+ *
+ * @param GSList of route_entry structs, or NULL.
+ */
+static void
+free_routes (GSList *routes)
+{
+  if (routes)
+  {
+    GSList *routes_p;
+
+    for (routes_p = routes; routes_p; routes_p = routes_p->next)
+      {
+        if (((route_entry_t *) (routes_p->data))->interface)
+          g_free (((route_entry_t *) (routes_p->data))->interface);
+      }
+    g_slist_free (routes);
+  }
+}
+
+/**
  * @brief Get Interface which should be used for routing to destination addr.
  *
  * This function should be used sparingly as it parses /proc/net/route for
@@ -1013,7 +1034,6 @@ gvm_routethrough (struct sockaddr_storage *storage_dest,
   if (storage_dest->ss_family == AF_INET)
     {
       GSList *routes;
-      GSList *routes_p;
 
       routes = get_routes ();
 
@@ -1043,6 +1063,7 @@ gvm_routethrough (struct sockaddr_storage *storage_dest,
           struct sockaddr_in *sin_dest_p, *sin_src_p;
           struct in_addr global_src;
           unsigned long best_match;
+          GSList *routes_p;
 
           /* Check if global_source_addr in use. */
           gvm_source_addr (&global_src);
@@ -1093,16 +1114,7 @@ gvm_routethrough (struct sockaddr_storage *storage_dest,
                 }
             }
         }
-      /* Free GSList. */
-      if (routes)
-        {
-          for (routes_p = routes; routes_p; routes_p = routes_p->next)
-            {
-              if (((route_entry_t *) (routes_p->data))->interface)
-                g_free (((route_entry_t *) (routes_p->data))->interface);
-            }
-          g_slist_free (routes);
-        }
+      free_routes (routes);
     }
   else if (storage_dest->ss_family == AF_INET6)
     {

--- a/base/networking.c
+++ b/base/networking.c
@@ -1124,6 +1124,7 @@ gvm_routethrough (struct sockaddr_storage *storage_dest,
                  __func__);
     }
 
+  freeifaddrs (ifaddr);
   return interface_out != NULL ? interface_out : NULL;
 }
 

--- a/base/networking_tests.c
+++ b/base/networking_tests.c
@@ -1102,6 +1102,7 @@ Ensure (networking, get_routes)
   list_len = g_slist_length (list);
   assert_that (list, is_not_null);
   assert_that (list_len, is_equal_to (3));
+  free_routes (list);
   g_g_io_channel_new_file_use_real = true;
   g_g_io_channel_shutdown_use_real = true;
 

--- a/base/networking_tests.c
+++ b/base/networking_tests.c
@@ -860,7 +860,9 @@ Ensure (networking, port_range_ranges)
   assert_that (validate_port_range (valid_portrange1), is_equal_to (0));
 
   assert_that (port_range_ranges (NULL), is_null);
-  assert_that (port_range_ranges (valid_portrange1), is_not_null);
+  valid_portrange1_ranges = port_range_ranges (valid_portrange1);
+  assert_that (valid_portrange1_ranges, is_not_null);
+  array_free (valid_portrange1_ranges);
 
   valid_portrange1_ranges = port_range_ranges (valid_portrange1);
   assert_that (valid_portrange1_ranges, is_not_null);
@@ -901,6 +903,8 @@ Ensure (networking, port_range_ranges)
   assert_that (valid_portrange1_range5->end, is_equal_to (12));
   assert_that (valid_portrange1_range5->exclude, is_equal_to (0));
   assert_that (valid_portrange1_range5->type, is_equal_to (PORT_PROTOCOL_UDP));
+
+  array_free (valid_portrange1_ranges);
 }
 
 Ensure (networking, port_in_port_ranges)
@@ -947,6 +951,8 @@ Ensure (networking, port_in_port_ranges)
                is_false);
   assert_that (port_in_port_ranges (12, PORT_PROTOCOL_OTHER, portrange_ranges),
                is_false);
+
+  array_free (portrange_ranges);
 }
 
 /* Test suite. */

--- a/base/networking_tests.c
+++ b/base/networking_tests.c
@@ -1109,6 +1109,7 @@ Ensure (networking, get_routes)
   status = g_io_channel_shutdown (file_channel, TRUE, &err);
   if ((G_IO_STATUS_NORMAL != status) || err)
     g_warning ("%s: Could not shutdown channel.", __func__);
+  g_io_channel_unref (file_channel);
   ret = unlink ("./myfile");
   if (0 != ret)
     g_warning ("%s: Could not delete file \"./myfile\");", __func__);

--- a/base/networking_tests.c
+++ b/base/networking_tests.c
@@ -1134,6 +1134,7 @@ Ensure (networking, gvm_routethrough_v4)
   /* No destination address. */
   interface = gvm_routethrough (NULL, &storage_src);
   assert_that (interface, is_null);
+  g_free (interface);
 
   /* Destination address localhost and no source address. */
   inet_pton (AF_INET, "127.0.0.1", &(dst.s_addr));
@@ -1143,6 +1144,7 @@ Ensure (networking, gvm_routethrough_v4)
   assert_that (interface, is_not_null);
   /* Dependent on local environment. */
   // assert_that (interface, is_equal_to_string ("lo"));
+  g_free (interface);
 
   /* Destination address not localhost and no source address. */
   inet_pton (AF_INET, "93.184.216.34", &(dst.s_addr)); // example.com
@@ -1152,6 +1154,7 @@ Ensure (networking, gvm_routethrough_v4)
   assert_that (interface, is_not_null);
   /* Dependent on local environment. */
   // assert_that (interface, is_equal_to_string ("enp0s9"));
+  g_free (interface);
 
   /* Destination address localhost and source address */
   inet_pton (AF_INET, "127.0.0.1", &(dst.s_addr));
@@ -1163,6 +1166,7 @@ Ensure (networking, gvm_routethrough_v4)
                == htonl (0x7F000001));
   /* Dependent on local environment. */
   // assert_that (interface, is_equal_to_string ("lo"));
+  g_free (interface);
 
   /* Dst address not localhost and src address */
   inet_pton (AF_INET, "93.184.216.34", &(dst.s_addr));
@@ -1176,6 +1180,7 @@ Ensure (networking, gvm_routethrough_v4)
   /* Dependent on local environment. */
   // assert_that (((struct sockaddr_in *) (&storage_src))->sin_addr.s_addr !=
   // 0); assert_that (interface, is_equal_to_string ("enp0s9"));
+  g_free (interface);
 }
 
 Ensure (networking, gvm_source_addr)

--- a/base/networking_tests.c
+++ b/base/networking_tests.c
@@ -1110,6 +1110,8 @@ Ensure (networking, get_routes)
   status = g_io_channel_shutdown (file_channel, TRUE, &err);
   if ((G_IO_STATUS_NORMAL != status) || err)
     g_warning ("%s: Could not shutdown channel.", __func__);
+  if (err)
+    g_error_free (err);
   g_io_channel_unref (file_channel);
   ret = unlink ("./myfile");
   if (0 != ret)


### PR DESCRIPTION
## What

Close some leaks.

## Why

Better to be tidy.

Note: this only touches `gvm_routethrough` in the actual library code. I don't see this function in use anywhere.