### PR TITLE
Fix: remove duplicate function declarations in http_scanner header

### DIFF
--- a/http_scanner/http_scanner.h
+++ b/http_scanner/http_scanner.h
@@ -202,10 +202,8 @@ int
 http_scanner_parsed_results (http_scanner_connector_t, unsigned long,
                              unsigned long, GSList **);
 
-http_scanner_resp_t http_scanner_get_scan_status (http_scanner_connector_t);
-
 http_scanner_scan_status_t
-  http_scanner_parsed_scan_status (http_scanner_connector_t);
+http_scanner_parsed_scan_status (http_scanner_connector_t);
 
 int http_scanner_get_scan_progress (http_scanner_connector_t);
 
@@ -216,10 +214,7 @@ http_scanner_resp_t http_scanner_get_health_ready (http_scanner_connector_t);
 http_scanner_resp_t http_scanner_get_health_started (http_scanner_connector_t);
 
 http_scanner_resp_t
-  http_scanner_get_scan_preferences (http_scanner_connector_t);
-
-http_scanner_resp_t
-  http_scanner_get_scan_preferences (http_scanner_connector_t);
+http_scanner_get_scan_preferences (http_scanner_connector_t);
 
 int
 http_scanner_parsed_scans_preferences (http_scanner_connector_t, GSList **);


### PR DESCRIPTION
## What

Removed duplicate function declarations (http_scanner_parsed_scan_status, http_scanner_get_scan_preferences) from the http_scanner header file.

## Why

Duplicate declarations were redundant and could cause a build issue in gvmd


