### PR TITLE
Fix: Add missing slash in CyberArk request URLs

### DIFF
--- a/cyberark/cyberark.c
+++ b/cyberark/cyberark.c
@@ -200,10 +200,10 @@ cyberark_send_request (cyberark_connector_t conn,
   gchar *url;
 
   if (conn->port )
-    url =  g_strdup_printf ("%s://%s:%d%s%s", conn->protocol, conn->host,
+    url =  g_strdup_printf ("%s://%s:%d/%s%s", conn->protocol, conn->host,
                             conn->port, conn->path, request_path);
   else
-    url =  g_strdup_printf ("%s://%s%s%s", conn->protocol, conn->host,
+    url =  g_strdup_printf ("%s://%s/%s%s", conn->protocol, conn->host,
                             conn->path, request_path);
 
   gvm_http_headers_t *headers = init_custom_header (apikey, payload ? TRUE : FALSE);


### PR DESCRIPTION
## What
In cyberark_send_request a slash is added to the URL, separating the hostname and optional port from the path.

## Why
This makes the connection work without having to add a slash a the start of the path manually.

## References
GEA-1562