### PR TITLE
Fix: close leak in gvm_http_multi_free

### DIFF
--- a/http/httputils.c
+++ b/http/httputils.c
@@ -579,8 +579,14 @@ gvm_http_multi_handler_free (gvm_http_multi_t *multi, gvm_http_t *http)
 void
 gvm_http_multi_free (gvm_http_multi_t *multi)
 {
-  if (!multi || !multi->handler)
+  if (!multi)
     return;
+
+  if (!multi->handler)
+    {
+      g_free (multi);
+      return;
+    }
 
   int queued = 0;
   CURLMsg *msg;


### PR DESCRIPTION
## What

Close a leak shown by the `http` tests with `-fsanitize=address`.

## Why

Tidier.
