### PR TITLE
Fix: Install 'libcgreen1-dev' for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ARG USER_GID=$USER_UID
 RUN --mount=type=bind,source=.github,target=/source/ \
     sh /source/install-dependencies.sh /source/build-dependencies.list
 RUN apt-get install -y --no-install-recommends \
-    clang-format cgreen1
+    clang-format libcgreen1-dev
 
 # add non-root user
 RUN groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
## What

Follow-up on #1016 

To properly execute the unit tests, the `cgreen-config.cmake` file needs to be present so that `cmake` can detect `cgreen`. This file is provided by the `libcgreen1-dev` package, so use this one instead.

## Why

Generating coverage reports in the devcontainer will fail otherwise.
<!-- Describe why are these changes necessary? -->

## References

#1016 

## Checklist

- [x] Tests

Previous output of `cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1 -DENABLE_COVERAGE=1`:

```
...
-- Tests enabled.
CMake Error at CMakeLists.txt:229 (find_package):
  By not providing "Findcgreen.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "cgreen", but
  CMake did not find one.

  Could not find a package configuration file provided by "cgreen" with any
  of the following names:

    cgreenConfig.cmake
    cgreen-config.cmake

  Add the installation prefix of "cgreen" to CMAKE_PREFIX_PATH or set
  "cgreen_DIR" to a directory containing one of the above files.  If "cgreen"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
```

With a container built with the fixed `Dockerfile`, generating coverage reports works again.
