### PR TITLE
Change: Move common functions for handling target credentials to utils.

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -33,17 +33,6 @@
 #define RESP_CODE_OK 0
 
 /**
- * @brief Struct credential information for openvasd.
- */
-struct openvasd_credential
-{
-  gchar *type;           /**< Credential type */
-  gchar *service;        /**< Service the credential is for */
-  gchar *port;           /**< Port the credential is for */
-  GHashTable *auth_data; /**< Authentication data (username, password, etc.)*/
-};
-
-/**
  * @brief Struct holding target information.
  */
 struct openvasd_target
@@ -267,6 +256,22 @@ add_port_to_scan_json (gpointer range, gpointer p_array)
 }
 
 /**
+ * @brief Add authentication data key value to a JSON object.
+ *
+ * @param key       Key string.
+ * @param value     Value string.
+ * @param json_obj  JSON object to add the key-value pair to.
+ */
+static void
+add_auth_data_key_value_as_json (const char *key, const char *value,
+                                 void *json_obj)
+{
+  if (!key || !value || !json_obj)
+    return;
+  cJSON_AddStringToObject ((cJSON *) json_obj, key, value);
+}
+
+/**
  * @brief Add a credential to the scan json object.
  *
  * @param credentials Credential to add.
@@ -275,26 +280,26 @@ add_port_to_scan_json (gpointer range, gpointer p_array)
 static void
 add_credential_to_scan_json (gpointer credentials, gpointer cred_array)
 {
-  GHashTableIter auth_data_iter;
-  gchar *auth_data_name, *auth_data_value;
   cJSON *cred_obj = NULL;
 
-  openvasd_credential_t *cred = credentials;
+  scan_credential_t *cred = credentials;
+
+  const gchar *type = scan_credential_get_type (cred);
+  const gchar *service = scan_credential_get_service (cred);
+  const gchar *port = scan_credential_get_port (cred);
 
   cred_obj = cJSON_CreateObject ();
-  cJSON_AddStringToObject (cred_obj, "service", cred->service);
+  cJSON_AddStringToObject (cred_obj, "service", service ? service : "");
 
-  if (cred->port)
+  if (port)
     {
-      cJSON_AddNumberToObject (cred_obj, "port", atoi (cred->port));
+      cJSON_AddNumberToObject (cred_obj, "port", atoi (port));
     }
 
   cJSON *cred_type_obj = cJSON_CreateObject ();
-  g_hash_table_iter_init (&auth_data_iter, cred->auth_data);
-  while (g_hash_table_iter_next (&auth_data_iter, (gpointer *) &auth_data_name,
-                                 (gpointer *) &auth_data_value))
-    cJSON_AddStringToObject (cred_type_obj, auth_data_name, auth_data_value);
-  cJSON_AddItemToObject (cred_obj, cred->type, cred_type_obj);
+  scan_credential_foreach_auth_data (cred, add_auth_data_key_value_as_json,
+                                     cred_type_obj);
+  cJSON_AddItemToObject (cred_obj, type ? type : "", cred_type_obj);
 
   cJSON_AddItemToArray ((cJSON *) cred_array, cred_obj);
 }
@@ -491,78 +496,6 @@ openvasd_build_scan_config_json (openvasd_target_t *target,
 }
 
 /**
- * @brief Allocate and initialize a new openvasd credential.
- *
- * @param type      The credential type.
- * @param service   The service the credential is for.
- * @param port      The port.
- *
- * @return New openvasd credential.
- */
-openvasd_credential_t *
-openvasd_credential_new (const gchar *type, const gchar *service,
-                         const gchar *port)
-{
-  openvasd_credential_t *new_credential;
-
-  new_credential = g_malloc0 (sizeof (openvasd_credential_t));
-
-  new_credential->type = type ? g_strdup (type) : NULL;
-  new_credential->service = service ? g_strdup (service) : NULL;
-  new_credential->port = port ? g_strdup (port) : NULL;
-  new_credential->auth_data =
-    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-
-  return new_credential;
-}
-
-/**
- * @brief Free an openvasd credential.
- *
- * @param credential  The credential to free.
- */
-void
-openvasd_credential_free (openvasd_credential_t *credential)
-{
-  if (!credential)
-    return;
-
-  g_free (credential->type);
-  g_free (credential->service);
-  g_free (credential->port);
-  g_hash_table_destroy (credential->auth_data);
-  g_free (credential);
-}
-
-/**
- * @brief Get authentication data from an openvasd credential.
- *
- * @param  credential  The credential to get the data from.
- * @param  name        The name of the data item to get.
- * @param  value       The authentication data or NULL to unset.
- */
-void
-openvasd_credential_set_auth_data (openvasd_credential_t *credential,
-                                   const gchar *name, const gchar *value)
-{
-  if (credential == NULL || name == NULL)
-    return;
-
-  if (g_regex_match_simple ("^[[:alpha:]][[:alnum:]_]*$", name, 0, 0))
-    {
-      if (value)
-        g_hash_table_replace (credential->auth_data, g_strdup (name),
-                              g_strdup (value));
-      else
-        g_hash_table_remove (credential->auth_data, name);
-    }
-  else
-    {
-      g_warning ("%s: Invalid auth data name: %s", __func__, name);
-    }
-}
-
-/**
  * @brief Create a new openvasd target.
  *
  * @param scanid         Scan ID.
@@ -623,7 +556,7 @@ openvasd_target_free (openvasd_target_t *target)
     return;
 
   g_slist_free_full (target->credentials,
-                     (GDestroyNotify) openvasd_credential_free);
+                     (GDestroyNotify) scan_credential_free);
   g_free (target->exclude_hosts);
   g_free (target->finished_hosts);
   g_free (target->scan_id);
@@ -667,7 +600,7 @@ openvasd_target_add_alive_test_methods (openvasd_target_t *target,
  */
 void
 openvasd_target_add_credential (openvasd_target_t *target,
-                                openvasd_credential_t *credential)
+                                scan_credential_t *credential)
 {
   if (!target || !credential)
     return;

--- a/openvasd/openvasd.h
+++ b/openvasd/openvasd.h
@@ -13,6 +13,7 @@
 
 #include "../base/nvti.h"
 #include "../http_scanner/http_scanner.h"
+#include "../util/credentialutils.h"
 #include "../util/jsonpull.h"
 
 #include <glib.h>
@@ -41,8 +42,6 @@ typedef struct openvasd_target openvasd_target_t;
 
 typedef struct openvasd_vt_single openvasd_vt_single_t;
 
-typedef struct openvasd_credential openvasd_credential_t;
-
 openvasd_target_t *
 openvasd_target_new (const gchar *, const gchar *, const gchar *, const gchar *,
                      int, int);
@@ -57,17 +56,8 @@ openvasd_target_add_alive_test_methods (openvasd_target_t *, gboolean, gboolean,
 void
 openvasd_target_free (openvasd_target_t *);
 
-openvasd_credential_t *
-openvasd_credential_new (const gchar *, const gchar *, const gchar *);
-
 void
-openvasd_credential_set_auth_data (openvasd_credential_t *, const gchar *,
-                                   const gchar *);
-void
-openvasd_credential_free (openvasd_credential_t *);
-
-void
-openvasd_target_add_credential (openvasd_target_t *, openvasd_credential_t *);
+openvasd_target_add_credential (openvasd_target_t *, scan_credential_t *);
 
 openvasd_vt_single_t *
 openvasd_vt_single_new (const gchar *);

--- a/openvasd/openvasd_tests.c
+++ b/openvasd/openvasd_tests.c
@@ -22,13 +22,13 @@ AfterEach (openvasd)
 
 Ensure (openvasd, openvasd_add_credential_to_scan_json)
 {
-  openvasd_credential_t *credential;
+  scan_credential_t *credential;
   cJSON *credentials = cJSON_CreateArray ();
 
-  credential = openvasd_credential_new ("up", "generic", "0");
+  credential = scan_credential_new ("up", "generic", "0");
 
-  openvasd_credential_set_auth_data (credential, "username", "admin");
-  openvasd_credential_set_auth_data (credential, "password", "admin");
+  scan_credential_set_auth_data (credential, "username", "admin");
+  scan_credential_set_auth_data (credential, "password", "admin");
 
   add_credential_to_scan_json (credential, credentials);
 
@@ -53,7 +53,7 @@ Ensure (openvasd, openvasd_add_credential_to_scan_json)
   assert_that (username, is_equal_to_string ("admin"));
   assert_that (password, is_equal_to_string ("admin"));
 
-  openvasd_credential_free (credential);
+  scan_credential_free (credential);
   cJSON_Delete (credentials);
 }
 

--- a/osp/osp.c
+++ b/osp/osp.c
@@ -54,17 +54,6 @@ struct osp_param
 };
 
 /**
- * @brief Struct credential information for OSP.
- */
-struct osp_credential
-{
-  gchar *type;           /**< Credential type */
-  gchar *service;        /**< Service the credential is for */
-  gchar *port;           /**< Port the credential is for */
-  GHashTable *auth_data; /**< Authentication data (username, password, etc.)*/
-};
-
-/**
  * @brief Struct holding target information.
  */
 struct osp_target
@@ -1100,6 +1089,22 @@ osp_start_scan (osp_connection_t *connection, const char *target,
 }
 
 /**
+ * @brief Add authentication data key value as XML.
+ *
+ * @param key         Key string.
+ * @param value       Value string.
+ * @param xml_string  XML string buffer to append to.
+ */
+static void
+add_auth_data_key_value_as_xml (const char *key, const char *value,
+                                void *xml_string)
+{
+  if (!key || !value || !xml_string)
+    return;
+  xml_string_append ((GString *) xml_string, "<%s>%s</%s>", key, value, key);
+}
+
+/**
  * @brief Concatenate a credential as XML.
  *
  * @param[in]     credential  Credential data.
@@ -1107,25 +1112,19 @@ osp_start_scan (osp_connection_t *connection, const char *target,
  *
  */
 static void
-credential_append_as_xml (osp_credential_t *credential, GString *xml_string)
+credential_append_as_xml (scan_credential_t *credential, GString *xml_string)
 
 {
-  GHashTableIter auth_data_iter;
-  gchar *auth_data_name, *auth_data_value;
+  const gchar *type = scan_credential_get_type (credential);
+  const gchar *service = scan_credential_get_service (credential);
+  const gchar *port = scan_credential_get_port (credential);
 
-  xml_string_append (xml_string,
-                     "<credential type=\"%s\" service=\"%s\" port=\"%s\">",
-                     credential->type ? credential->type : "",
-                     credential->service ? credential->service : "",
-                     credential->port ? credential->port : "");
+  xml_string_append (
+    xml_string, "<credential type=\"%s\" service=\"%s\" port=\"%s\">",
+    type ? type : "", service ? service : "", port ? port : "");
 
-  g_hash_table_iter_init (&auth_data_iter, credential->auth_data);
-  while (g_hash_table_iter_next (&auth_data_iter, (gpointer *) &auth_data_name,
-                                 (gpointer *) &auth_data_value))
-    {
-      xml_string_append (xml_string, "<%s>%s</%s>", auth_data_name,
-                         auth_data_value, auth_data_name);
-    }
+  scan_credential_foreach_auth_data (credential, add_auth_data_key_value_as_xml,
+                                     xml_string);
 
   xml_string_append (xml_string, "</credential>");
 }
@@ -1589,93 +1588,6 @@ osp_param_free (osp_param_t *param)
 }
 
 /**
- * @brief Allocate and initialize a new OSP credential.
- *
- * @param[in]   type      The credential type.
- * @param[in]   service   The service the credential is for.
- * @param[in]   port      The port.
- *
- * @return New osp credential.
- */
-osp_credential_t *
-osp_credential_new (const char *type, const char *service, const char *port)
-{
-  osp_credential_t *new_credential;
-
-  new_credential = g_malloc0 (sizeof (osp_credential_t));
-
-  new_credential->type = type ? g_strdup (type) : NULL;
-  new_credential->service = service ? g_strdup (service) : NULL;
-  new_credential->port = port ? g_strdup (port) : NULL;
-  new_credential->auth_data =
-    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-
-  return new_credential;
-}
-
-/**
- * @brief Free an OSP credential.
- *
- * @param[in]   credential  The credential to free.
- */
-void
-osp_credential_free (osp_credential_t *credential)
-{
-  if (!credential)
-    return;
-
-  g_free (credential->type);
-  g_free (credential->service);
-  g_free (credential->port);
-  g_hash_table_destroy (credential->auth_data);
-  g_free (credential);
-}
-
-/**
- * @brief Get authentication data from an OSP credential.
- *
- * @param[in]  credential  The credential to get the data from.
- * @param[in]  name        The name of the data item to get.
- *
- * @return The requested authentication data or NULL if not available.
- */
-const gchar *
-osp_credential_get_auth_data (osp_credential_t *credential, const char *name)
-{
-  if (credential == NULL || name == NULL)
-    return NULL;
-  return g_hash_table_lookup (credential->auth_data, name);
-}
-
-/**
- * @brief Get authentication data from an OSP credential.
- *
- * @param[in]  credential  The credential to get the data from.
- * @param[in]  name        The name of the data item to get.
- * @param[in]  value       The authentication data or NULL to unset.
- */
-void
-osp_credential_set_auth_data (osp_credential_t *credential, const char *name,
-                              const char *value)
-{
-  if (credential == NULL || name == NULL)
-    return;
-
-  if (g_regex_match_simple ("^[[:alpha:]][[:alnum:]_]*$", name, 0, 0))
-    {
-      if (value)
-        g_hash_table_replace (credential->auth_data, g_strdup (name),
-                              g_strdup (value));
-      else
-        g_hash_table_remove (credential->auth_data, name);
-    }
-  else
-    {
-      g_warning ("%s: Invalid auth data name: %s", __func__, name);
-    }
-}
-
-/**
  * @brief Create a new OSP target.
  *
  * @param[in]  hosts          The hostnames of the target.
@@ -1732,7 +1644,8 @@ osp_target_free (osp_target_t *target)
   if (!target)
     return;
 
-  g_slist_free_full (target->credentials, (GDestroyNotify) osp_credential_free);
+  g_slist_free_full (target->credentials,
+                     (GDestroyNotify) scan_credential_free);
   g_free (target->exclude_hosts);
   g_free (target->hosts);
   g_free (target->ports);
@@ -1771,7 +1684,7 @@ osp_target_add_alive_test_methods (osp_target_t *target, gboolean icmp,
  * @param[in]  credential   The credential to add. Will be freed with target.
  */
 void
-osp_target_add_credential (osp_target_t *target, osp_credential_t *credential)
+osp_target_add_credential (osp_target_t *target, scan_credential_t *credential)
 {
   if (!target || !credential)
     return;

--- a/osp/osp.h
+++ b/osp/osp.h
@@ -11,6 +11,7 @@
 #ifndef _GVM_OSP_OSP_H
 #define _GVM_OSP_OSP_H
 
+#include "../util/credentialutils.h"
 #include "../util/xmlutils.h"
 
 #include <glib.h> /* for GHashTable, GSList */
@@ -18,8 +19,6 @@
 /* Type definitions */
 
 typedef struct osp_connection osp_connection_t;
-
-typedef struct osp_credential osp_credential_t;
 
 typedef struct osp_target osp_target_t;
 
@@ -179,20 +178,6 @@ osp_param_mandatory (const osp_param_t *);
 void
 osp_param_free (osp_param_t *);
 
-/* OSP credential handling */
-
-osp_credential_t *
-osp_credential_new (const char *, const char *, const char *);
-
-void
-osp_credential_free (osp_credential_t *);
-
-const gchar *
-osp_credential_get_auth_data (osp_credential_t *, const char *);
-
-void
-osp_credential_set_auth_data (osp_credential_t *, const char *, const char *);
-
 /* OSP targets handling */
 
 osp_target_t *
@@ -209,7 +194,7 @@ osp_target_add_alive_test_methods (osp_target_t *, gboolean, gboolean, gboolean,
                                    gboolean, gboolean);
 
 void
-osp_target_add_credential (osp_target_t *, osp_credential_t *);
+osp_target_add_credential (osp_target_t *, scan_credential_t *);
 
 /* OSP VT group handling */
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -124,6 +124,7 @@ set(
   cpeutils.c
   passwordbasedauthentication.c
   compressutils.c
+  credentialutils.c
   fileutils.c
   gpgmeutils.c
   json.c
@@ -149,6 +150,7 @@ set(
   passwordbasedauthentication.h
   authutils.h
   compressutils.h
+  credentialutils.h
   fileutils.h
   gpgmeutils.h
   json.h
@@ -210,6 +212,7 @@ if(BUILD_SHARED)
       ${CRYPT_LDFLAGS}
       ${CJSON_LDFLAGS}
       ${VTPARSER_LDFLAGS}
+      ${CREDENTIALUTILS_LDFLAGS}
   )
 endif(BUILD_SHARED)
 
@@ -410,6 +413,15 @@ if(BUILD_TESTS)
     ${GLIB_LDFLAGS}
     ${CJSON_LDFLAGS}
     ${VTPARSER_LDFLAGS}
+    ${LINKER_HARDENING_FLAGS}
+  )
+  add_unit_test(
+    credentialutils-test
+    credentialutils_tests.c
+    gvm_base_shared
+    gvm_util_shared
+    ${GLIB_LDFLAGS}
+    ${CREDENTIALUTILS_LDFLAGS}
     ${LINKER_HARDENING_FLAGS}
   )
 endif(BUILD_TESTS)

--- a/util/credentialutils.c
+++ b/util/credentialutils.c
@@ -1,0 +1,188 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Functions for handling scan credentials.
+ */
+
+#include "credentialutils.h"
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "libgvm util"
+
+/**
+ * @brief Struct credential information.
+ */
+struct scan_credential
+{
+  gchar *type;           /**< Credential type */
+  gchar *service;        /**< Service the credential is for */
+  gchar *port;           /**< Port the credential is for */
+  GHashTable *auth_data; /**< Authentication data (username, password, etc.)*/
+};
+
+/**
+ * @brief Allocate and initialize a new scan credential.
+ *
+ * @param[in]   type      The credential type.
+ * @param[in]   service   The service the credential is for.
+ * @param[in]   port      The port.
+ *
+ * @return New osp credential.
+ */
+scan_credential_t *
+scan_credential_new (const char *type, const char *service, const char *port)
+{
+  scan_credential_t *new_credential;
+
+  new_credential = g_malloc0 (sizeof (scan_credential_t));
+
+  new_credential->type = type ? g_strdup (type) : NULL;
+  new_credential->service = service ? g_strdup (service) : NULL;
+  new_credential->port = port ? g_strdup (port) : NULL;
+  new_credential->auth_data =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  return new_credential;
+}
+
+/**
+ * @brief Get the type of a scan credential.
+ *
+ * @param[in]  credential  The credential to get the type from.
+ *
+ * @return The type of the credential or NULL if not available.
+ */
+const gchar *
+scan_credential_get_type (scan_credential_t *credential)
+{
+  if (!credential)
+    return NULL;
+  return credential->type;
+}
+
+/**
+ * @brief Get the service of a scan credential.
+ *
+ * @param[in]  credential  The credential to get the service from.
+ *
+ * @return The service of the credential or NULL if not available.
+ */
+const gchar *
+scan_credential_get_service (scan_credential_t *credential)
+{
+  if (!credential)
+    return NULL;
+  return credential->service;
+}
+
+/**
+ * @brief Get the port of a scan credential.
+ *
+ * @param[in]  credential  The credential to get the port from.
+ *
+ * @return The port of the credential or NULL if not available.
+ */
+const gchar *
+scan_credential_get_port (scan_credential_t *credential)
+{
+  if (!credential)
+    return NULL;
+  return credential->port;
+}
+
+/**
+ * @brief Iterate over each authentication data item in a scan credential.
+ *
+ * @param[in]  credential  The credential to iterate over.
+ * @param[in]  func        The function to call for each
+ *                          authentication data item.
+ * @param[in]  user_data   User data to pass to the function.
+ */
+void
+scan_credential_foreach_auth_data (scan_credential_t *credential,
+                                   void (*func) (const char *name,
+                                                 const char *value,
+                                                 void *user_data),
+                                   void *user_data)
+{
+  if (!credential || !func)
+    return;
+
+  GHashTableIter iter;
+  gpointer key, value;
+
+  g_hash_table_iter_init (&iter, credential->auth_data);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      func ((const char *) key, (const char *) value, user_data);
+    }
+}
+
+/**
+ * @brief Free a scan credential.
+ *
+ * @param[in]   credential  The credential to free.
+ */
+void
+scan_credential_free (scan_credential_t *credential)
+{
+  if (!credential)
+    return;
+
+  g_free (credential->type);
+  g_free (credential->service);
+  g_free (credential->port);
+  g_hash_table_destroy (credential->auth_data);
+  g_free (credential);
+}
+
+/**
+ * @brief Get authentication data from a scan credential.
+ *
+ * @param[in]  credential  The credential to get the data from.
+ * @param[in]  name        The name of the data item to get.
+ *
+ * @return The requested authentication data or NULL if not available.
+ */
+const gchar *
+scan_credential_get_auth_data (scan_credential_t *credential, const char *name)
+{
+  if (credential == NULL || name == NULL)
+    return NULL;
+  return g_hash_table_lookup (credential->auth_data, name);
+}
+
+/**
+ * @brief Set authentication data for a scan credential.
+ *
+ * @param[in]  credential  The credential to set the data for.
+ * @param[in]  name        The name of the data item to set.
+ * @param[in]  value       The authentication data or NULL to unset.
+ */
+void
+scan_credential_set_auth_data (scan_credential_t *credential, const char *name,
+                               const char *value)
+{
+  if (credential == NULL || name == NULL)
+    return;
+
+  if (g_regex_match_simple ("^[[:alpha:]][[:alnum:]_]*$", name, 0, 0))
+    {
+      if (value)
+        g_hash_table_replace (credential->auth_data, g_strdup (name),
+                              g_strdup (value));
+      else
+        g_hash_table_remove (credential->auth_data, name);
+    }
+  else
+    {
+      g_warning ("%s: Invalid auth data name: %s", __func__, name);
+    }
+}

--- a/util/credentialutils.h
+++ b/util/credentialutils.h
@@ -1,0 +1,45 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * @file
+ * @brief Functions for handling scan credentials.
+ */
+
+#ifndef _GVM_UTIL_CREDENTIALUTILS_H
+#define _GVM_UTIL_CREDENTIALUTILS_H
+
+#include <glib.h> /* for GHashTable, GSList */
+
+typedef struct scan_credential scan_credential_t;
+
+scan_credential_t *
+scan_credential_new (const char *, const char *, const char *);
+
+void
+scan_credential_free (scan_credential_t *);
+
+const gchar *
+scan_credential_get_auth_data (scan_credential_t *, const char *);
+
+void
+scan_credential_set_auth_data (scan_credential_t *, const char *, const char *);
+
+const gchar *
+scan_credential_get_type (scan_credential_t *);
+
+const gchar *
+scan_credential_get_service (scan_credential_t *);
+
+const gchar *
+scan_credential_get_port (scan_credential_t *);
+
+void
+scan_credential_foreach_auth_data (scan_credential_t *,
+                                   void (*func) (const char *, const char *,
+                                                 void *),
+                                   void *);
+
+#endif /* not _GVM_UTIL_CREDENTIALUTILS_H */

--- a/util/credentialutils_tests.c
+++ b/util/credentialutils_tests.c
@@ -1,0 +1,139 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "credentialutils.c"
+
+#include <cgreen/cgreen.h>
+#include <cgreen/mocks.h>
+#include <fcntl.h>
+
+Describe (credentialutils);
+BeforeEach (credentialutils)
+{
+}
+
+AfterEach (credentialutils)
+{
+}
+
+// -------------------- Mock Functions --------------------
+static void
+collect_auth_data (const char *name, const char *value, void *user_data)
+{
+  GHashTable *auth_data = (GHashTable *) user_data;
+  g_hash_table_insert (auth_data, g_strdup (name), g_strdup (value));
+}
+
+Ensure (credentialutils, credentialutils_set_and_retrieve_auth_data)
+{
+  scan_credential_t *credential;
+
+  credential = scan_credential_new ("up", "generic", "0");
+
+  scan_credential_set_auth_data (credential, "username", "admin");
+  scan_credential_set_auth_data (credential, "password", "admin");
+
+  const char *type = scan_credential_get_type (credential);
+  assert_that (type, is_equal_to_string ("up"));
+
+  const char *service = scan_credential_get_service (credential);
+  assert_that (service, is_equal_to_string ("generic"));
+
+  int port = atoi (scan_credential_get_port (credential));
+  assert_that (port, is_equal_to (0));
+
+  const char *username = scan_credential_get_auth_data (credential, "username");
+  const char *password = scan_credential_get_auth_data (credential, "password");
+
+  assert_that (username, is_equal_to_string ("admin"));
+  assert_that (password, is_equal_to_string ("admin"));
+
+  scan_credential_free (credential);
+}
+
+Ensure (credentialutils, credentialutils_set_and_unset_auth_data)
+{
+  scan_credential_t *credential;
+
+  credential = scan_credential_new ("up", "generic", "0");
+
+  scan_credential_set_auth_data (credential, "username", "admin");
+  const char *username = scan_credential_get_auth_data (credential, "username");
+  assert_that (username, is_equal_to_string ("admin"));
+
+  scan_credential_set_auth_data (credential, "username", NULL);
+  username = scan_credential_get_auth_data (credential, "username");
+  assert_that (username, is_null);
+
+  scan_credential_free (credential);
+}
+
+Ensure (credentialutils, credentialutils_set_auth_data_invalid_name)
+{
+  scan_credential_t *credential;
+
+  credential = scan_credential_new ("up", "generic", "0");
+
+  scan_credential_set_auth_data (credential, "invalid-name", "value");
+
+  const char *value =
+    scan_credential_get_auth_data (credential, "invalid-name");
+  assert_that (value, is_null);
+
+  scan_credential_free (credential);
+}
+
+Ensure (credentialutils, credentialutils_foreach_auth_data)
+{
+  scan_credential_t *credential;
+
+  credential = scan_credential_new ("up", "generic", "0");
+
+  scan_credential_set_auth_data (credential, "username", "admin1");
+  scan_credential_set_auth_data (credential, "password", "admin2");
+
+  GHashTable *collected_auth_data =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  scan_credential_foreach_auth_data (credential, collect_auth_data,
+                                     collected_auth_data);
+
+  const char *username = g_hash_table_lookup (collected_auth_data, "username");
+  const char *password = g_hash_table_lookup (collected_auth_data, "password");
+
+  assert_that (username, is_equal_to_string ("admin1"));
+  assert_that (password, is_equal_to_string ("admin2"));
+
+  g_hash_table_destroy (collected_auth_data);
+  scan_credential_free (credential);
+}
+
+/* Test suite. */
+int
+main (int argc, char **argv)
+{
+  int ret;
+  TestSuite *suite;
+
+  suite = create_test_suite ();
+
+  add_test_with_context (suite, credentialutils,
+                         credentialutils_set_and_retrieve_auth_data);
+  add_test_with_context (suite, credentialutils,
+                         credentialutils_set_and_unset_auth_data);
+  add_test_with_context (suite, credentialutils,
+                         credentialutils_set_auth_data_invalid_name);
+  add_test_with_context (suite, credentialutils,
+                         credentialutils_foreach_auth_data);
+
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
+
+  destroy_test_suite (suite);
+
+  return ret;
+}

--- a/util/credentialutils_tests.c
+++ b/util/credentialutils_tests.c
@@ -70,7 +70,7 @@ Ensure (credentialutils, credentialutils_set_and_unset_auth_data)
   scan_credential_free (credential);
 }
 
-Ensure (credentialutils, credentialutils_set_auth_data_invalid_name)
+Ensure (credentialutils, credentialutils_set_auth_data_rejects_invalid_name)
 {
   scan_credential_t *credential;
 
@@ -124,7 +124,7 @@ main (int argc, char **argv)
   add_test_with_context (suite, credentialutils,
                          credentialutils_set_and_unset_auth_data);
   add_test_with_context (suite, credentialutils,
-                         credentialutils_set_auth_data_invalid_name);
+                         credentialutils_set_auth_data_rejects_invalid_name);
   add_test_with_context (suite, credentialutils,
                          credentialutils_foreach_auth_data);
 


### PR DESCRIPTION
## What
 Move common functions for handling target credentials to utils.

## Why
To avoid duplicated functions. Target credentials are handled in the same way for OSP and OpenVASD targets.

## References
GEA-1736