### PR TITLE
Install the correct libgpgme version for testing container

### DIFF
--- a/.github/runtime-dependencies.testing.list
+++ b/.github/runtime-dependencies.testing.list
@@ -3,7 +3,7 @@ libcurl4t64
 libgcrypt20
 libglib2.0-0
 libgnutls30
-libgpgme11
+libgpgme45
 libhiredis1.1.0
 libldap-common
 libnet9


### PR DESCRIPTION


## What
Install the correct libgpgme version for testing container

## Why

Debian Testing libgpgme-dev depends on libgpgme45 instead of libgpgme11.

## References

https://github.com/greenbone/gsad/actions/runs/20058533921/job/57529419521?pr=274


