### PR TITLE
Fix: length in digest_hex_returns_correct_hex_string

### DIFF
--- a/util/authutils.c
+++ b/util/authutils.c
@@ -162,13 +162,14 @@ gvm_auth_init (void)
 /**
  * @brief Generate a hexadecimal representation of a message digest.
  *
- * @param gcrypt_algorithm The libgcrypt message digest algorithm used to
- * create the digest (e.g. GCRY_MD_MD5; see the enum gcry_md_algos in
- * gcrypt.h).
- * @param digest The binary representation of the digest.
+ * @param gcrypt_algorithm  The libgcrypt message digest algorithm used to
+ *                          create the digest (e.g. GCRY_MD_MD5; see the enum
+ *                          gcry_md_algos in gcrypt.h).
+ * @param digest  The binary representation of the digest. Must be big enough
+ *                for the gcrypt_algorithm.
  *
  * @return A pointer to the hexadecimal representation of the message digest
- * or NULL if an unavailable message digest algorithm was selected.
+ *         or NULL if an unavailable message digest algorithm was selected.
  */
 gchar *
 digest_hex (int gcrypt_algorithm, const guchar *digest)

--- a/util/authutils_tests.c
+++ b/util/authutils_tests.c
@@ -75,10 +75,11 @@ Ensure (authutils, gvm_auth_radius_enabled_returns_one_when_enabled)
 
 Ensure (authutils, digest_hex_returns_correct_hex_string)
 {
-  guchar digest[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};
+  guchar digest[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
   gchar *hex = digest_hex (GCRY_MD_MD5, digest);
   assert_that (hex, is_not_null);
-  assert_that (hex, is_equal_to_string ("000102030405"));
+  assert_that (hex, is_equal_to_string ("000102030405060708090a0b0c0d0e0f"));
   g_free (hex);
 }
 
@@ -215,9 +216,8 @@ main (int argc, char **argv)
                          gvm_auth_ldap_enabled_returns_one_when_enabled);
   add_test_with_context (suite, authutils,
                          gvm_auth_radius_enabled_returns_one_when_enabled);
-  // TODO
-  // add_test_with_context (suite,
-  //                        authutils, digest_hex_returns_correct_hex_string);
+  add_test_with_context (suite, authutils,
+                         digest_hex_returns_correct_hex_string);
   add_test_with_context (suite, authutils,
                          digest_hex_returns_null_for_invalid_algorithm);
   add_test_with_context (suite, authutils,


### PR DESCRIPTION
## What

Fix the length of the digest argument in the test `digest_hex_returns_correct_hex_string`, and enable the test.

Also note the length requirement in the digest_hex doc.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

The digest array must be long enough for the algorithm, else a segfault occurs.

<!-- Describe why are these changes necessary? -->
