### PR TITLE
Use libcurl4 with OpenSSL instead of GnuTLS

### DIFF
--- a/.github/build-dependencies.list
+++ b/.github/build-dependencies.list
@@ -7,7 +7,7 @@ git
 gnupg
 lcov
 libcjson-dev
-libcurl4-gnutls-dev
+libcurl4-openssl-dev
 libgcrypt-dev
 libglib2.0-dev
 libgnutls28-dev

--- a/.github/runtime-dependencies.stable.list
+++ b/.github/runtime-dependencies.stable.list
@@ -1,5 +1,5 @@
 libcjson1
-libcurl3t64-gnutls
+libcurl4t64
 libgcrypt20
 libglib2.0-0
 libgnutls30t64

--- a/.github/runtime-dependencies.testing.list
+++ b/.github/runtime-dependencies.testing.list
@@ -1,5 +1,5 @@
 libcjson1
-libcurl3t64-gnutls
+libcurl4t64
 libgcrypt20
 libglib2.0-0
 libgnutls30


### PR DESCRIPTION
## What

Use libcurl4 with OpenSSL instead of GnuTLS

## Why

Require OpenSSL for using libcurl with SSL because it seems the GnuTLS version can't handle certificates passed as blobs. This change affects the following `.so` files of gvm-libs

```
libgvm_agent_controller.so
libgvm_http_scanner.so
libgvm_http.so
libgvm_openvasd.so
libgvm_container_image_scanner.so
```

All these `.so` files are now incompatible with GPLv2 only binaries because OpenSSL >= version 3 is published under the Apache 2 license.



