### PR TITLE
Add: check for NULL in auth_method_name_valid

### DIFF
--- a/util/authutils.c
+++ b/util/authutils.c
@@ -90,8 +90,9 @@ auth_method_name (auth_method_t method)
 int
 auth_method_name_valid (const gchar *name)
 {
-  int i;
-  for (i = 0; i < 1000; i++)
+  if (name == NULL)
+    return 0;
+  for (int i = 0; i < 1000; i++)
     if (authentication_methods[i] == NULL)
       break;
     else if (strcmp (authentication_methods[i], name) == 0)

--- a/util/authutils_tests.c
+++ b/util/authutils_tests.c
@@ -46,7 +46,7 @@ Ensure (authutils, auth_method_name_valid_returns_one_for_valid_names)
 Ensure (authutils, auth_method_name_valid_returns_zero_for_invalid_names)
 {
   assert_that (auth_method_name_valid ("invalid_method"), is_equal_to (0));
-  // assert_that (auth_method_name_valid (NULL), is_equal_to (0)); // TODO
+  assert_that (auth_method_name_valid (NULL), is_equal_to (0));
 }
 
 /* gvm_auth_ldap_enabled */


### PR DESCRIPTION
## What

Add a NULL check in `auth_method_name_valid`.

## Why

Prevents a segfault if NULL is ever passed.
<!-- Describe why are these changes necessary? -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


