### PR TITLE
Fix: Fix setting boolean values for reverse lookup in scan config.

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -450,14 +450,14 @@ openvasd_build_scan_config_json (openvasd_target_t *target,
 
   // reverse lookup
   if (target->reverse_lookup_unify)
-    cJSON_AddBoolToObject (target_obj, "reverse_lookup_unify", cJSON_True);
+    cJSON_AddBoolToObject (target_obj, "reverse_lookup_unify", 1);
   else
-    cJSON_AddBoolToObject (target_obj, "reverse_lookup_unify", cJSON_False);
+    cJSON_AddBoolToObject (target_obj, "reverse_lookup_unify", 0);
 
   if (target->reverse_lookup_only)
-    cJSON_AddBoolToObject (target_obj, "reverse_lookup_only", cJSON_True);
+    cJSON_AddBoolToObject (target_obj, "reverse_lookup_only", 1);
   else
-    cJSON_AddBoolToObject (target_obj, "reverse_lookup_only", cJSON_False);
+    cJSON_AddBoolToObject (target_obj, "reverse_lookup_only", 0);
 
   // alive test methods
   cJSON *alive_test_methods = cJSON_CreateArray ();


### PR DESCRIPTION
## What
Use 1 and 0 instead of `cJSON_True` and `cJSON_False` to set boolean values for reverse lookup.

## Why
Was always set to true in the scan config regardless of the value in target. 

`cJSON_AddBoolToObject` expects `cJSON_bool` which is a type alias to int. See https://github.com/DaveGamble/cJSON/issues/324 


