### PR TITLE
Change: make the header guards all the same format

### DIFF
--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -28,8 +28,8 @@
  * agent
  */
 
-#ifndef AGENT_CONTROLLER_H
-#define AGENT_CONTROLLER_H
+#ifndef _GVM_AGENT_CONTROLLER_AGENT_CONTROLLER_H
+#define _GVM_AGENT_CONTROLLER_AGENT_CONTROLLER_H
 
 #include <glib.h>
 
@@ -247,4 +247,4 @@ agent_controller_build_create_scan_payload (
 gchar *
 agent_controller_get_scan_id (const gchar *body);
 
-#endif // AGENT_CONTROLLER_H
+#endif /* not _GVM_AGENT_CONTROLLER_AGENT_CONTROLLER_H */

--- a/base/array.h
+++ b/base/array.h
@@ -8,8 +8,8 @@
  * @brief Array utilities.
  */
 
-#ifndef _GVM_ARRAY_H
-#define _GVM_ARRAY_H
+#ifndef _GVM_BASE_ARRAY_H
+#define _GVM_BASE_ARRAY_H
 
 #include <glib.h>
 
@@ -30,4 +30,4 @@ array_add (array_t *array, gpointer pointer);
 void
 array_terminate (array_t *array);
 
-#endif /* not _GVM_ARRAY_H */
+#endif /* not _GVM_BASE_ARRAY_H */

--- a/base/credentials.h
+++ b/base/credentials.h
@@ -8,8 +8,8 @@
  * @brief Credential pairs and triples.
  */
 
-#ifndef _GVM_CREDENTIALS_H
-#define _GVM_CREDENTIALS_H
+#ifndef _GVM_BASE_CREDENTIALS_H
+#define _GVM_BASE_CREDENTIALS_H
 
 #include <glib.h>
 
@@ -49,4 +49,4 @@ void
 append_to_credentials_password (credentials_t *credentials, const char *text,
                                 gsize length);
 
-#endif /* _GVM_CREDENTIALS_H */
+#endif /* not _GVM_BASE_CREDENTIALS_H */

--- a/base/cvss.h
+++ b/base/cvss.h
@@ -10,12 +10,12 @@
  * This file contains the protos for \ref cvss.c
  */
 
-#ifndef _GVM_CVSS_H
-#define _GVM_CVSS_H
+#ifndef _GVM_BASE_CVSS_H
+#define _GVM_BASE_CVSS_H
 
 #include <glib.h>
 
 double
 get_cvss_score_from_base_metrics (const char *);
 
-#endif /* not _GVM_CVSS_H */
+#endif /* not _GVM_BASE_CVSS_H */

--- a/base/drop_privileges.h
+++ b/base/drop_privileges.h
@@ -8,8 +8,8 @@
  * @brief Privilege dropping header file.
  */
 
-#ifndef _GVM_DROP_PRIVILEGES_H
-#define _GVM_DROP_PRIVILEGES_H
+#ifndef _GVM_BASE_DROP_PRIVILEGES_H
+#define _GVM_BASE_DROP_PRIVILEGES_H
 
 #include <glib.h>
 
@@ -57,4 +57,4 @@
 int
 drop_privileges (gchar *username, GError **error);
 
-#endif
+#endif /* not _GVM_BASE_DROP_PRIVILEGES_H */

--- a/base/gvm_sentry.h
+++ b/base/gvm_sentry.h
@@ -12,8 +12,8 @@
  *
  */
 
-#ifndef _GVM_SENTRY_H
-#define _GVM_SENTRY_H
+#ifndef _GVM_BASE_GVM_SENTRY_H
+#define _GVM_BASE_GVM_SENTRY_H
 
 #ifdef HAVE_SENTRY
 #include <sentry.h>
@@ -31,4 +31,4 @@ gvm_close_sentry (void);
 int
 gvm_has_sentry_support (void);
 
-#endif /* not _GVM_SENTRY_H */
+#endif /* not _GVM_BASE_GVM_SENTRY_H */

--- a/base/hosts.h
+++ b/base/hosts.h
@@ -11,8 +11,8 @@
  * This file contains the protos for \ref hosts.c
  */
 
-#ifndef _GVM_HOSTS_H
-#define _GVM_HOSTS_H
+#ifndef _GVM_BASE_HOSTS_H
+#define _GVM_BASE_HOSTS_H
 
 /** @brief Flag that indecates that this version includes
  *  the function gvm_hosts_allowed_only()
@@ -208,4 +208,4 @@ gvm_vhost_new (char *, char *);
 int
 gvm_get_host_type (const gchar *);
 
-#endif /* not _GVM_HOSTS_H */
+#endif /* not _GVM_BASE_HOSTS_H */

--- a/base/logging.h
+++ b/base/logging.h
@@ -8,8 +8,8 @@
  * @brief Implementation of logging methods.
  */
 
-#ifndef _GVM_LOGGING_H
-#define _GVM_LOGGING_H
+#ifndef _GVM_BASE_LOGGING_H
+#define _GVM_BASE_LOGGING_H
 
 #include <glib.h> /* for GSList, gchar, GLogLevelFlags, gpointer */
 
@@ -57,4 +57,4 @@ free_log_reference (void);
 void
 set_log_tz (const gchar *);
 
-#endif /* not _GVM_LOGGING_H */
+#endif /* not _GVM_BASE_LOGGING_H */

--- a/base/logging_domain.h
+++ b/base/logging_domain.h
@@ -7,8 +7,8 @@
  * @brief Implementation of logging domain handling.
  */
 
-#ifndef _GVM_LOGGING_DOMAIN_H
-#define _GVM_LOGGING_DOMAIN_H
+#ifndef _GVM_BASE_LOGGING_DOMAIN_H
+#define _GVM_BASE_LOGGING_DOMAIN_H
 
 #include <glib.h>
 
@@ -79,4 +79,4 @@ void
 gvm_logging_domain_set_log_channel (gvm_logging_domain_t *log_domain,
                                     GIOChannel *log_channel);
 
-#endif /* _GVM_LOGGING_DOMAIN_H */
+#endif /* not _GVM_BASE_LOGGING_DOMAIN_H */

--- a/base/networking.h
+++ b/base/networking.h
@@ -8,8 +8,8 @@
  * @brief GVM Networking related API.
  */
 
-#ifndef _GVM_NETWORKING_H
-#define _GVM_NETWORKING_H
+#ifndef _GVM_BASE_NETWORKING_H
+#define _GVM_BASE_NETWORKING_H
 
 #include "array.h" /* for array_t */
 
@@ -105,4 +105,4 @@ gvm_routethrough (struct sockaddr_storage *, struct sockaddr_storage *);
 char *
 gvm_get_outgoing_iface (struct sockaddr_storage *);
 
-#endif /* not _GVM_NETWORKING_H */
+#endif /* not _GVM_BASE_NETWORKING_H */

--- a/base/nvti.h
+++ b/base/nvti.h
@@ -10,8 +10,8 @@
  * This file contains the protos for \ref nvti.c
  */
 
-#ifndef _NVTI_H
-#define _NVTI_H
+#ifndef _GVM_BASE_NVTI_H
+#define _GVM_BASE_NVTI_H
 
 #include <glib.h>
 
@@ -263,4 +263,4 @@ nvtis_add (nvtis_t *, nvti_t *);
 nvti_t *
 nvtis_lookup (nvtis_t *, const char *);
 
-#endif /* not _NVTI_H */
+#endif /* not _GVM_BASE_NVTI_H */

--- a/base/pidfile.h
+++ b/base/pidfile.h
@@ -8,8 +8,8 @@
  * @brief PID-file management.
  */
 
-#ifndef _GVM_PIDFILE_H
-#define _GVM_PIDFILE_H
+#ifndef _GVM_BASE_PIDFILE_H
+#define _GVM_BASE_PIDFILE_H
 
 #include <glib.h>
 
@@ -18,4 +18,4 @@ pidfile_create (gchar *);
 void
 pidfile_remove (gchar *);
 
-#endif /* not _GVM_PIDFILE_H */
+#endif /* not _GVM_BASE_PIDFILE_H */

--- a/base/prefs.h
+++ b/base/prefs.h
@@ -10,8 +10,8 @@
  * This file contains the protos for \ref prefs.c
  */
 
-#ifndef _GVM_PREFS_H
-#define _GVM_PREFS_H
+#ifndef _GVM_BASE_PREFS_H
+#define _GVM_BASE_PREFS_H
 
 #include <glib.h> /* for gchar */
 
@@ -31,4 +31,4 @@ prefs_nvt_timeout (const char *);
 GHashTable *
 preferences_get (void);
 
-#endif /* not _GVM_PREFS_H */
+#endif /* not _GVM_BASE_PREFS_H */

--- a/base/proctitle.h
+++ b/base/proctitle.h
@@ -8,8 +8,8 @@
  * @brief API for process title setting.
  */
 
-#ifndef _GVM_PROCTITLE_H
-#define _GVM_PROCTITLE_H
+#ifndef _GVM_BASE_PROCTITLE_H
+#define _GVM_BASE_PROCTITLE_H
 
 void
 proctitle_init (int, char **);
@@ -17,4 +17,4 @@ proctitle_init (int, char **);
 void
 proctitle_set (const char *, ...);
 
-#endif /* not _GVM_PROCTITLE_H */
+#endif /* not _GVM_BASE_PROCTITLE_H */

--- a/base/pwpolicy.h
+++ b/base/pwpolicy.h
@@ -10,12 +10,12 @@
  * This file contains the protos for \ref pwpolicy.c
  */
 
-#ifndef _GVM_PWPOLICY_H
-#define _GVM_PWPOLICY_H
+#ifndef _GVM_BASE_PWPOLICY_H
+#define _GVM_BASE_PWPOLICY_H
 
 char *
 gvm_validate_password (const char *, const char *);
 void
 gvm_disable_password_policy (void);
 
-#endif /*_GVM_PWPOLICY_H*/
+#endif /* not _GVM_BASE_PWPOLICY_H */

--- a/base/settings.h
+++ b/base/settings.h
@@ -10,8 +10,8 @@
  * This file contains the protos for \ref settings.c
  */
 
-#ifndef _GVM_SETTINGS_H
-#define _GVM_SETTINGS_H
+#ifndef _GVM_BASE_SETTINGS_H
+#define _GVM_BASE_SETTINGS_H
 
 #include <glib.h>
 
@@ -52,4 +52,4 @@ settings_iterator_name (settings_iterator_t *);
 gchar *
 settings_iterator_value (settings_iterator_t *);
 
-#endif /* not _GVM_SETTINGS_H */
+#endif /* not _GVM_BASE_SETTINGS_H */

--- a/base/strings.h
+++ b/base/strings.h
@@ -8,8 +8,8 @@
  * @brief String utilities.
  */
 
-#ifndef _GVM_STRINGS_H
-#define _GVM_STRINGS_H
+#ifndef _GVM_BASE_STRINGS_H
+#define _GVM_BASE_STRINGS_H
 
 #include <glib.h>
 
@@ -23,4 +23,4 @@ gvm_free_string_var (gchar **);
 char *
 gvm_strip_space (char *, char *);
 
-#endif /* not _GVM_STRINGS_H */
+#endif /* not _GVM_BASE_STRINGS_H */

--- a/base/version.h
+++ b/base/version.h
@@ -8,10 +8,10 @@
  * @brief Version utilities.
  */
 
-#ifndef _GVM_VERSION_H
-#define _GVM_VERSION_H
+#ifndef _GVM_BASE_VERSION_H
+#define _GVM_BASE_VERSION_H
 
 const char *
 gvm_libs_version (void);
 
-#endif
+#endif /* not _GVM_BASE_VERSION_H */

--- a/boreas/alivedetection.h
+++ b/boreas/alivedetection.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef ALIVE_DETECTION_H
-#define ALIVE_DETECTION_H
+#ifndef _GVM_BOREAS_ALIVEDETECTION_H
+#define _GVM_BOREAS_ALIVEDETECTION_H
 
 #include "../base/hosts.h"
 #include "../util/kb.h"
@@ -126,4 +126,4 @@ typedef enum
   UDPV6,
 } socket_type_t;
 
-#endif /* not ALIVE_DETECTION_H */
+#endif /* not _GVM_BOREAS_ALIVEDETECTION_H */

--- a/boreas/arp.h
+++ b/boreas/arp.h
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef ARP_H
-#define ARP_H
+#ifndef _GVM_BOREAS_ARP_H
+#define _GVM_BOREAS_ARP_H
 
 void
 send_arp_v4 (const char *);
 
-#endif /* not ARP_H */
+#endif /* not _GVM_BOREAS_ARP_H */

--- a/boreas/boreas_error.h
+++ b/boreas/boreas_error.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef BOREAS_ERROR_H
-#define BOREAS_ERROR_H
+#ifndef _GVM_BOREAS_BOREAS_ERROR_H
+#define _GVM_BOREAS_BOREAS_ERROR_H
 
 /**
  * @brief Alive detection error codes.
@@ -21,4 +21,4 @@ typedef enum
 
 const char *str_boreas_error (boreas_error_t);
 
-#endif /* not BOREAS_ERROR_H */
+#endif /* not _GVM_BOREAS_BOREAS_ERROR_H */

--- a/boreas/boreas_io.h
+++ b/boreas/boreas_io.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef BOREAS_IO_H
-#define BOREAS_IO_H
+#ifndef _GVM_BOREAS_BOREAS_IO_H
+#define _GVM_BOREAS_BOREAS_IO_H
 
 #include "../base/hosts.h"
 #include "../util/kb.h"
@@ -48,4 +48,4 @@ get_alive_test_wait_timeout (void);
 int
 get_alive_hosts_count (void);
 
-#endif /* not BOREAS_IO_H */
+#endif /* not _GVM_BOREAS_BOREAS_IO_H */

--- a/boreas/cli.h
+++ b/boreas/cli.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef CLI_H
-#define CLI_H
+#ifndef _GVM_BOREAS_CLI_H
+#define _GVM_BOREAS_CLI_H
 
 #include "alivedetection.h"
 #include "boreas_error.h"
@@ -19,4 +19,4 @@ run_cli (gvm_hosts_t *, alive_test_t, const gchar *);
 boreas_error_t
 is_host_alive (const char *, int *);
 
-#endif /* not CLI_H */
+#endif /* not _GVM_BOREAS_CLI_H */

--- a/boreas/ping.h
+++ b/boreas/ping.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef BOREAS_PING_H
-#define BOREAS_PING_H
+#ifndef _GVM_BOREAS_PING_H
+#define _GVM_BOREAS_PING_H
 
 #include <glib.h>
 
@@ -14,4 +14,4 @@ void send_tcp (gpointer, gpointer, gpointer);
 
 void send_arp (gpointer, gpointer, gpointer);
 
-#endif /* not BOREAS_PING_H */
+#endif /* not _GVM_BOREAS_PING_H */

--- a/boreas/sniffer.h
+++ b/boreas/sniffer.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef BOREAS_SNIFFER_H
-#define BOREAS_SNIFFER_H
+#ifndef _GVM_BOREAS_SNIFFER_H
+#define _GVM_BOREAS_SNIFFER_H
 
 #include "alivedetection.h"
 
@@ -16,4 +16,4 @@ start_sniffer_thread (scanner_t *, pthread_t *);
 int
 stop_sniffer_thread (scanner_t *, pthread_t);
 
-#endif /* not BOREAS_SNIFFER_H */
+#endif /* not _GVM_BOREAS_SNIFFER_H */

--- a/boreas/util.h
+++ b/boreas/util.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef BOREAS_UTIL_H
-#define BOREAS_UTIL_H
+#ifndef _GVM_BOREAS_UTIL_H
+#define _GVM_BOREAS_UTIL_H
 
 #include "alivedetection.h"
 #include "boreas_error.h"
@@ -39,4 +39,4 @@ wait_until_so_sndbuf_empty (int, int);
 int
 count_difference (GHashTable *, GHashTable *);
 
-#endif /* not BOREAS_UTIL_H */
+#endif /* not _GVM_BOREAS_UTIL_H */

--- a/container_image_scanner/container_image_scanner.h
+++ b/container_image_scanner/container_image_scanner.h
@@ -8,8 +8,8 @@
  * @brief API for Container Image Scanner communication.
  */
 
-#ifndef _GVM_CONTAINER_IMAGE_SCANNER_H
-#define _GVM_CONTAINER_IMAGE_SCANNER_H
+#ifndef _GVM_CONTAINER_IMAGE_SCANNER_CONTAINER_IMAGE_SCANNER_H
+#define _GVM_CONTAINER_IMAGE_SCANNER_CONTAINER_IMAGE_SCANNER_H
 
 #include "../util/jsonpull.h"
 
@@ -44,4 +44,4 @@ char *
 container_image_build_scan_config_json (container_image_target_t *target,
                                         GHashTable *scan_preferences);
 
-#endif
+#endif /* not _GVM_CONTAINER_IMAGE_SCANNER_CONTAINER_IMAGE_SCANNER_H */

--- a/cyberark/cyberark.h
+++ b/cyberark/cyberark.h
@@ -1,5 +1,5 @@
-#ifndef _GVM_CYBERARK_H
-#define _GVM_CYBERARK_H
+#ifndef _GVM_CYBERARK_CYBERARK_H
+#define _GVM_CYBERARK_CYBERARK_H
 
 
 #include <glib.h>
@@ -69,4 +69,4 @@ cyberark_object_t
 cyberark_get_object (cyberark_connector_t,
                      const gchar *, const gchar *, const gchar *);
 
-#endif /* _GVM_CYBERARK_H */
+#endif /* not _GVM_CYBERARK_CYBERARK_H */

--- a/gmp/gmp.h
+++ b/gmp/gmp.h
@@ -8,8 +8,8 @@
  * @brief API for Greenbone Management Protocol communication.
  */
 
-#ifndef _GVM_GMP_H
-#define _GVM_GMP_H
+#ifndef _GVM_GMP_GMP_H
+#define _GVM_GMP_GMP_H
 
 #include "../base/array.h"       /* for array_t */
 #include "../util/serverutils.h" /* for gvm_connection_t */
@@ -398,4 +398,4 @@ int
 gmp_get_system_reports_ext (gnutls_session_t *, gmp_get_system_reports_opts_t,
                             entity_t *);
 
-#endif /* not _GVM_GMP_H */
+#endif /* not _GVM_GMP_GMP_H */

--- a/http/httputils.h
+++ b/http/httputils.h
@@ -29,8 +29,8 @@
  * multi interface
  */
 
-#ifndef HTTPUTILS_H
-#define HTTPUTILS_H
+#ifndef _GVM_HTTP_HTTPUTILS_H
+#define _GVM_HTTP_HTTPUTILS_H
 
 #include <curl/curl.h>
 #include <curl/easy.h>
@@ -164,4 +164,4 @@ gvm_http_response_stream_free (gvm_http_response_stream_t s);
 void
 gvm_http_response_stream_reset (gvm_http_response_stream_t s);
 
-#endif // HTTPUTILS_H
+#endif /* not _GVM_HTTP_HTTPUTILS_H */

--- a/http_scanner/http_scanner.h
+++ b/http_scanner/http_scanner.h
@@ -8,8 +8,8 @@
  * @brief API for communication with an HTTP scanner.
  */
 
-#ifndef _GVM_HTTP_SCANNER_H
-#define _GVM_HTTP_SCANNER_H
+#ifndef _GVM_HTTP_SCANNER_HTTP_SCANNER_H
+#define _GVM_HTTP_SCANNER_HTTP_SCANNER_H
 
 #include "../util/jsonpull.h"
 
@@ -251,4 +251,4 @@ http_scanner_resp_t
 http_scanner_send_request (http_scanner_connector_t, http_scanner_method_t,
                            const gchar *, const gchar *, const gchar *);
 
-#endif /* _GVM_HTTP_SCANNER_H */
+#endif /* not _GVM_HTTP_SCANNER_HTTP_SCANNER_H */

--- a/openvasd/openvasd.h
+++ b/openvasd/openvasd.h
@@ -8,8 +8,8 @@
  * @brief API for Openvas Daemon communication.
  */
 
-#ifndef _GVM_OPENVASD_H
-#define _GVM_OPENVASD_H
+#ifndef _GVM_OPENVASD_OPENVASD_H
+#define _GVM_OPENVASD_OPENVASD_H
 
 #include "../base/nvti.h"
 #include "../http_scanner/http_scanner.h"
@@ -87,4 +87,4 @@ http_scanner_resp_t openvasd_get_vt_stream_init (http_scanner_connector_t);
 
 int openvasd_get_vt_stream (http_scanner_connector_t);
 
-#endif
+#endif /* not _GVM_OPENVASD_OPENVASD_H */

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -8,8 +8,8 @@
  * @brief API for Open Scanner Protocol communication.
  */
 
-#ifndef _GVM_OSP_H
-#define _GVM_OSP_H
+#ifndef _GVM_OSP_OSP_H
+#define _GVM_OSP_OSP_H
 
 #include "../util/xmlutils.h"
 
@@ -230,4 +230,4 @@ osp_vt_single_free (osp_vt_single_t *);
 void
 osp_vt_single_add_value (osp_vt_single_t *, const char *, const char *);
 
-#endif
+#endif /* not _GVM_OSP_OSP_H */

--- a/util/authutils.h
+++ b/util/authutils.h
@@ -8,8 +8,8 @@
  * @brief Authentication mechanism(s).
  */
 
-#ifndef _GVM_AUTHUTILS_H
-#define _GVM_AUTHUTILS_H
+#ifndef _GVM_UTIL_AUTHUTILS_H
+#define _GVM_UTIL_AUTHUTILS_H
 
 #include <glib.h>
 
@@ -56,4 +56,4 @@ gvm_auth_ldap_enabled (void);
 int
 gvm_auth_radius_enabled (void);
 
-#endif /* not _GVM_AUTHUTILS_H */
+#endif /* not _GVM_UTIL_AUTHUTILS_H */

--- a/util/compressutils.h
+++ b/util/compressutils.h
@@ -8,8 +8,8 @@
  * @brief API related to data compression (gzip format.)
  */
 
-#ifndef _GVM_COMPRESSUTILS_H
-#define _GVM_COMPRESSUTILS_H
+#ifndef _GVM_UTIL_COMPRESSUTILS_H
+#define _GVM_UTIL_COMPRESSUTILS_H
 
 #include <stdio.h>
 
@@ -28,4 +28,4 @@ gvm_gzip_open_file_reader (const char *);
 FILE *
 gvm_gzip_open_file_reader_fd (int);
 
-#endif /* not _GVM_COMPRESSUTILS_H */
+#endif /* not _GVM_UTIL_COMPRESSUTILS_H */

--- a/util/cpeutils.h
+++ b/util/cpeutils.h
@@ -8,8 +8,8 @@
  * @brief Headers for CPE utils.
  */
 
-#ifndef _GVM_CPEUTILS_H
-#define _GVM_CPEUTILS_H
+#ifndef _GVM_UTIL_CPEUTILS_H
+#define _GVM_UTIL_CPEUTILS_H
 
 #include <glib.h>
 #include <stdio.h>
@@ -93,4 +93,4 @@ enum set_relation
 
 #define CPE_COMPONENT_IS_ANY(component) (component[0] == 'A')
 
-#endif
+#endif /* not _GVM_UTIL_CPEUTILS_H */

--- a/util/fileutils.h
+++ b/util/fileutils.h
@@ -43,4 +43,4 @@ gchar *
 gvm_export_file_name (const char *, const char *, const char *, const char *,
                       const char *, const char *, const char *, const char *);
 
-#endif /* not _GVM_FILEUTILS_H */
+#endif /* not _GVM_UTIL_FILEUTILS_H */

--- a/util/gpgmeutils.h
+++ b/util/gpgmeutils.h
@@ -10,8 +10,8 @@
  * This file contains the protos for \ref gpgmeutils.c
  */
 
-#ifndef _GVM_GPGMEUTILS_H
-#define _GVM_GPGMEUTILS_H
+#ifndef _GVM_UTIL_GPGMEUTILS_H
+#define _GVM_UTIL_GPGMEUTILS_H
 
 #include <glib.h>  /* for gchar */
 #include <gpgme.h> /* for gpgme_ctx_t */
@@ -37,4 +37,4 @@ gvm_pgp_pubkey_encrypt_stream (FILE *, FILE *, const char *, const char *,
 int
 gvm_smime_encrypt_stream (FILE *, FILE *, const char *, const char *, ssize_t);
 
-#endif /*_GVM_GPGMEUTILS_H*/
+#endif /* not _GVM_UTIL_GPGMEUTILS_H */

--- a/util/json.h
+++ b/util/json.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef _GVM_JSON_H
-#define _GVM_JSON_H
+#ifndef _GVM_UTIL_JSON_H
+#define _GVM_UTIL_JSON_H
 
 #define _GNU_SOURCE
 
@@ -29,4 +29,4 @@ gvm_json_obj_check_str (cJSON *, const gchar *, gchar **);
 gchar *
 gvm_json_obj_str (cJSON *, const gchar *);
 
-#endif /* _GVM_JSON_H */
+#endif /* not _GVM_UTIL_JSON_H */

--- a/util/jsonpull.h
+++ b/util/jsonpull.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef _GVM_JSONPULL_H
-#define _GVM_JSONPULL_H
+#ifndef _GVM_UTIL_JSONPULL_H
+#define _GVM_UTIL_JSONPULL_H
 
 #define _GNU_SOURCE
 
@@ -129,4 +129,4 @@ gvm_json_pull_expand_container (gvm_json_pull_parser_t *, gchar **);
 gchar *
 gvm_json_path_to_string (GQueue *path);
 
-#endif /* _GVM_JSONPULL_H */
+#endif /* not _GVM_UTIL_JSONPULL_H */

--- a/util/kb.h
+++ b/util/kb.h
@@ -8,8 +8,8 @@
  * @brief Knowledge base management API - Redis backend.
  */
 
-#ifndef _GVM_KB_H
-#define _GVM_KB_H
+#ifndef _GVM_UTIL_KB_H
+#define _GVM_UTIL_KB_H
 
 #include "../base/nvti.h" /* for nvti_t */
 

--- a/util/ldaputils.h
+++ b/util/ldaputils.h
@@ -8,8 +8,8 @@
  * @brief Header for LDAP-Connect Authentication module.
  */
 
-#ifndef _GVM_LDAPUTILS_H
-#define _GVM_LDAPUTILS_H
+#ifndef _GVM_UTIL_LDAPUTILS_H
+#define _GVM_UTIL_LDAPUTILS_H
 
 #include <glib.h>
 
@@ -65,4 +65,4 @@ ldap_auth_dn_is_good (const gchar *);
 
 #endif /* ENABLE_LDAP_AUTH */
 
-#endif /* not _GVM_LDAPUTILS_H */
+#endif /* not _GVM_UTIL_LDAPUTILS_H */

--- a/util/mqtt.h
+++ b/util/mqtt.h
@@ -8,8 +8,8 @@
  * @brief Protos for MQTT handling.
  */
 
-#ifndef _GVM_MQTT_H
-#define _GVM_MQTT_H
+#ifndef _GVM_UTIL_MQTT_H
+#define _GVM_UTIL_MQTT_H
 
 #include <MQTTClient.h>
 #include <glib.h>
@@ -47,4 +47,4 @@ mqtt_retrieve_message (char **, int *, char **, int *, const unsigned int);
 int
 mqtt_unsubscribe (const char *);
 
-#endif /* _GVM_MQTT_H */
+#endif /* not _GVM_UTIL_MQTT_H */

--- a/util/nvticache.h
+++ b/util/nvticache.h
@@ -10,8 +10,8 @@
  * This file contains the protos for \ref nvticache.c
  */
 
-#ifndef _GVM_NVTICACHE_H
-#define _GVM_NVTICACHE_H
+#ifndef _GVM_UTIL_NVTICACHE_H
+#define _GVM_UTIL_NVTICACHE_H
 
 #include "../base/nvti.h" /* for nvti_t */
 #include "kb.h"           /* for kb_t */
@@ -112,4 +112,4 @@ nvticache_feed_version (void);
 int
 nvticache_check_feed (void);
 
-#endif /* not _GVM_NVTICACHE_H */
+#endif /* not _GVM_UTIL_NVTICACHE_H */

--- a/util/passwordbasedauthentication.h
+++ b/util/passwordbasedauthentication.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef _GVM_PASSWORDBASEDAUTHENTICATION_H
-#define _GVM_PASSWORDBASEDAUTHENTICATION_H
+#ifndef _GVM_UTIL_PASSWORDBASEDAUTHENTICATION_H
+#define _GVM_UTIL_PASSWORDBASEDAUTHENTICATION_H
 
 /* max amount of applied pepper */
 #define MAX_PEPPER_SIZE 4
@@ -73,4 +73,4 @@ pba_verify_hash (const struct PBASettings *settings, const char *hash,
 void
 pba_finalize (struct PBASettings *settings);
 
-#endif
+#endif /* not _GVM_UTIL_PASSWORDBASEDAUTHENTICATION_H */

--- a/util/radiusutils.h
+++ b/util/radiusutils.h
@@ -8,10 +8,10 @@
  * @brief Headers of an API for Radius authentication.
  */
 
-#ifndef _GVM_RADIUSUTILS_H
-#define _GVM_RADIUSUTILS_H
+#ifndef _GVM_UTIL_RADIUSUTILS_H
+#define _GVM_UTIL_RADIUSUTILS_H
 
 int
 radius_authenticate (const char *, const char *, const char *, const char *);
 
-#endif /* not _GVM_RADIUSUTILS_H */
+#endif /* not _GVM_UTIL_RADIUSUTILS_H */

--- a/util/serverutils.h
+++ b/util/serverutils.h
@@ -11,8 +11,8 @@
  * with a server over GnuTLS.
  */
 
-#ifndef _GVM_SERVERUTILS_H
-#define _GVM_SERVERUTILS_H
+#ifndef _GVM_UTIL_SERVERUTILS_H
+#define _GVM_UTIL_SERVERUTILS_H
 
 #include <glib.h>          /* for gchar, gboolean, gint */
 #include <gnutls/gnutls.h> /* for gnutls_session_t, gnutls_certificate_cred... */
@@ -113,4 +113,4 @@ unload_gnutls_file (gnutls_datum_t *);
 int
 set_gnutls_dhparams (gnutls_certificate_credentials_t, const char *);
 
-#endif /* not _GVM_SERVERUTILS_H */
+#endif /* not _GVM_UTIL_SERVERUTILS_H */

--- a/util/sshutils.h
+++ b/util/sshutils.h
@@ -8,8 +8,8 @@
  * @brief SSH related API.
  */
 
-#ifndef _GVM_SSHUTILS_H
-#define _GVM_SSHUTILS_H
+#ifndef _GVM_UTIL_SSHUTILS_H
+#define _GVM_UTIL_SSHUTILS_H
 
 char *
 gvm_ssh_pkcs8_decrypt (const char *, const char *);
@@ -20,4 +20,4 @@ gvm_ssh_public_from_private (const char *, const char *);
 int
 gvm_ssh_private_key_info (const char *, const char *, const char **, char **);
 
-#endif /* not _GVM_SSHUTILS_H */
+#endif /* not _GVM_UTIL_SSHUTILS_H */

--- a/util/streamvalidator.h
+++ b/util/streamvalidator.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#ifndef _GVM_STREAMVALIDATOR_H
-#define _GVM_STREAMVALIDATOR_H
+#ifndef _GVM_UTIL_STREAMVALIDATOR_H
+#define _GVM_UTIL_STREAMVALIDATOR_H
 
 #include <stdio.h>
 
@@ -59,4 +59,4 @@ gvm_stream_validator_write (gvm_stream_validator_t, const char *, size_t);
 
 gvm_stream_validator_return_t gvm_stream_validator_end (gvm_stream_validator_t);
 
-#endif /* not _GVM_STREAMVALIDATOR_H */
+#endif /* not _GVM_UTIL_STREAMVALIDATOR_H */

--- a/util/tlsutils.h
+++ b/util/tlsutils.h
@@ -8,8 +8,8 @@
  * @brief TLS certificate utilities headers.
  */
 
-#ifndef _GVM_TLSUTILS_H
-#define _GVM_TLSUTILS_H
+#ifndef _GVM_UTIL_TLSUTILS_H
+#define _GVM_UTIL_TLSUTILS_H
 
 #include <glib.h>
 #include <gnutls/gnutls.h>
@@ -38,4 +38,4 @@ gvm_pkcs12_to_pem (gnutls_pkcs12_t pkcs12, const char *passphrase,
                    gchar **privkey_out, gchar **cert_chain_out,
                    gchar **extra_certs_out, gchar **crl_out);
 
-#endif /* not _GVM_UUIDUTILS_H */
+#endif /* not _GVM_UTIL_TLSUTILS_H */

--- a/util/uuidutils.h
+++ b/util/uuidutils.h
@@ -8,10 +8,10 @@
  * @brief UUID creation.
  */
 
-#ifndef _GVM_UUIDUTILS_H
-#define _GVM_UUIDUTILS_H
+#ifndef _GVM_UTIL_UUIDUTILS_H
+#define _GVM_UTIL_UUIDUTILS_H
 
 char *
 gvm_uuid_make (void);
 
-#endif /* not _GVM_UUIDUTILS_H */
+#endif /* not _GVM_UTIL_UUIDUTILS_H */

--- a/util/versionutils.h
+++ b/util/versionutils.h
@@ -8,8 +8,8 @@
  * @brief Headers for version utils.
  */
 
-#ifndef _GVM_VERSIONUTILS_H
-#define _GVM_VERSIONUTILS_H
+#ifndef _GVM_UTIL_VERSIONUTILS_H
+#define _GVM_UTIL_VERSIONUTILS_H
 
 #include <glib.h>
 #include <stdio.h>
@@ -17,4 +17,4 @@
 int
 cmp_versions (const char *, const char *);
 
-#endif
+#endif /* not _GVM_UTIL_VERSIONUTILS_H */

--- a/util/vtparser.h
+++ b/util/vtparser.h
@@ -8,8 +8,8 @@
  * @brief Simple JSON reader.
  */
 
-#ifndef _GVM_VTPARSER_H
-#define _GVM_VTPARSER_H
+#ifndef _GVM_UTIL_VTPARSER_H
+#define _GVM_UTIL_VTPARSER_H
 
 #define _GNU_SOURCE /* See feature_test_macros(7) */
 #define _FILE_OFFSET_BITS 64
@@ -44,4 +44,4 @@ typedef enum
 int
 parse_vt_json (gvm_json_pull_parser_t *, gvm_json_pull_event_t *, nvti_t **);
 
-#endif /* _GVM_VTPARSER_H */
+#endif /* not _GVM_UTIL_VTPARSER_H */

--- a/util/xmlutils.h
+++ b/util/xmlutils.h
@@ -8,8 +8,8 @@
  * @brief Headers for simple XML reader.
  */
 
-#ifndef _GVM_XMLUTILS_H
-#define _GVM_XMLUTILS_H
+#ifndef _GVM_UTIL_XMLUTILS_H
+#define _GVM_UTIL_XMLUTILS_H
 
 #include "serverutils.h"
 
@@ -200,4 +200,4 @@ int xml_file_iterator_rewind (xml_file_iterator_t);
 element_t
 xml_file_iterator_next (xml_file_iterator_t, gchar **);
 
-#endif /* not _GVM_XMLUTILS_H */
+#endif /* not _GVM_UTIL_XMLUTILS_H */


### PR DESCRIPTION
## What

Use the same format for the header guards in .h files: `#ifndef _GVM_<DIRNAME>_<FILENAME>`

## Why

1. It's neater
2. It's easier to understand what to use for new files.
3. It may prevent clashes with headers from other libraries.
4. It may prevent clashes when there are files with the same name in multiple dirs.

## Testing

Compiles fine.
