### PR TITLE
Fix uploading stable images to public greenbone container registry

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -64,7 +64,7 @@ jobs:
       prefix: ${{ matrix.build.prefix }}
       images: |
         ghcr.io/${{ github.repository }},enable=true
-        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'default' }}
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'stable' }}
     secrets: inherit
 
   notify:


### PR DESCRIPTION


## What

Fix uploading stable images to public greenbone container registry

## Why

The build name is stable not default.

