### PR TITLE
Change: simplify http_scanner_connector_builder conn requirements

### DIFF
--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -59,18 +59,18 @@ http_scanner_connector_new (void)
  *
  *  Receive option name and value to build the HTTP scanner connector.
  *
- *  @param conn   struct holding the HTTP scanner connector information.
+ *  @param conn   the HTTP scanner connector information.
  *  @param opt    option to set.
  *  @param val    value to set.
  *
- *  @return Return OK on success, otherwise error.
+ *  @return Return HTTP_SCANNER_OK on success, otherwise error.
  */
 http_scanner_error_t
 http_scanner_connector_builder (http_scanner_connector_t conn,
                                 http_scanner_conn_opt_t opt, const void *val)
 {
   if (conn == NULL)
-    conn = http_scanner_connector_new ();
+    return HTTP_SCANNER_NOT_INITIALIZED;
 
   if (opt < HTTP_SCANNER_CA_CERT || opt > HTTP_SCANNER_SCAN_PREFIX)
     return HTTP_SCANNER_INVALID_OPT;

--- a/http_scanner/http_scanner_test.c
+++ b/http_scanner/http_scanner_test.c
@@ -244,6 +244,14 @@ Ensure (http_scanner, http_scanner_connector_builder_invalid_protocol)
   g_free (conn);
 }
 
+Ensure (http_scanner, http_scanner_connector_builder_null_conn)
+{
+  http_scanner_error_t result =
+    http_scanner_connector_builder (NULL, HTTP_SCANNER_PROTOCOL, "https");
+
+  assert_that (result, is_equal_to (HTTP_SCANNER_NOT_INITIALIZED));
+}
+
 Ensure (http_scanner, http_scanner_connector_free)
 {
   http_scanner_connector_t conn = http_scanner_connector_new ();
@@ -287,6 +295,8 @@ main (int argc, char **argv)
                          http_scanner_connector_builder_valid_protocol_http);
   add_test_with_context (suite, http_scanner,
                          http_scanner_connector_builder_invalid_protocol);
+  add_test_with_context (suite, http_scanner,
+                         http_scanner_connector_builder_null_conn);
   add_test_with_context (suite, http_scanner, http_scanner_connector_free);
   add_test_with_context (suite, http_scanner,
                          http_scanner_connector_builder_invalid_protocol);


### PR DESCRIPTION
## What

When conn is NULL return an error instead of trying to allocate. 

## Why

The is easier to maintain. For example, because conn is a pointer to a struct the allocation was actually leaking.

The callers in gvmd all create the conn themselves so this is a safe change.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


