### PR TITLE
Fix: Log error messages when failing to read vt object

### DIFF
--- a/util/vtparser.c
+++ b/util/vtparser.c
@@ -272,7 +272,12 @@ parse_vt_json (gvm_json_pull_parser_t *parser, gvm_json_pull_event_t *event,
   vt_obj = gvm_json_pull_expand_container (parser, &error_message);
   if (!cJSON_IsObject (vt_obj))
     {
-      g_free (error_message);
+      if (error_message)
+        {
+          g_warning ("%s: Error reading VT object: %s", __func__,
+                     error_message);
+          g_free (error_message);
+        }
       cJSON_Delete (vt_obj);
       return -1;
     }


### PR DESCRIPTION
## What
 Log error messages when failing to read a vt object

## Why
Was not logged. Could help debugging when VT parsing issues.

## References
GEA-1797