### PR TITLE
Add: 422 response code for modifying the scan agent config

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -901,7 +901,7 @@ agent_controller_update_agents (agent_controller_connector_t conn,
       return AGENT_RESP_ERR;
     }
 
-  if (response->http_status == 400)
+  if (response->http_status == 400 || response->http_status == 422)
     {
       if (response->data)
         {
@@ -1191,7 +1191,7 @@ agent_controller_update_scan_agent_config (
       return AGENT_RESP_ERR;
     }
 
-  if (response->http_status == 400)
+  if (response->http_status == 400 || response->http_status == 422)
     {
       if (response->data)
         {

--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -220,8 +220,6 @@ agent_controller_parse_scan_agent_config (cJSON *root)
         gvm_json_obj_int (exec, "bulk_throttle_time_in_ms");
       cfg->agent_script_executor.indexer_dir_depth =
         gvm_json_obj_int (exec, "indexer_dir_depth");
-      cfg->agent_script_executor.period_in_seconds =
-        gvm_json_obj_int (exec, "period_in_seconds");
 
       cJSON *cron = cJSON_GetObjectItem (exec, "scheduler_cron_time");
       if (cJSON_IsArray (cron))
@@ -1037,8 +1035,6 @@ agent_controller_convert_scan_agent_config_string (
                            cfg->agent_script_executor.bulk_throttle_time_in_ms);
   cJSON_AddNumberToObject (exec, "indexer_dir_depth",
                            cfg->agent_script_executor.indexer_dir_depth);
-  cJSON_AddNumberToObject (exec, "period_in_seconds",
-                           cfg->agent_script_executor.period_in_seconds);
 
   const GPtrArray *arr = cfg->agent_script_executor.scheduler_cron_time;
   if (arr && arr->len > 0)

--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -220,6 +220,8 @@ agent_controller_parse_scan_agent_config (cJSON *root)
         gvm_json_obj_int (exec, "bulk_throttle_time_in_ms");
       cfg->agent_script_executor.indexer_dir_depth =
         gvm_json_obj_int (exec, "indexer_dir_depth");
+      cfg->agent_script_executor.period_in_seconds =
+        gvm_json_obj_int (exec, "period_in_seconds");
 
       cJSON *cron = cJSON_GetObjectItem (exec, "scheduler_cron_time");
       if (cJSON_IsArray (cron))
@@ -1035,6 +1037,8 @@ agent_controller_convert_scan_agent_config_string (
                            cfg->agent_script_executor.bulk_throttle_time_in_ms);
   cJSON_AddNumberToObject (exec, "indexer_dir_depth",
                            cfg->agent_script_executor.indexer_dir_depth);
+  cJSON_AddNumberToObject (exec, "period_in_seconds",
+                           cfg->agent_script_executor.period_in_seconds);
 
   const GPtrArray *arr = cfg->agent_script_executor.scheduler_cron_time;
   if (arr && arr->len > 0)

--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -88,6 +88,7 @@ struct agent_controller_script_exec_cfg
   int bulk_throttle_time_in_ms; ///< Throttle/sleep between batches in
   ///< milliseconds
   int indexer_dir_depth; ///< Max directory depth to scan/index
+  int period_in_seconds; ///< Period in second
 
   GPtrArray *scheduler_cron_time; ///< Optional list of cron expressions
   ///< Format: standard 5-field cron like

--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -88,7 +88,6 @@ struct agent_controller_script_exec_cfg
   int bulk_throttle_time_in_ms; ///< Throttle/sleep between batches in
   ///< milliseconds
   int indexer_dir_depth; ///< Max directory depth to scan/index
-  int period_in_seconds; ///< Period in second
 
   GPtrArray *scheduler_cron_time; ///< Optional list of cron expressions
   ///< Format: standard 5-field cron like

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -107,7 +107,6 @@ make_scan_agent_config (void)
   cfg->agent_script_executor.bulk_size = 1;
   cfg->agent_script_executor.bulk_throttle_time_in_ms = 1;
   cfg->agent_script_executor.indexer_dir_depth = 1;
-  cfg->agent_script_executor.period_in_seconds = 1;
   cfg->agent_script_executor.scheduler_cron_time =
     g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (cfg->agent_script_executor.scheduler_cron_time,
@@ -824,7 +823,6 @@ Ensure (agent_controller, scan_agent_config_new_initializes_defaults)
   assert_that (cfg->agent_script_executor.bulk_throttle_time_in_ms,
                is_equal_to (0));
   assert_that (cfg->agent_script_executor.indexer_dir_depth, is_equal_to (0));
-  assert_that (cfg->agent_script_executor.period_in_seconds, is_equal_to (0));
   assert_that (cfg->agent_script_executor.scheduler_cron_time, is_null);
 
   /* heartbeat defaults */
@@ -899,7 +897,6 @@ Ensure (agent_controller, build_scan_agent_config_payload_with_values)
   cfg->agent_script_executor.bulk_size = 2;
   cfg->agent_script_executor.bulk_throttle_time_in_ms = 100;
   cfg->agent_script_executor.indexer_dir_depth = 10;
-  cfg->agent_script_executor.period_in_seconds = 1;
 
   /* GPtrArray-based cron list */
   cfg->agent_script_executor.scheduler_cron_time =
@@ -924,7 +921,6 @@ Ensure (agent_controller, build_scan_agent_config_payload_with_values)
   assert_that (payload, contains_string ("\"bulk_size\":2"));
   assert_that (payload, contains_string ("\"bulk_throttle_time_in_ms\":100"));
   assert_that (payload, contains_string ("\"indexer_dir_depth\":10"));
-  assert_that (payload, contains_string ("\"period_in_seconds\":1"));
 
   assert_that (payload, contains_string ("\"scheduler_cron_time\":["));
   assert_that (payload, contains_string ("\"0 23 * * *\""));

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -1396,6 +1396,34 @@ Ensure (agent_controller, update_agents_400_invalid_json_adds_invalid_payload)
   agent_controller_connector_free (conn);
 }
 
+Ensure (agent_controller, update_agents_422_invalid_json_adds_invalid_payload)
+{
+  mock_http_status = 422;
+  mock_response_data = g_strdup ("not-json");
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_agent_list_t list = agent_controller_agent_list_new (1);
+  list->agents[0] = agent_controller_agent_new ();
+  list->agents[0]->agent_id = g_strdup ("agent1");
+
+  agent_controller_agent_update_t update = agent_controller_agent_update_new ();
+
+  GPtrArray *errs = NULL;
+  int rc = agent_controller_update_agents (conn, list, update, &errs);
+
+  assert_that (rc, is_equal_to (-1));
+  assert_that (errs, is_not_null);
+  assert_that ((int) errs->len, is_equal_to (1));
+  assert_that ((const gchar *) g_ptr_array_index (errs, 0),
+               contains_string ("invalid JSON payload"));
+
+  g_ptr_array_free (errs, TRUE);
+  agent_controller_agent_list_free (list);
+  agent_controller_agent_update_free (update);
+  agent_controller_connector_free (conn);
+}
+
 Ensure (agent_controller, update_agents_500_does_not_allocate_errors)
 {
   mock_http_status = 500;
@@ -1744,6 +1772,34 @@ Ensure (agent_controller,
         update_scan_agent_config_400_populates_errors_from_json)
 {
   mock_http_status = 400;
+  mock_response_data =
+    g_strdup ("{ \"errors\": [\"e1\", \"e2\"], \"warnings\": null }");
+
+  agent_controller_connector_t conn = make_conn ();
+  agent_controller_scan_agent_config_t cfg = make_scan_agent_config ();
+
+  GPtrArray *errs = NULL;
+  int rc = agent_controller_update_scan_agent_config (conn, cfg, &errs);
+
+  assert_that (rc, is_equal_to (-1));
+  assert_that (errs, is_not_null);
+  assert_that ((int) errs->len, is_equal_to (2));
+  assert_that ((const gchar *) g_ptr_array_index (errs, 0),
+               is_equal_to_string ("e1"));
+  assert_that ((const gchar *) g_ptr_array_index (errs, 1),
+               is_equal_to_string ("e2"));
+  assert_that (last_sent_url,
+               contains_string ("/api/v1/admin/scan-agent-config"));
+
+  g_ptr_array_free (errs, TRUE);
+  agent_controller_scan_agent_config_free (cfg);
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        update_scan_agent_config_422_populates_errors_from_json)
+{
+  mock_http_status = 422;
   mock_response_data =
     g_strdup ("{ \"errors\": [\"e1\", \"e2\"], \"warnings\": null }");
 
@@ -2580,6 +2636,8 @@ main (int argc, char **argv)
   add_test_with_context (suite, agent_controller,
                          update_agents_400_invalid_json_adds_invalid_payload);
   add_test_with_context (suite, agent_controller,
+                         update_agents_422_invalid_json_adds_invalid_payload);
+  add_test_with_context (suite, agent_controller,
                          update_agents_500_does_not_allocate_errors);
   add_test_with_context (suite, agent_controller,
                          update_agents_no_response_returns_error);
@@ -2616,6 +2674,9 @@ main (int argc, char **argv)
   add_test_with_context (
     suite, agent_controller,
     update_scan_agent_config_400_populates_errors_from_json);
+  add_test_with_context (
+    suite, agent_controller,
+    update_scan_agent_config_422_populates_errors_from_json);
   add_test_with_context (suite, agent_controller,
                          update_scan_agent_config_400_empty_body_adds_fallback);
   add_test_with_context (

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -107,6 +107,7 @@ make_scan_agent_config (void)
   cfg->agent_script_executor.bulk_size = 1;
   cfg->agent_script_executor.bulk_throttle_time_in_ms = 1;
   cfg->agent_script_executor.indexer_dir_depth = 1;
+  cfg->agent_script_executor.period_in_seconds = 1;
   cfg->agent_script_executor.scheduler_cron_time =
     g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (cfg->agent_script_executor.scheduler_cron_time,
@@ -823,6 +824,7 @@ Ensure (agent_controller, scan_agent_config_new_initializes_defaults)
   assert_that (cfg->agent_script_executor.bulk_throttle_time_in_ms,
                is_equal_to (0));
   assert_that (cfg->agent_script_executor.indexer_dir_depth, is_equal_to (0));
+  assert_that (cfg->agent_script_executor.period_in_seconds, is_equal_to (0));
   assert_that (cfg->agent_script_executor.scheduler_cron_time, is_null);
 
   /* heartbeat defaults */
@@ -897,6 +899,7 @@ Ensure (agent_controller, build_scan_agent_config_payload_with_values)
   cfg->agent_script_executor.bulk_size = 2;
   cfg->agent_script_executor.bulk_throttle_time_in_ms = 100;
   cfg->agent_script_executor.indexer_dir_depth = 10;
+  cfg->agent_script_executor.period_in_seconds = 1;
 
   /* GPtrArray-based cron list */
   cfg->agent_script_executor.scheduler_cron_time =
@@ -921,6 +924,7 @@ Ensure (agent_controller, build_scan_agent_config_payload_with_values)
   assert_that (payload, contains_string ("\"bulk_size\":2"));
   assert_that (payload, contains_string ("\"bulk_throttle_time_in_ms\":100"));
   assert_that (payload, contains_string ("\"indexer_dir_depth\":10"));
+  assert_that (payload, contains_string ("\"period_in_seconds\":1"));
 
   assert_that (payload, contains_string ("\"scheduler_cron_time\":["));
   assert_that (payload, contains_string ("\"0 23 * * *\""));


### PR DESCRIPTION
## What
Add 422 response code for modifying the scan agent config
## Why

This response code needs to be handled properly for returning a valid error response
 
## References

GEA-1278

## Checklist


- [x] Tests


