### PR TITLE
Add: Added scan_id to container_image_target

### DIFF
--- a/container_image_scanner/container_image_scanner.c
+++ b/container_image_scanner/container_image_scanner.c
@@ -15,6 +15,7 @@
  */
 struct container_image_target
 {
+  gchar *scan_id;      /**  Scan ID */
   GSList *credentials; /** Credentials to use in the scan */
   gchar *hosts;        /** String defining one or many hosts to scan */
 };
@@ -98,6 +99,9 @@ container_image_build_scan_config_json (container_image_target_t *target,
   /* Build the message in json format to be published. */
   scan_obj = cJSON_CreateObject ();
 
+  if (target->scan_id && target->scan_id[0] != '\0')
+    cJSON_AddStringToObject (scan_obj, "scan_id", target->scan_id);
+
   // begin target
   target_obj = cJSON_CreateObject ();
 
@@ -138,15 +142,19 @@ container_image_build_scan_config_json (container_image_target_t *target,
 /**
  * @brief Create a new container_image target.
  *
+ * @param scanid         Scan ID.
  * @param hosts          The hostnames of the target.
  *
  * @return The newly allocated container_image_target_t.
  */
 container_image_target_t *
-container_image_target_new (const gchar *hosts)
+container_image_target_new (const gchar *scanid, const gchar *hosts)
 {
   container_image_target_t *new_target;
   new_target = g_malloc0 (sizeof (container_image_target_t));
+
+  if (scanid && *scanid)
+    new_target->scan_id = g_strdup (scanid);
 
   new_target->hosts = hosts ? g_strdup (hosts) : NULL;
 
@@ -167,6 +175,7 @@ container_image_target_free (container_image_target_t *target)
   g_slist_free_full (target->credentials,
                      (GDestroyNotify) container_image_credential_free);
   g_free (target->hosts);
+  g_free (target->scan_id);
   g_free (target);
   target = NULL;
 }

--- a/container_image_scanner/container_image_scanner.h
+++ b/container_image_scanner/container_image_scanner.h
@@ -21,7 +21,7 @@ typedef struct container_image_target container_image_target_t;
 typedef struct container_image_credential container_image_credential_t;
 
 container_image_target_t *
-container_image_target_new (const gchar *);
+container_image_target_new (const gchar *, const gchar *);
 
 void
 container_image_target_free (container_image_target_t *);

--- a/container_image_scanner/container_image_scanner_tests.c
+++ b/container_image_scanner/container_image_scanner_tests.c
@@ -28,16 +28,19 @@ Ensure (container_image, null_free_doesnt_crash)
 
 Ensure (container_image, new_container_image_target_has_hosts)
 {
-  container_image_target_t *target = container_image_target_new (NULL);
+  container_image_target_t *target = container_image_target_new (NULL, NULL);
 
   assert_that (target, is_not_equal_to (NULL));
+  assert_that (target->scan_id, is_equal_to (NULL));
   assert_that (target->hosts, is_equal_to (NULL));
   container_image_target_free (target);
 
+  const gchar *scanid = "TEST-SCAN-ID";
   const gchar *hosts = "oci://test/path,oci://test2/path";
-  target = container_image_target_new (hosts);
+  target = container_image_target_new (scanid, hosts);
 
   assert_that (target, is_not_equal_to (NULL));
+  assert_that (target->scan_id, is_equal_to_string (scanid));
   assert_that (target->hosts, is_equal_to_string (hosts));
   container_image_target_free (target);
 }
@@ -157,7 +160,7 @@ Ensure (container_image, container_image_add_preferences_to_scan_json)
 
 Ensure (container_image, container_image_target_add_credentials)
 {
-  container_image_target_t *target = container_image_target_new ("hosts");
+  container_image_target_t *target = container_image_target_new (NULL, "hosts");
 
   container_image_credential_t *credential =
     container_image_credential_new ("test", "generic");
@@ -187,7 +190,7 @@ Ensure (container_image, container_image_target_add_credentials)
 Ensure (container_image, emit_simple_scan_json)
 {
   container_image_target_t *target =
-    container_image_target_new ("oci://test-host/test-image");
+    container_image_target_new ("TEST-ID", "oci://test-host/test-image");
 
   container_image_credential_t *credential =
     container_image_credential_new ("up", "generic");
@@ -202,6 +205,7 @@ Ensure (container_image, emit_simple_scan_json)
 
   assert_that (json, is_equal_to_string (
                        "{\n"
+                       "\t\"scan_id\":\t\"TEST-ID\",\n"
                        "\t\"target\":\t{\n"
                        "\t\t\"hosts\":\t[\"oci://test-host/test-image\"],\n"
                        "\t\t\"credentials\":\t[{\n"


### PR DESCRIPTION
## What

Added scan_id to container_image_target

## Why

It is required to start a scanner task properly

## References

GEA-1254


