### PR TITLE
Don't build versioned container image for testing and oldstable

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -37,11 +37,15 @@ jobs:
               dockerfile: .docker/prod-testing.Dockerfile
               stable-name: testing
               edge-name: testing-edge
+              enable-version: false
+              enable-latest: false
           - build:
               name: oldstable
               dockerfile: .docker/prod-oldstable.Dockerfile
               stable-name: oldstable
               edge-name: oldstable-edge
+              enable-version: false
+              enable-latest: false
     name: Build and Push Container Images (${{ matrix.build.name }})
     uses: greenbone/workflows/.github/workflows/container-build-push-gea.yml@main
     with:


### PR DESCRIPTION


## What

Don't build versioned container image for testing and oldstable

## Why

Also don't use the latest container image tag for testing and oldstable builds.