### PR TITLE
Fix: decrement past start of allocated memory in add_quoting

### DIFF
--- a/util/cpeutils.c
+++ b/util/cpeutils.c
@@ -938,7 +938,7 @@ add_quoting (const char *component)
       if (*c == '*')
         {
           if ((c == tmp_component)
-              || (c == tmp_component + strlen (tmp_component - 1)))
+              || (c == tmp_component + strlen (tmp_component) - 1))
             {
               g_string_append_c (quoted_component, *c);
               c++;
@@ -954,7 +954,7 @@ add_quoting (const char *component)
       if (*c == '?')
         {
           if ((c == tmp_component)
-              || (c == tmp_component + strlen (tmp_component - 1))
+              || (c == tmp_component + strlen (tmp_component) - 1)
               || (!embedded && (c > tmp_component) && (*(c - 1) == '?'))
               || (embedded && *(c + 1) == '?'))
             {

--- a/util/cpeutils_tests.c
+++ b/util/cpeutils_tests.c
@@ -293,6 +293,16 @@ Ensure (cpeutils, uri_cpe_to_uri_product)
   g_free (uri_product);
 }
 
+Ensure (cpeutils, fs_cpe_to_uri_cpe_accepts_end_star)
+{
+  char *result;
+
+  result =
+    fs_cpe_to_uri_cpe ("cpe:2.3:*:microsoft:foo*:8.0.6001:beta:*:*:*:*:*:*");
+  assert_that (result, is_not_null);
+  g_free (result);
+}
+
 /* Test suite. */
 int
 main (int argc, char **argv)
@@ -310,6 +320,7 @@ main (int argc, char **argv)
   add_test_with_context (suite, cpeutils, fs_cpe_to_uri_cpe);
   add_test_with_context (suite, cpeutils, cpe_struct_match);
   add_test_with_context (suite, cpeutils, uri_cpe_to_uri_product);
+  add_test_with_context (suite, cpeutils, fs_cpe_to_uri_cpe_accepts_end_star);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

Change the decrement of a pointer to be the decrement of a length, in `add_quoting` in `cpeutils.c`.

## Why

This was leading to aborts in `gvmd` SCAP rebuilds on my Asan builds (and might be leading to empty fields in the CPE structs).

`tmp_component` is created by `g_strdup`. Doing `strlen` on `tmp_component - 1` is reading into arbitrary memory. It's likely generally safe due to malloc padding, but may result in the length being off (if the byte before `tmp_component` is NULL).

Pretty sure the intention was just to decrement the length after.

I've confirmed with a test and `-fsantize=address`. Before the patch there were Asan leak warnings in the log, after the patch the warnings are gone.

## Checklist

- [x] Tests


