### PR TITLE
Tune linking of container_image_scanner

### DIFF
--- a/container_image_scanner/CMakeLists.txt
+++ b/container_image_scanner/CMakeLists.txt
@@ -70,6 +70,7 @@ if(BUILD_SHARED)
       gvm_util_shared
       ${GLIB_LDFLAGS}
       ${CURL_LDFLAGS}
+      ${CJSON_LDFLAGS}
       ${LINKER_HARDENING_FLAGS}
   )
 endif(BUILD_SHARED)


### PR DESCRIPTION
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Tune linking of container_image_scanner.

## Why

<!-- Describe why are these changes necessary? -->

Without cjson ldflags ldd will compain about undefined symbols.

Before:

```
ldd -r -d /usr/lib64/libgvm_container_image_scanner.so.22.29.0
        linux-vdso.so.1 (0x00007fa6784c6000)
        libeatmydata.so => /lib64/libeatmydata.so (0x00007fa6784b3000)
        libglib-2.0.so.0 => /lib64/libglib-2.0.so.0 (0x00007fa678364000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fa67818b000)
        libpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x00007fa6780e9000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fa6784c8000)
undefined symbol: cJSON_CreateObject    (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
undefined symbol: cJSON_Print   (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
undefined symbol: cJSON_AddStringToObject       (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
undefined symbol: cJSON_AddItemToArray  (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
undefined symbol: cJSON_Delete  (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
undefined symbol: cJSON_CreateArray     (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
undefined symbol: cJSON_CreateString    (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
undefined symbol: cJSON_AddItemToObject (/usr/lib64/libgvm_container_image_scanner.so.22.29.0)
```

After:
```
ldd -r -d /usr/lib64/libgvm_container_image_scanner.so.22
        linux-vdso.so.1 (0x00007f56b4a00000)
        libeatmydata.so => /lib64/libeatmydata.so (0x00007f56b49ed000)
        libglib-2.0.so.0 => /lib64/libglib-2.0.so.0 (0x00007f56b489e000)
        libcjson.so.1 => /lib64/libcjson.so.1 (0x00007f56b4894000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f56b46bb000)
        libpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x00007f56b4619000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f56b4a02000)
```