### PR TITLE
Add: New gvm_ssh_private_key_info function

### DIFF
--- a/util/sshutils.h
+++ b/util/sshutils.h
@@ -17,4 +17,7 @@ gvm_ssh_pkcs8_decrypt (const char *, const char *);
 char *
 gvm_ssh_public_from_private (const char *, const char *);
 
+int
+gvm_ssh_private_key_info (const char *, const char *, const char **, char **);
+
 #endif /* not _GVM_SSHUTILS_H */


### PR DESCRIPTION
## What
A new function is added to sshutils.c to get the key type and SHA-256 hash of a private key.

## Why
This will allow gvmd to show this info about the private key without revealing the key itself.

## References
GEA-1409

