### PR TITLE
Add/merge agent group crons

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -424,6 +424,60 @@ agent_controller_parse_agent (cJSON *item)
 }
 
 /**
+ * @brief Merge cron lists while replacing a previous cron value.
+ *
+ * Copies cron entries from @p base, skips @p to_remove if set, then appends
+ * entries from @p to_add that are not already present.
+ *
+ * @param[in] base       Existing cron list, usually from the agent config.
+ * @param[in] to_add     New cron values to add, usually from the update config.
+ * @param[in] to_remove  Previous cron value to remove, or NULL.
+ *
+ * @return Newly allocated cron list. Must be freed with g_ptr_array_free().
+ */
+static GPtrArray *
+dup_str_ptr_array_merge_crons (const GPtrArray *base,
+                               const GPtrArray *to_add,
+                               const gchar *to_remove)
+{
+  GPtrArray *merged;
+
+  merged = g_ptr_array_new_with_free_func (g_free);
+
+  if (base)
+    {
+      for (guint i = 0; i < base->len; i++)
+        {
+          const gchar *item = g_ptr_array_index (base, i);
+
+          if (!item || item[0] == '\0')
+            continue;
+
+          if (to_remove && to_remove[0] != '\0'
+              && strcmp (item, to_remove) == 0)
+            continue;
+
+          g_ptr_array_add (merged, g_strdup (item));
+        }
+    }
+
+  if (to_add)
+    {
+      for (guint i = 0; i < to_add->len; i++)
+        {
+          const gchar *item = g_ptr_array_index (to_add, i);
+
+          if (!item || item[0] == '\0')
+            continue;
+
+          g_ptr_array_add (merged, g_strdup (item));
+        }
+    }
+
+  return merged;
+}
+
+/**
  * @brief Deep-copy a GPtrArray of char*.
  *
  * @param[in] src  Source pointer array to duplicate (may be NULL).
@@ -468,6 +522,7 @@ dup_str_ptr_array (const GPtrArray *src)
  *
  * @param[in] agent       Agent providing the base configuration.
  * @param[in] update_cfg  Optional configuration overrides. May be NULL.
+ * @param[in] cron_time   Optional old cron time to remove. May be NULL.
  *
  * @return Newly allocated merged configuration on success,
  *         or NULL on error.
@@ -475,7 +530,8 @@ dup_str_ptr_array (const GPtrArray *src)
 static agent_controller_agent_config_t
 agent_controller_build_agent_config_with_defaults (
   const agent_controller_agent_t agent,
-  const agent_controller_agent_config_t update_cfg)
+  const agent_controller_agent_config_t update_cfg,
+  const gchar *cron_time)
 {
   if (!agent || !agent->config)
     return NULL;
@@ -528,13 +584,20 @@ agent_controller_build_agent_config_with_defaults (
           agent->config->agent_script_executor.indexer_dir_depth;
     }
 
-  const GPtrArray *src_cron =
-    (update_cfg && update_cfg->agent_script_executor.scheduler_cron_time)
-      ? update_cfg->agent_script_executor.scheduler_cron_time
-      : agent->config->agent_script_executor.scheduler_cron_time;
-
-  merged->agent_script_executor.scheduler_cron_time =
-    dup_str_ptr_array (src_cron);
+  if (update_cfg)
+    {
+      merged->agent_script_executor.scheduler_cron_time =
+        dup_str_ptr_array_merge_crons (
+          agent->config->agent_script_executor.scheduler_cron_time,
+          update_cfg->agent_script_executor.scheduler_cron_time,
+          cron_time);
+    }
+  else
+    {
+      merged->agent_script_executor.scheduler_cron_time =
+        dup_str_ptr_array (
+          agent->config->agent_script_executor.scheduler_cron_time);
+    }
 
   return merged;
 }
@@ -587,7 +650,8 @@ agent_controller_build_patch_payload (agent_controller_agent_list_t agents,
         {
           agent_controller_agent_config_t merged =
             agent_controller_build_agent_config_with_defaults (agent,
-                                                               update->config);
+                                                               update->config,
+                                                               update->prev_scheduler_cron_time);
           if (merged)
             {
               cfg_obj = agent_controller_agent_config_struct_to_cjson (merged);
@@ -949,6 +1013,11 @@ agent_controller_agent_update_free (agent_controller_agent_update_t update)
   if (update->config)
     {
       agent_controller_agent_config_free (update->config);
+    }
+
+  if (update->prev_scheduler_cron_time)
+    {
+      g_free (update->prev_scheduler_cron_time);
     }
 
   g_free (update);

--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -521,7 +521,7 @@ dup_str_ptr_array (const GPtrArray *src)
  *
  * @param[in] agent       Agent providing the base configuration.
  * @param[in] update_cfg  Optional configuration overrides. May be NULL.
- * @param[in] cron_time   Optional old cron time to remove. May be NULL.
+ * @param[in] prev_cron_time   Optional old cron time to remove. May be NULL.
  *
  * @return Newly allocated merged configuration on success,
  *         or NULL on error.
@@ -529,7 +529,7 @@ dup_str_ptr_array (const GPtrArray *src)
 static agent_controller_agent_config_t
 agent_controller_build_agent_config_with_defaults (
   const agent_controller_agent_t agent,
-  const agent_controller_agent_config_t update_cfg, const gchar *cron_time)
+  const agent_controller_agent_config_t update_cfg, const gchar *prev_cron_time)
 {
   if (!agent || !agent->config)
     return NULL;
@@ -582,12 +582,13 @@ agent_controller_build_agent_config_with_defaults (
           agent->config->agent_script_executor.indexer_dir_depth;
     }
 
-  if (update_cfg)
+  if (update_cfg && update_cfg->agent_script_executor.scheduler_cron_time)
     {
       merged->agent_script_executor.scheduler_cron_time =
         dup_str_ptr_array_merge_crons (
           agent->config->agent_script_executor.scheduler_cron_time,
-          update_cfg->agent_script_executor.scheduler_cron_time, cron_time);
+          update_cfg->agent_script_executor.scheduler_cron_time,
+          prev_cron_time);
     }
   else
     {

--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -436,8 +436,7 @@ agent_controller_parse_agent (cJSON *item)
  * @return Newly allocated cron list. Must be freed with g_ptr_array_free().
  */
 static GPtrArray *
-dup_str_ptr_array_merge_crons (const GPtrArray *base,
-                               const GPtrArray *to_add,
+dup_str_ptr_array_merge_crons (const GPtrArray *base, const GPtrArray *to_add,
                                const gchar *to_remove)
 {
   GPtrArray *merged;
@@ -530,8 +529,7 @@ dup_str_ptr_array (const GPtrArray *src)
 static agent_controller_agent_config_t
 agent_controller_build_agent_config_with_defaults (
   const agent_controller_agent_t agent,
-  const agent_controller_agent_config_t update_cfg,
-  const gchar *cron_time)
+  const agent_controller_agent_config_t update_cfg, const gchar *cron_time)
 {
   if (!agent || !agent->config)
     return NULL;
@@ -589,14 +587,12 @@ agent_controller_build_agent_config_with_defaults (
       merged->agent_script_executor.scheduler_cron_time =
         dup_str_ptr_array_merge_crons (
           agent->config->agent_script_executor.scheduler_cron_time,
-          update_cfg->agent_script_executor.scheduler_cron_time,
-          cron_time);
+          update_cfg->agent_script_executor.scheduler_cron_time, cron_time);
     }
   else
     {
-      merged->agent_script_executor.scheduler_cron_time =
-        dup_str_ptr_array (
-          agent->config->agent_script_executor.scheduler_cron_time);
+      merged->agent_script_executor.scheduler_cron_time = dup_str_ptr_array (
+        agent->config->agent_script_executor.scheduler_cron_time);
     }
 
   return merged;
@@ -649,9 +645,8 @@ agent_controller_build_patch_payload (agent_controller_agent_list_t agents,
       if (update && update->config)
         {
           agent_controller_agent_config_t merged =
-            agent_controller_build_agent_config_with_defaults (agent,
-                                                               update->config,
-                                                               update->prev_scheduler_cron_time);
+            agent_controller_build_agent_config_with_defaults (
+              agent, update->config, update->prev_scheduler_cron_time);
           if (merged)
             {
               cfg_obj = agent_controller_agent_config_struct_to_cjson (merged);

--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -191,6 +191,8 @@ struct agent_controller_agent_update
   int update_to_latest;                   ///< Automatically update the agent
                                           ///  to the latest available version.
   agent_controller_agent_config_t config; ///< The Agent scan configuration
+  gchar *prev_scheduler_cron_time;        ///< Previous scheduler cron time
+                                          /// to match for update (optional)
 };
 typedef struct agent_controller_agent_update *agent_controller_agent_update_t;
 

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -407,8 +407,20 @@ Ensure (agent_controller, agent_update_new_initializes_defaults_correctly)
   assert_that (update->authorized, is_equal_to (-1));
   assert_that (update->update_to_latest, is_equal_to (-1));
   assert_that (update->config, is_null);
+  assert_that (update->prev_scheduler_cron_time, is_null);
 
   agent_controller_agent_update_free (update);
+}
+
+Ensure (agent_controller, agent_update_free_handles_prev_scheduler_cron_time)
+{
+  agent_controller_agent_update_t update = agent_controller_agent_update_new ();
+  assert_that (update, is_not_null);
+
+  update->prev_scheduler_cron_time = g_strdup ("0 */2 * * *");
+
+  agent_controller_agent_update_free (update);
+  assert_that (true, is_true);
 }
 
 Ensure (agent_controller, agent_update_free_handles_nested_schedule)
@@ -2593,7 +2605,7 @@ Ensure (agent_controller, build_config_with_defaults_fills_zeros_from_agent)
   upd->heartbeat.interval_in_seconds = 42;
 
   agent_controller_agent_config_t merged =
-    agent_controller_build_agent_config_with_defaults (agent, upd);
+    agent_controller_build_agent_config_with_defaults (agent, upd, NULL);
 
   assert_that (merged, is_not_null);
 
@@ -2630,12 +2642,12 @@ Ensure (agent_controller, build_config_with_defaults_deep_copies_update_cron)
                    g_strdup ("0 0 * * *"));
 
   agent_controller_agent_config_t merged =
-    agent_controller_build_agent_config_with_defaults (agent, upd);
+    agent_controller_build_agent_config_with_defaults (agent, upd, NULL);
 
   assert_that (merged, is_not_null);
   assert_that (merged->agent_script_executor.scheduler_cron_time, is_not_null);
   assert_that ((int) merged->agent_script_executor.scheduler_cron_time->len,
-               is_equal_to (1));
+               is_equal_to (2));
 
   /* Not the same pointer as update */
   assert_that (
@@ -2646,7 +2658,7 @@ Ensure (agent_controller, build_config_with_defaults_deep_copies_update_cron)
   const gchar *u0 =
     g_ptr_array_index (upd->agent_script_executor.scheduler_cron_time, 0);
   const gchar *m0 =
-    g_ptr_array_index (merged->agent_script_executor.scheduler_cron_time, 0);
+    g_ptr_array_index (merged->agent_script_executor.scheduler_cron_time, 1);
   assert_that (m0, is_equal_to_string ("0 0 * * *"));
   assert_that (m0, is_not_equal_to (u0));
 
@@ -2668,7 +2680,7 @@ Ensure (agent_controller,
   assert_that (upd, is_not_null);
 
   agent_controller_agent_config_t merged =
-    agent_controller_build_agent_config_with_defaults (agent, upd);
+    agent_controller_build_agent_config_with_defaults (agent, upd, NULL);
 
   assert_that (merged, is_not_null);
   assert_that (merged->agent_script_executor.scheduler_cron_time, is_not_null);
@@ -2729,7 +2741,7 @@ Ensure (agent_controller,
   assert_that (upd, is_not_null);
 
   agent_controller_agent_config_t merged =
-    agent_controller_build_agent_config_with_defaults (NULL, upd);
+    agent_controller_build_agent_config_with_defaults (NULL, upd, NULL);
 
   assert_that (merged, is_null);
 
@@ -2747,7 +2759,7 @@ Ensure (agent_controller,
   assert_that (upd, is_not_null);
 
   agent_controller_agent_config_t merged =
-    agent_controller_build_agent_config_with_defaults (agent, upd);
+    agent_controller_build_agent_config_with_defaults (agent, upd, NULL);
 
   assert_that (merged, is_null);
 
@@ -2768,7 +2780,7 @@ Ensure (agent_controller,
   agent->config->heartbeat.miss_until_inactive = 3;
 
   agent_controller_agent_config_t merged =
-    agent_controller_build_agent_config_with_defaults (agent, NULL);
+    agent_controller_build_agent_config_with_defaults (agent, NULL, NULL);
   assert_that (merged, is_not_null);
 
   /* copied from agent */
@@ -2807,7 +2819,7 @@ Ensure (agent_controller,
   upd->heartbeat.interval_in_seconds = 42;
 
   agent_controller_agent_config_t merged =
-    agent_controller_build_agent_config_with_defaults (agent, upd);
+    agent_controller_build_agent_config_with_defaults (agent, upd, NULL);
 
   assert_that (merged, is_not_null);
   assert_that (merged->heartbeat.interval_in_seconds, is_equal_to (42));
@@ -2815,6 +2827,95 @@ Ensure (agent_controller,
   agent_controller_agent_config_free (merged);
   agent_controller_agent_config_free (upd);
   agent_controller_agent_free (agent);
+}
+
+Ensure (agent_controller, build_config_with_defaults_merges_update_cron)
+{
+  agent_controller_agent_t agent = agent_controller_agent_new ();
+  assert_that (agent, is_not_null);
+
+  agent->config = make_agent_config ();
+  assert_that (agent->config, is_not_null);
+
+  agent_controller_agent_config_t upd = agent_controller_agent_config_new ();
+  assert_that (upd, is_not_null);
+
+  upd->agent_script_executor.scheduler_cron_time =
+    g_ptr_array_new_with_free_func (g_free);
+  g_ptr_array_add (upd->agent_script_executor.scheduler_cron_time,
+                   g_strdup ("0 0 * * *"));
+
+  agent_controller_agent_config_t merged =
+    agent_controller_build_agent_config_with_defaults (agent, upd, NULL);
+
+  assert_that (merged, is_not_null);
+  assert_that (merged->agent_script_executor.scheduler_cron_time, is_not_null);
+  assert_that ((int) merged->agent_script_executor.scheduler_cron_time->len,
+               is_equal_to (2));
+
+  assert_that (
+    merged->agent_script_executor.scheduler_cron_time,
+    is_not_equal_to (agent->config->agent_script_executor.scheduler_cron_time));
+  assert_that (
+    merged->agent_script_executor.scheduler_cron_time,
+    is_not_equal_to (upd->agent_script_executor.scheduler_cron_time));
+
+  const gchar *m0 =
+    g_ptr_array_index (merged->agent_script_executor.scheduler_cron_time, 0);
+  const gchar *m1 =
+    g_ptr_array_index (merged->agent_script_executor.scheduler_cron_time, 1);
+
+  assert_that (m0, is_equal_to_string ("* * * * *"));
+  assert_that (m1, is_equal_to_string ("0 0 * * *"));
+
+  agent_controller_agent_config_free (merged);
+  agent_controller_agent_config_free (upd);
+  agent_controller_agent_free (agent);
+}
+
+Ensure (agent_controller, build_config_with_defaults_allows_duplicate_crons)
+{
+  agent_controller_agent_t agent = agent_controller_agent_new ();
+  assert_that (agent, is_not_null);
+
+  agent->config = make_agent_config ();
+  assert_that (agent->config, is_not_null);
+
+  agent_controller_agent_config_t upd = agent_controller_agent_config_new ();
+  assert_that (upd, is_not_null);
+
+  upd->agent_script_executor.scheduler_cron_time =
+    g_ptr_array_new_with_free_func (g_free);
+
+  g_ptr_array_add (upd->agent_script_executor.scheduler_cron_time,
+                   g_strdup ("* * * * *"));
+  g_ptr_array_add (upd->agent_script_executor.scheduler_cron_time,
+                   g_strdup ("* * * * *"));
+
+  gchar *removed_cron = g_strdup ("* * * * *");
+
+  agent_controller_agent_config_t merged =
+    agent_controller_build_agent_config_with_defaults (agent, upd,
+                                                       removed_cron);
+
+  assert_that (merged, is_not_null);
+  assert_that (merged->agent_script_executor.scheduler_cron_time, is_not_null);
+
+  assert_that ((int) merged->agent_script_executor.scheduler_cron_time->len,
+               is_equal_to (2));
+
+  assert_that ((const gchar *) g_ptr_array_index (
+                 merged->agent_script_executor.scheduler_cron_time, 0),
+               is_equal_to_string ("* * * * *"));
+
+  assert_that ((const gchar *) g_ptr_array_index (
+                 merged->agent_script_executor.scheduler_cron_time, 1),
+               is_equal_to_string ("* * * * *"));
+
+  agent_controller_agent_config_free (merged);
+  agent_controller_agent_config_free (upd);
+  agent_controller_agent_free (agent);
+  g_free (removed_cron);
 }
 
 Ensure (agent_controller, scan_agent_config_new_initializes_members)
@@ -3018,6 +3119,8 @@ main (int argc, char **argv)
                          agent_list_free_handles_null_list);
   add_test_with_context (suite, agent_controller,
                          agent_update_new_initializes_defaults_correctly);
+  add_test_with_context (suite, agent_controller,
+                         agent_update_free_handles_prev_scheduler_cron_time);
   add_test_with_context (suite, agent_controller,
                          agent_update_free_handles_nested_schedule);
   add_test_with_context (suite, agent_controller,
@@ -3284,6 +3387,10 @@ main (int argc, char **argv)
   add_test_with_context (
     suite, agent_controller,
     build_config_with_defaults_starts_from_update_when_provided);
+  add_test_with_context (suite, agent_controller,
+                         build_config_with_defaults_merges_update_cron);
+  add_test_with_context (suite, agent_controller,
+                         build_config_with_defaults_allows_duplicate_crons);
   add_test_with_context (suite, agent_controller,
                          scan_agent_config_new_initializes_members);
   add_test_with_context (suite, agent_controller,


### PR DESCRIPTION
## What

* Add support for merging scheduler cron values during agent config updates.
* Remove the previous group cron from the agent cron list.
* Add the new cron value from the update config.
* Keep existing agent-specific cron values.
* Allow duplicate cron values if they are provided.
* Add unit tests for the new merge behavior.

## Why

* Agent groups can define a group-level cron.
* Agents can still have their own cron values.
* Duplicate handling should stay consistent with the provided cron list instead of silently filtering values.


## References

GEA-1791

## Checklist

- [x] Tests


