### PR TITLE
Fix: close leaks shown by sshutils tests

### DIFF
--- a/util/sshutils.c
+++ b/util/sshutils.c
@@ -150,6 +150,7 @@ gvm_ssh_private_key_info (const char *private_key, const char *passphrase,
             {
               g_snprintf (hex + i * 2, 3, "%02x", hash[i]);
             }
+          ssh_clean_pubkey_hash (&hash);
           *sha256_hash = hex;
         }
     }


### PR DESCRIPTION
## What

Close a couple small leaks shown by the sshutils test (using `-fsanitize=address`.

## Why

Cleaner.


