### PR TITLE
Fix: Ignore tests themselves for coverage

### DIFF
--- a/.gcovr.cfg
+++ b/.gcovr.cfg
@@ -1,0 +1,2 @@
+exclude = .*_tests\.c$
+exclude = ^tests/.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,15 +287,15 @@ if(BUILD_TESTS AND NOT SKIP_SRC)
     add_custom_target(
       coverage-html
       COMMAND
-        ${GCOVR} --html-details ${COVERAGE_DIR}/coverage.html -r
-        ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
+        ${GCOVR} --config ${CMAKE_SOURCE_DIR}/.gcovr.cfg --html-details
+        ${COVERAGE_DIR}/coverage.html -r ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
       DEPENDS tests
     )
     add_custom_target(
       coverage-xml
       COMMAND
-        ${GCOVR} --xml ${COVERAGE_DIR}/coverage.xml -r ${CMAKE_SOURCE_DIR}
-        ${CMAKE_BINARY_DIR}
+        ${GCOVR} --config ${CMAKE_SOURCE_DIR}/.gcovr.cfg --xml
+        ${COVERAGE_DIR}/coverage.xml -r ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
       DEPENDS tests
     )
     add_custom_target(coverage DEPENDS coverage-xml coverage-html)


### PR DESCRIPTION
## What

Add a configuration file for `gcovr` to ensure that files ending with `_tests.c` or in the `tests/` directory are excluded when computing the unit test coverage.

## Why

As the `_tests` files are certain to be executed fully during unit tests, they all achieve a "coverage" of or close enough to 100 %, which makes the total test coverage of the functional code (i.e., excluding tests) seem larger than it actually is.
