### PR TITLE
Fix installing dependencies for Debian Testing

### DIFF
--- a/.github/runtime-dependencies.testing.list
+++ b/.github/runtime-dependencies.testing.list
@@ -6,10 +6,10 @@ libgnutls30
 libgpgme11
 libhiredis1.1.0
 libldap-common
-libnet1
+libnet9
 libpaho-mqtt1.3
 libpcap0.8
 libradcli4
 libssh-4
 libuuid1
-libxml2
+libxml2-16


### PR DESCRIPTION


## What

Fix installing dependencies for Debian Testing

## Why

It seems libxml2 is libxm2-16 and libnet1 is libnet9 now. Get Debian Testing build to run again.