### PR TITLE
Fix: close leaks in JSON, Radius and vtparser tests

### DIFF
--- a/util/json_tests.c
+++ b/util/json_tests.c
@@ -49,6 +49,7 @@ Ensure (json, gvm_json_obj_double_gets_value)
   assert_that (json, is_not_null);
   d = gvm_json_obj_double (json, "eg");
   assert_that_double (d, is_equal_to_double (2.3));
+  cJSON_Delete (json);
 }
 
 Ensure (json, gvm_json_obj_double_0_when_missing)
@@ -60,6 +61,7 @@ Ensure (json, gvm_json_obj_double_0_when_missing)
   assert_that (json, is_not_null);
   d = gvm_json_obj_double (json, "err");
   assert_that_double (d, is_equal_to_double (0));
+  cJSON_Delete (json);
 }
 
 /* gvm_json_obj_check_str */

--- a/util/radiusutils_tests.c
+++ b/util/radiusutils_tests.c
@@ -33,6 +33,7 @@ Ensure (radiusutils, radius_init)
 
   rh = radius_init (HOST, SECRET);
   assert_that (rh, is_not_null);
+  rc_destroy (rh);
 }
 
 #else

--- a/util/vtparser_tests.c
+++ b/util/vtparser_tests.c
@@ -87,6 +87,7 @@ Ensure (vtparser, parse_vt_json_parses_a_vt)
   gvm_json_pull_event_t event;
   FILE *file;
   nvti_t *nvt;
+  gchar *refs;
 
   file = memopen ("[" VT "]");
   assert_that (file, is_not_null);
@@ -100,10 +101,13 @@ Ensure (vtparser, parse_vt_json_parses_a_vt)
   parse_vt_json (&parser, &event, &nvt);
   assert_that (nvt, is_not_null);
   assert_that (nvti_name (nvt), is_equal_to_string (VT_NAME));
-  assert_that (nvti_refs (nvt, NULL, NULL, 1),
+  refs = nvti_refs (nvt, NULL, NULL, 1);
+  assert_that (refs,
                is_equal_to_string ("cve:CVE-2017-18189,"
                                    " 2020-cb7b7181a0:FEDORA,"
                                    " https://example.org/ann/EG-IZ3CX:URL"));
+  g_free (refs);
+  nvti_free (nvt);
 
   gvm_json_pull_event_cleanup (&event);
   gvm_json_pull_parser_cleanup (&parser);


### PR DESCRIPTION
## What

Close leaks in the tests themselves. Found by `-fsanitize=address`.

## Why

Makes it easier to see actual leaks.