### PR TITLE
Add: Parse agent_update_available and updater_update_available

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -387,16 +387,17 @@ agent_controller_parse_agent (cJSON *item)
   const gchar *agt_ver = gvm_json_obj_str (item, "agent_version");
   const gchar *os_str = gvm_json_obj_str (item, "operating_system");
   const gchar *arch = gvm_json_obj_str (item, "architecture");
-  cJSON *update_to_latest_str = cJSON_GetObjectItem (item, "update_to_latest");
 
   agent->updater_version = upd_ver ? g_strdup (upd_ver) : NULL;
   agent->agent_version = agt_ver ? g_strdup (agt_ver) : NULL;
   agent->operating_system = os_str ? g_strdup (os_str) : NULL;
   agent->architecture = arch ? g_strdup (arch) : NULL;
-  if (cJSON_IsBool (update_to_latest_str))
-    agent->update_to_latest = cJSON_IsTrue (update_to_latest_str) ? 1 : 0;
-  else
-    agent->update_to_latest = 0;
+  agent->update_to_latest =
+    cJSON_IsTrue (cJSON_GetObjectItem (item, "update_to_latest"));
+  agent->agent_update_available =
+    cJSON_IsTrue (cJSON_GetObjectItem (item, "agent_update_available"));
+  agent->updater_update_available =
+    cJSON_IsTrue (cJSON_GetObjectItem (item, "updater_update_available"));
 
   /* Config */
   cJSON *config_obj = cJSON_GetObjectItem (item, "config");

--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -140,7 +140,9 @@ struct agent_controller_agent
   gchar *operating_system; ///< OS string (may be empty)
   gchar *architecture; ///< Architecture string (e.g., "amd64", may be empty)
 
-  int update_to_latest; ///< 1: update to latest, 0: do not
+  int update_to_latest;         ///< 1: update to latest, 0: do not
+  int agent_update_available;   ///< 1 agent update available, 0 do not
+  int updater_update_available; ///< 1 updater update available, 0 do not
 };
 typedef struct agent_controller_agent *agent_controller_agent_t;
 

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -564,7 +564,9 @@ Ensure (agent_controller, parse_agent_with_minimal_fields)
     "\"authorized\": true,"
     "\"last_update\": \"2025-04-29T13:06:00.34994Z\","
     "\"last_updater_heartbeat\": \"2025-04-29T13:06:00.34994Z\","
-    "\"ip_addresses\": [\"192.168.1.1\"]"
+    "\"ip_addresses\": [\"192.168.1.1\"],"
+    "\"agent_update_available\": true,"
+    "\"updater_update_available\": true"
     "}";
 
   cJSON *obj = cJSON_Parse (json);
@@ -579,6 +581,8 @@ Ensure (agent_controller, parse_agent_with_minimal_fields)
   assert_that (agent->ip_addresses[0], is_equal_to_string ("192.168.1.1"));
   assert_that (agent->last_update, is_not_equal_to ((time_t) 0));
   assert_that (agent->last_updater_heartbeat, is_not_equal_to ((time_t) 0));
+  assert_that (agent->agent_update_available, is_equal_to (1));
+  assert_that (agent->updater_update_available, is_equal_to (1));
 
   agent_controller_agent_free (agent);
   cJSON_Delete (obj);


### PR DESCRIPTION
## What

Adds support in gvm-libs for the new `agent_update_available` and `updater_update_available` fields, including parsing and data model updates.

## Why

These changes are required to correctly propagate agent and updater update availability information to higher layers.

## References

GEA-1523

## Checklist

- [x] Tests


