### PR TITLE
Doc: Updated INSTALL.md to reflect using libcurl-openssl-dev

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ Install prerequisites on Debian stable:
     apt-get install \
     cmake \
     libcjson-dev \
-    libcurl4-gnutls-dev \
+    libcurl4-openssl-dev \
     libgcrypt-dev \
     libglib2.0-dev \
     libgnutls28-dev \


### PR DESCRIPTION
## What

Update INSTALL.md document to reflect used packages for building gvm-libs.

## Why

Keep documentation up-to-date, as we switched to libcurl linked against openssl.

## References

GEA-1245
