### PR TITLE
Fix: close leak in logging domain test

### DIFF
--- a/base/logging_domain_tests.c
+++ b/base/logging_domain_tests.c
@@ -91,6 +91,7 @@ Ensure (logging_domain, should_allow_setting_properties)
                is_equal_to_string ("|"));
 
   gvm_logging_domain_free (log_domain_entry);
+  g_io_channel_unref (log_channel);
   g_remove ("log_channel.log");
 }
 


### PR DESCRIPTION
## What

Close a leak shown by `-fsanitize=address` in the logging domain test.

## Why

Tidier.