### PR TITLE
Change: Support excluded images in OCI image targets

### DIFF
--- a/container_image_scanner/container_image_scanner.h
+++ b/container_image_scanner/container_image_scanner.h
@@ -21,7 +21,7 @@ typedef struct container_image_target container_image_target_t;
 typedef struct container_image_credential container_image_credential_t;
 
 container_image_target_t *
-container_image_target_new (const gchar *, const gchar *);
+container_image_target_new (const gchar *, const gchar *, const gchar *);
 
 void
 container_image_target_free (container_image_target_t *);


### PR DESCRIPTION
## What
Support excluded images in OCI image targets.

## Why
To allow excluding images for container scanning tasks as well as pausing and resuming tasks.

## References
GEA-1504


