### PR TITLE
closes #960; Fix missed link to CJson

### DIFF
--- a/http_scanner/CMakeLists.txt
+++ b/http_scanner/CMakeLists.txt
@@ -67,6 +67,7 @@ if(BUILD_SHARED)
       gvm_util_shared
       ${GLIB_LDFLAGS}
       ${CURL_LDFLAGS}
+      ${CJSON_LDFLAGS}
       ${LINKER_HARDENING_FLAGS}
   )
 endif(BUILD_SHARED)


### PR DESCRIPTION
## What

http_scanner misses link to libcjson.
Build fails on clang with  -Wl,--no-allow-shlib-undefined

## Why
Allowing to build with shared libs using -Wl,--no-allow-shlib-undefined

## References
https://github.com/greenbone/gvm-libs/issues/960

