### PR TITLE
Require CMake >= 3.18 and update copyright year in README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 message("-- Configuring the Greenbone Vulnerability Management Libraries...")
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ some supported platforms.
 General build environment:
 
 * a C compiler (e.g. gcc)
-* cmake >= 3.5
+* cmake >= 3.18
 * pkg-config
 
 Specific development libraries:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ to empty the build directory before `scan-build` call.
 
 ## License
 
-Copyright (C) 2009-2025 [Greenbone AG](https://www.greenbone.net/)
+Copyright (C) 2009-2026 [Greenbone AG](https://www.greenbone.net/)
 
 Licensed under the [GNU General Public License v2.0 or later](COPYING).


### PR DESCRIPTION



## What

Require CMake >= 3.18 and update copyright year in README

## Why

CMake 3.18 is the version in Debian Bullseye. Thus it's the lowest version we should support.


## References

Closes #1043
