### PR TITLE
Fix: Add missing build dependencies

### DIFF
--- a/.github/build-dependencies.list
+++ b/.github/build-dependencies.list
@@ -2,16 +2,14 @@ build-essential
 ca-certificates
 cmake
 curl
-doxygen
 gcovr
 git
 gnupg
-graphviz
 lcov
 libcjson-dev
 libcrypt-dev
 libcurl4-openssl-dev
-libgcrypt-dev
+libgcrypt20-dev
 libglib2.0-dev
 libgnutls28-dev
 libgpgme-dev

--- a/.github/runtime-dependencies.oldstable.list
+++ b/.github/runtime-dependencies.oldstable.list
@@ -1,4 +1,5 @@
 libcjson1
+libcrypt1
 libgcrypt20
 libglib2.0-0
 libgnutls30

--- a/.github/runtime-dependencies.stable.list
+++ b/.github/runtime-dependencies.stable.list
@@ -1,4 +1,5 @@
 libcjson1
+libcrypt1
 libcurl4t64
 libgcrypt20
 libglib2.0-0

--- a/.github/runtime-dependencies.testing.list
+++ b/.github/runtime-dependencies.testing.list
@@ -1,4 +1,5 @@
 libcjson1
+libcrypt1
 libcurl4t64
 libgcrypt20
 libglib2.0-0


### PR DESCRIPTION
## What
libcrypt-dev is added to the list of build dependencies.

## Why

libcrypt-dev is required to build gvm-libs.