### PR TITLE
Fix: close leaks in version utils

### DIFF
--- a/util/versionutils.c
+++ b/util/versionutils.c
@@ -104,10 +104,16 @@ cmp_versions (const char *version1, const char *version2)
     }
 
   if (part1 == NULL && part2 == NULL)
-    return release_state2 - release_state1;
+    {
+      g_free (ver1);
+      g_free (ver2);
+      return release_state2 - release_state1;
+    }
 
   if (is_text (part1) || is_text (part2))
     {
+      g_free (ver1);
+      g_free (ver2);
       g_free (part1);
       g_free (part2);
       return -5; // undefined
@@ -116,8 +122,15 @@ cmp_versions (const char *version1, const char *version2)
   rs1 = get_release_state (ver1, index1);
   rs2 = get_release_state (ver2, index2);
 
+  g_free (ver1);
+  g_free (ver2);
+
   if ((rs1 && release_state1) || (rs2 && release_state2))
-    return -5; // undefined
+    {
+      g_free (part1);
+      g_free (part2);
+      return -5; // undefined
+    }
 
   if (part1 == NULL)
     {
@@ -159,8 +172,6 @@ cmp_versions (const char *version1, const char *version2)
 
   g_free (part1);
   g_free (part2);
-  g_free (ver1);
-  g_free (ver2);
   return ret;
 }
 

--- a/util/versionutils.c
+++ b/util/versionutils.c
@@ -110,14 +110,14 @@ cmp_versions (const char *version1, const char *version2)
     {
       g_free (part1);
       g_free (part2);
-      return (-5); // undefined
+      return -5; // undefined
     }
 
   rs1 = get_release_state (ver1, index1);
   rs2 = get_release_state (ver2, index2);
 
   if ((rs1 && release_state1) || (rs2 && release_state2))
-    return (-5); // undefined
+    return -5; // undefined
 
   if (part1 == NULL)
     {
@@ -255,7 +255,7 @@ prepare_version_string (const char *version)
 
   prep_version[index_pv] = '\0';
   g_free (ver);
-  return (g_strdup (prep_version));
+  return g_strdup (prep_version);
 }
 
 /**

--- a/util/versionutils.c
+++ b/util/versionutils.c
@@ -108,10 +108,8 @@ cmp_versions (const char *version1, const char *version2)
 
   if (is_text (part1) || is_text (part2))
     {
-      if (part1)
-        g_free (part1);
-      if (part2)
-        g_free (part2);
+      g_free (part1);
+      g_free (part2);
       return (-5); // undefined
     }
 

--- a/util/versionutils_tests.c
+++ b/util/versionutils_tests.c
@@ -172,16 +172,23 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, versionutils, cmp_versions_handles_null_inputs);
   add_test_with_context (suite, versionutils, cmp_versions_identical_versions);
-  add_test_with_context (suite, versionutils, cmp_versions_basic_format_differences);
-  add_test_with_context (suite, versionutils, cmp_versions_text_vs_numeric_parts);
+  add_test_with_context (suite, versionutils,
+                         cmp_versions_basic_format_differences);
+  add_test_with_context (suite, versionutils,
+                         cmp_versions_text_vs_numeric_parts);
   add_test_with_context (suite, versionutils, cmp_versions_equivalent_formats);
-  add_test_with_context (suite, versionutils, cmp_versions_undefined_text_parts);
+  add_test_with_context (suite, versionutils,
+                         cmp_versions_undefined_text_parts);
   add_test_with_context (suite, versionutils, cmp_versions_text_vs_numeric);
-  add_test_with_context (suite, versionutils, cmp_versions_release_candidate_vs_release);
-  add_test_with_context (suite, versionutils, cmp_versions_release_candidate_numeric_comparison);
-  add_test_with_context (suite, versionutils, cmp_versions_release_candidate_text_comparison);
+  add_test_with_context (suite, versionutils,
+                         cmp_versions_release_candidate_vs_release);
+  add_test_with_context (suite, versionutils,
+                         cmp_versions_release_candidate_numeric_comparison);
+  add_test_with_context (suite, versionutils,
+                         cmp_versions_release_candidate_text_comparison);
   add_test_with_context (suite, versionutils, cmp_versions_date_format);
-  add_test_with_context (suite, versionutils, cmp_versions_additional_numeric_comparison);
+  add_test_with_context (suite, versionutils,
+                         cmp_versions_additional_numeric_comparison);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());

--- a/util/versionutils_tests.c
+++ b/util/versionutils_tests.c
@@ -17,9 +17,9 @@ AfterEach (versionutils)
 {
 }
 
-/* parse_entity */
+/* cmp_versions */
 
-Ensure (versionutils, cmp_versions)
+Ensure (versionutils, cmp_versions_basic_format_differences)
 {
   char *version1, *version2;
   int result;
@@ -29,41 +29,89 @@ Ensure (versionutils, cmp_versions)
   result = cmp_versions (version1, version2);
   assert_that (result, is_less_than (0));
   assert_that (result, is_greater_than (-5));
+}
+
+Ensure (versionutils, cmp_versions_text_vs_numeric_parts)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "beta-test-2";
   version2 = "test_1";
   result = cmp_versions (version1, version2);
   assert_that (result, is_greater_than (0));
+}
+
+Ensure (versionutils, cmp_versions_equivalent_formats)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "beta-test-2";
   version2 = "test-2.beta";
   result = cmp_versions (version1, version2);
   assert_that (result, is_equal_to (0));
+}
+
+Ensure (versionutils, cmp_versions_undefined_text_parts)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "test-2.beta";
   version2 = "test-2.a";
   result = cmp_versions (version1, version2);
   assert_that (result, is_equal_to (-5));
+}
+
+Ensure (versionutils, cmp_versions_text_vs_numeric)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "test-2.beta";
   version2 = "test-2.1";
   result = cmp_versions (version1, version2);
   assert_that (result, is_equal_to (-1));
+}
+
+Ensure (versionutils, cmp_versions_release_candidate_vs_release)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "test-2.release_candidate";
   version2 = "test-2";
   result = cmp_versions (version1, version2);
   assert_that (result, is_equal_to (-1));
+}
+
+Ensure (versionutils, cmp_versions_release_candidate_numeric_comparison)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "test-2.release_candidate2";
   version2 = "test-2.release_candidate1";
   result = cmp_versions (version1, version2);
   assert_that (result, is_greater_than (0));
+}
+
+Ensure (versionutils, cmp_versions_release_candidate_text_comparison)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "test-2.release_candidatea";
   version2 = "test-2.release_candidateb";
   result = cmp_versions (version1, version2);
   assert_that (result, is_equal_to (-5));
+}
+
+Ensure (versionutils, cmp_versions_date_format)
+{
+  char *version1, *version2;
+  int result;
 
   version1 = "2024-06-24";
   version2 = "2024-06-23";
@@ -72,6 +120,7 @@ Ensure (versionutils, cmp_versions)
 }
 
 /* Test suite. */
+
 int
 main (int argc, char **argv)
 {
@@ -80,7 +129,15 @@ main (int argc, char **argv)
 
   suite = create_test_suite ();
 
-  add_test_with_context (suite, versionutils, cmp_versions);
+  add_test_with_context (suite, versionutils, cmp_versions_basic_format_differences);
+  add_test_with_context (suite, versionutils, cmp_versions_text_vs_numeric_parts);
+  add_test_with_context (suite, versionutils, cmp_versions_equivalent_formats);
+  add_test_with_context (suite, versionutils, cmp_versions_undefined_text_parts);
+  add_test_with_context (suite, versionutils, cmp_versions_text_vs_numeric);
+  add_test_with_context (suite, versionutils, cmp_versions_release_candidate_vs_release);
+  add_test_with_context (suite, versionutils, cmp_versions_release_candidate_numeric_comparison);
+  add_test_with_context (suite, versionutils, cmp_versions_release_candidate_text_comparison);
+  add_test_with_context (suite, versionutils, cmp_versions_date_format);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());

--- a/util/versionutils_tests.c
+++ b/util/versionutils_tests.c
@@ -19,6 +19,31 @@ AfterEach (versionutils)
 
 /* cmp_versions */
 
+Ensure (versionutils, cmp_versions_handles_null_inputs)
+{
+  int result;
+
+  result = cmp_versions (NULL, "test");
+  assert_that (result, is_equal_to (-5));
+
+  result = cmp_versions ("test", NULL);
+  assert_that (result, is_equal_to (-5));
+
+  result = cmp_versions (NULL, NULL);
+  assert_that (result, is_equal_to (-5));
+}
+
+Ensure (versionutils, cmp_versions_identical_versions)
+{
+  char *version1, *version2;
+  int result;
+
+  version1 = "test-1.0";
+  version2 = "test-1.0";
+  result = cmp_versions (version1, version2);
+  assert_that (result, is_equal_to (0));
+}
+
 Ensure (versionutils, cmp_versions_basic_format_differences)
 {
   char *version1, *version2;
@@ -119,6 +144,22 @@ Ensure (versionutils, cmp_versions_date_format)
   assert_that (result, is_greater_than (0));
 }
 
+Ensure (versionutils, cmp_versions_additional_numeric_comparison)
+{
+  char *version1, *version2;
+  int result;
+
+  version1 = "test-2.5";
+  version2 = "test-2.3";
+  result = cmp_versions (version1, version2);
+  assert_that (result, is_greater_than (0));
+
+  version1 = "test-2.22";
+  version2 = "test-2.1";
+  result = cmp_versions (version1, version2);
+  assert_that (result, is_greater_than (0));
+}
+
 /* Test suite. */
 
 int
@@ -129,6 +170,8 @@ main (int argc, char **argv)
 
   suite = create_test_suite ();
 
+  add_test_with_context (suite, versionutils, cmp_versions_handles_null_inputs);
+  add_test_with_context (suite, versionutils, cmp_versions_identical_versions);
   add_test_with_context (suite, versionutils, cmp_versions_basic_format_differences);
   add_test_with_context (suite, versionutils, cmp_versions_text_vs_numeric_parts);
   add_test_with_context (suite, versionutils, cmp_versions_equivalent_formats);
@@ -138,6 +181,7 @@ main (int argc, char **argv)
   add_test_with_context (suite, versionutils, cmp_versions_release_candidate_numeric_comparison);
   add_test_with_context (suite, versionutils, cmp_versions_release_candidate_text_comparison);
   add_test_with_context (suite, versionutils, cmp_versions_date_format);
+  add_test_with_context (suite, versionutils, cmp_versions_additional_numeric_comparison);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

Close leaks in `cmp_versions`.

Found by `-fsanitize=address`.

Also increased test coverage of `cmp_versions`.

## Why

Neater.