### PR TITLE
Fix syntax for install dependencies shell script

### DIFF
--- a/.github/install-dependencies.sh
+++ b/.github/install-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This script installs gvm-libs dependencies
 set -e
 
@@ -6,7 +6,7 @@ BASEDIR=$(dirname "$0")
 DEFAULT_DEPENDENCIES_FILE="$BASEDIR/build-dependencies.list"
 DEPENDENCIES_FILE=${1:-$DEFAULT_DEPENDENCIES_FILE}
 
-if [[ ! -f "$DEPENDENCIES_FILE" ]]; then
+if [ ! -f "$DEPENDENCIES_FILE" ]; then
     echo "Dependencies file not found: $DEPENDENCIES_FILE"
     exit 1
 fi


### PR DESCRIPTION


## What
Fix syntax for install dependencies shell script
## Why

The script required bash but is actually run with the standard shell. Therefore just use standard shell syntax for if statement.