### PR TITLE
Change: demote HTTP non-200 and CURL errors to debug

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -814,8 +814,7 @@ agent_controller_get_agents (agent_controller_connector_t conn)
 
   if (response->http_status != 200)
     {
-      g_debug ("%s: Received HTTP status %ld", __func__,
-                 response->http_status);
+      g_debug ("%s: Received HTTP status %ld", __func__, response->http_status);
       gvm_http_response_free (response);
       return NULL;
     }

--- a/http/httputils.c
+++ b/http/httputils.c
@@ -338,7 +338,7 @@ gvm_http_request (const gchar *url, gvm_http_method_t method,
   else
     {
       g_debug ("%s: Error performing CURL request: %s", __func__,
-                 curl_easy_strerror (result));
+               curl_easy_strerror (result));
       http_response->http_status = -1;
       http_response->data =
         g_strdup_printf ("{\"error\": \"CURL request failed: %s\"}",


### PR DESCRIPTION
## What

Demote HTTP non-200 and CURL errors to debug.

## Why

Reduce log noise during expected/transient conditions that were spamming WARNING.

## References

GEA-1306



