### PR TITLE
Fix: close leaks shown by agent controller tests

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -97,7 +97,7 @@ init_custom_header (const gchar *apikey, gboolean content_type)
  * @param[in] apikey        Optional Api key for Authorization header.
  *
  * @return Pointer to a `gvm_http_response_t` containing status code and body.
- *         Must be freed using `gvm_http_response_cleanup()`.
+ *         Must be freed using `gvm_http_response_free()`.
  */
 static gvm_http_response_t *
 agent_controller_send_request (agent_controller_connector_t conn,
@@ -816,7 +816,7 @@ agent_controller_get_agents (agent_controller_connector_t conn)
     {
       g_warning ("%s: Received HTTP status %ld", __func__,
                  response->http_status);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return NULL;
     }
 
@@ -826,7 +826,7 @@ agent_controller_get_agents (agent_controller_connector_t conn)
       g_warning ("%s: Failed to parse JSON array", __func__);
       if (root)
         cJSON_Delete (root);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return NULL;
     }
 
@@ -852,7 +852,7 @@ agent_controller_get_agents (agent_controller_connector_t conn)
   agent_list->count = valid_index;
 
   cJSON_Delete (root);
-  gvm_http_response_cleanup (response);
+  gvm_http_response_free (response);
 
   return agent_list;
 }
@@ -914,7 +914,7 @@ agent_controller_update_agents (agent_controller_connector_t conn,
           g_free (msg);
         }
 
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return AGENT_RESP_ERR;
     }
 
@@ -922,11 +922,11 @@ agent_controller_update_agents (agent_controller_connector_t conn,
     {
       g_warning ("%s: Received HTTP status %ld", __func__,
                  response->http_status);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return AGENT_RESP_ERR;
     }
 
-  gvm_http_response_cleanup (response);
+  gvm_http_response_free (response);
 
   return AGENT_RESP_OK;
 }
@@ -990,11 +990,11 @@ agent_controller_delete_agents (agent_controller_connector_t conn,
     {
       g_warning ("%s: Received HTTP status %ld", __func__,
                  response->http_status);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return AGENT_RESP_ERR;
     }
 
-  gvm_http_response_cleanup (response);
+  gvm_http_response_free (response);
 
   return AGENT_RESP_OK;
 }
@@ -1131,7 +1131,7 @@ agent_controller_get_scan_agent_config (agent_controller_connector_t conn)
   if (response->http_status < 200 || response->http_status >= 300)
     {
       g_warning ("%s: HTTP %ld", __func__, response->http_status);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return NULL;
     }
 
@@ -1139,7 +1139,7 @@ agent_controller_get_scan_agent_config (agent_controller_connector_t conn)
   if (!root)
     {
       g_warning ("%s: JSON parse failed", __func__);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return NULL;
     }
 
@@ -1147,7 +1147,7 @@ agent_controller_get_scan_agent_config (agent_controller_connector_t conn)
     agent_controller_parse_scan_agent_config (root);
 
   cJSON_Delete (root);
-  gvm_http_response_cleanup (response);
+  gvm_http_response_free (response);
   return cfg;
 }
 
@@ -1206,18 +1206,18 @@ agent_controller_update_scan_agent_config (
           g_free (msg);
         }
 
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return AGENT_RESP_ERR;
     }
 
   if (response->http_status < 200 || response->http_status >= 300)
     {
       g_warning ("%s: HTTP %ld", __func__, response->http_status);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return AGENT_RESP_ERR;
     }
 
-  gvm_http_response_cleanup (response);
+  gvm_http_response_free (response);
   return AGENT_RESP_OK;
 }
 
@@ -1251,7 +1251,7 @@ agent_controller_get_agents_with_updates (agent_controller_connector_t conn)
     {
       g_warning ("%s: Received HTTP status %ld", __func__,
                  response->http_status);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return NULL;
     }
 
@@ -1261,7 +1261,7 @@ agent_controller_get_agents_with_updates (agent_controller_connector_t conn)
       g_warning ("%s: Failed to parse JSON array", __func__);
       if (root)
         cJSON_Delete (root);
-      gvm_http_response_cleanup (response);
+      gvm_http_response_free (response);
       return NULL;
     }
 
@@ -1283,7 +1283,7 @@ agent_controller_get_agents_with_updates (agent_controller_connector_t conn)
   agent_list->count = valid_index;
 
   cJSON_Delete (root);
-  gvm_http_response_cleanup (response);
+  gvm_http_response_free (response);
 
   return agent_list;
 }

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -266,6 +266,8 @@ Ensure (agent_controller, agent_new_allocates_zero_initialized_agent)
   agent_controller_agent_t agent = agent_controller_agent_new ();
 
   assert_that (agent, is_not_null);
+
+  agent_controller_agent_free (agent);
 }
 
 Ensure (agent_controller, agent_free_handles_agent)
@@ -444,7 +446,7 @@ Ensure (agent_controller, send_request_builds_url_and_calls_http_request)
                is_equal_to_string ("https://localhost:8080/api/v1/test"));
   assert_that (last_sent_payload, is_equal_to_string (payload));
 
-  g_free (resp);
+  gvm_http_response_free (resp);
   agent_controller_connector_free (conn);
 }
 
@@ -495,7 +497,7 @@ Ensure (agent_controller, send_request_works_without_bearer_token)
   assert_that (last_sent_url,
                is_equal_to_string ("https://localhost:8080/test"));
 
-  g_free (resp);
+  gvm_http_response_free (resp);
   agent_controller_connector_free (conn);
 }
 

--- a/http/httputils.c
+++ b/http/httputils.c
@@ -295,7 +295,7 @@ gvm_http_response_stream_free (gvm_http_response_stream_t s)
  * created.
  *
  * @return A pointer to a `gvm_http_response_t` containing the response data and
- * status. Must be freed with `gvm_http_response_cleanup()`.
+ * status. Must be freed with `gvm_http_response_free()`.
  */
 gvm_http_response_t *
 gvm_http_request (const gchar *url, gvm_http_method_t method,
@@ -369,20 +369,14 @@ gvm_http_request (const gchar *url, gvm_http_method_t method,
  *                 Can safely be NULL.
  */
 void
-gvm_http_response_cleanup (gvm_http_response_t *response)
+gvm_http_response_free (gvm_http_response_t *response)
 {
   if (!response)
     return;
 
-  if (response->http)
-    {
-      gvm_http_free (response->http);
-      response->http = NULL;
-    }
-
+  gvm_http_free (response->http);
   g_free (response->data);
-  response->data = NULL;
-  response->size = 0;
+  g_free (response);
 }
 
 /**

--- a/http/httputils.h
+++ b/http/httputils.h
@@ -135,7 +135,7 @@ void
 gvm_http_headers_free (gvm_http_headers_t *headers);
 
 void
-gvm_http_response_cleanup (gvm_http_response_t *response);
+gvm_http_response_free (gvm_http_response_t *response);
 
 gvm_http_multi_t *
 gvm_http_multi_new (void);

--- a/http/httputils_tests.c
+++ b/http/httputils_tests.c
@@ -76,18 +76,16 @@ Ensure (gvm_http, multi_handler_free_does_not_crash_on_null)
   assert_that (true, is_true);
 }
 
-Ensure (gvm_http, response_cleanup_frees_data_fields)
+Ensure (gvm_http, response_free_does_not_crash)
 {
   gvm_http_response_t *res = g_malloc0 (sizeof (gvm_http_response_t));
   res->data = g_strdup ("mock");
   res->size = 100;
   res->http_status = 200;
 
-  gvm_http_response_cleanup (res);
+  gvm_http_response_free (res);
 
-  assert_that (res->data, is_null);
-  assert_that (res->size, is_equal_to (0));
-  g_free (res);
+  assert_that (true, is_true);
 }
 
 Ensure (gvm_http, response_stream_free_handles_null)
@@ -187,7 +185,7 @@ main (int argc, char **argv)
                          multi_perform_with_null_returns_bad_handle);
   add_test_with_context (suite, gvm_http,
                          multi_handler_free_does_not_crash_on_null);
-  add_test_with_context (suite, gvm_http, response_cleanup_frees_data_fields);
+  add_test_with_context (suite, gvm_http, response_free_does_not_crash);
   add_test_with_context (suite, gvm_http, response_stream_free_handles_null);
   add_test_with_context (suite, gvm_http,
                          response_stream_free_handles_valid_stream);

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -410,7 +410,7 @@ http_scanner_send_request (http_scanner_connector_t conn,
     {
       g_warning ("%s: Error performing CURL request", __func__);
       response->body = g_strdup ("{\"error\": \"Error sending request\"}");
-      gvm_http_response_cleanup (http_response);
+      gvm_http_response_free (http_response);
       g_free (url);
       gvm_http_headers_free (custom_headers);
       return response;
@@ -434,7 +434,7 @@ http_scanner_send_request (http_scanner_connector_t conn,
     }
 
   // Cleanup
-  gvm_http_response_cleanup (http_response);
+  gvm_http_response_free (http_response);
   g_free (url);
   gvm_http_headers_free (custom_headers);
 


### PR DESCRIPTION
## What

Close a leak in `gvm_http_response_cleanup`. And close leaks in the agent controller tests themselves.

Shown by `-fsanitize=address`.

## Why

Neater.

