### PR TITLE
add: support IPv6 host discovery alive test for openvasd

### DIFF
--- a/openvasd/openvasd.c
+++ b/openvasd/openvasd.c
@@ -37,17 +37,13 @@
  */
 struct openvasd_target
 {
-  gchar *scan_id;           /**  Scan ID */
-  GSList *credentials;      /** Credentials to use in the scan */
-  gchar *exclude_hosts;     /** String defining one or many hosts to exclude */
-  gchar *hosts;             /** String defining one or many hosts to scan */
-  gchar *ports;             /** String defining the ports to scan */
-  gchar *finished_hosts;    /** String defining hosts to exclude as finished */
-  gboolean icmp;            /** Alive test method icmp */
-  gboolean tcp_syn;         /** Alive test method tcp_syn */
-  gboolean tcp_ack;         /** Alive test method tcp_ack */
-  gboolean arp;             /** Alive test method arp */
-  gboolean consider_alive;  /** Alive test method consider alive */
+  gchar *scan_id;        /**  Scan ID */
+  GSList *credentials;   /** Credentials to use in the scan */
+  gchar *exclude_hosts;  /** String defining one or many hosts to exclude */
+  gchar *hosts;          /** String defining one or many hosts to scan */
+  gchar *ports;          /** String defining the ports to scan */
+  gchar *finished_hosts; /** String defining hosts to exclude as finished */
+  openvasd_alive_test_methods_t alive_test_methods; /** Alive test methods */
   int reverse_lookup_unify; /** Value defining reverse_lookup_unify opt */
   int reverse_lookup_only;  /** Value defining reverse_lookup_only opt */
 };
@@ -461,17 +457,21 @@ openvasd_build_scan_config_json (openvasd_target_t *target,
 
   // alive test methods
   cJSON *alive_test_methods = cJSON_CreateArray ();
-  if (target->arp)
+  if (target->alive_test_methods.arp)
     cJSON_AddItemToArray (alive_test_methods, cJSON_CreateString ("arp"));
-  if (target->tcp_ack)
+  if (target->alive_test_methods.tcp_ack)
     cJSON_AddItemToArray (alive_test_methods, cJSON_CreateString ("tcp_ack"));
-  if (target->tcp_syn)
+  if (target->alive_test_methods.tcp_syn)
     cJSON_AddItemToArray (alive_test_methods, cJSON_CreateString ("tcp_syn"));
-  if (target->consider_alive)
+  if (target->alive_test_methods.consider_alive)
     cJSON_AddItemToArray (alive_test_methods,
                           cJSON_CreateString ("consider_alive"));
-  if (target->icmp)
+  if (target->alive_test_methods.icmp)
     cJSON_AddItemToArray (alive_test_methods, cJSON_CreateString ("icmp"));
+  if (target->alive_test_methods.host_discovery_ipv6)
+    cJSON_AddItemToArray (alive_test_methods,
+                          cJSON_CreateString ("host_discovery_ipv6"));
+
   cJSON_AddItemToObject (target_obj, "alive_test_methods", alive_test_methods);
 
   cJSON_AddItemToObject (scan_obj, "target", target_obj);
@@ -570,26 +570,23 @@ openvasd_target_free (openvasd_target_t *target)
  * @brief Add alive test methods to openvasd target.
  *
  * @param target           The openvasd target to add the methods to.
- * @param icmp             Use ICMP ping.
- * @param tcp_syn          Use TCP-SYN ping.
- * @param tcp_ack          Use TCP-ACK ping.
- * @param arp              Use ARP ping.
- * @param consider_alive   Consider host to be alive.
+ * @param methods          The alive test methods to add.
  */
 void
-openvasd_target_add_alive_test_methods (openvasd_target_t *target,
-                                        gboolean icmp, gboolean tcp_syn,
-                                        gboolean tcp_ack, gboolean arp,
-                                        gboolean consider_alive)
+openvasd_target_set_alive_test_methods (
+  openvasd_target_t *target, const openvasd_alive_test_methods_t *methods)
 {
-  if (!target)
+  if (!target || !methods)
     return;
 
-  target->icmp = icmp;
-  target->tcp_syn = tcp_syn;
-  target->tcp_ack = tcp_ack;
-  target->arp = arp;
-  target->consider_alive = consider_alive;
+  if (methods->host_discovery_ipv6)
+    {
+      target->alive_test_methods =
+        (openvasd_alive_test_methods_t){.host_discovery_ipv6 = TRUE};
+      return;
+    }
+
+  target->alive_test_methods = *methods;
 }
 
 /**

--- a/openvasd/openvasd.h
+++ b/openvasd/openvasd.h
@@ -27,6 +27,19 @@ typedef struct
   const gchar *titles; /**< Graph title. */
 } openvasd_get_performance_opts_t;
 
+/**
+ * @brief Struct holding alive test method options.
+ */
+typedef struct openvasd_alive_test_methods
+{
+  gboolean icmp;                /** Use ICMP ping. */
+  gboolean tcp_syn;             /** Use TCP-SYN ping. */
+  gboolean tcp_ack;             /** Use TCP-ACK ping. */
+  gboolean arp;                 /** Use ARP ping. */
+  gboolean consider_alive;      /** Consider host to be alive. */
+  gboolean host_discovery_ipv6; /** Use IPv6 host discovery. */
+} openvasd_alive_test_methods_t;
+
 // Requests
 http_scanner_resp_t openvasd_get_vts (http_scanner_connector_t);
 
@@ -50,8 +63,8 @@ void
 openvasd_target_set_finished_hosts (openvasd_target_t *, const gchar *);
 
 void
-openvasd_target_add_alive_test_methods (openvasd_target_t *, gboolean, gboolean,
-                                        gboolean, gboolean, gboolean);
+openvasd_target_set_alive_test_methods (
+  openvasd_target_t *target, const openvasd_alive_test_methods_t *methods);
 
 void
 openvasd_target_free (openvasd_target_t *);

--- a/openvasd/openvasd_tests.c
+++ b/openvasd/openvasd_tests.c
@@ -11,6 +11,27 @@
 #include <cgreen/internal/c_assertions.h>
 #include <cgreen/mocks.h>
 
+static gboolean
+json_array_contains_string (cJSON *array, const char *value)
+{
+  int size;
+
+  if (!cJSON_IsArray (array) || !value)
+    return FALSE;
+
+  size = cJSON_GetArraySize (array);
+
+  for (int i = 0; i < size; i++)
+    {
+      const char *item = cJSON_GetStringValue (cJSON_GetArrayItem (array, i));
+
+      if (item && strcmp (item, value) == 0)
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
 Describe (openvasd);
 BeforeEach (openvasd)
 {
@@ -135,6 +156,232 @@ Ensure (openvasd, openvasd_add_vts_to_scan_json)
   cJSON_Delete (vts_array);
 }
 
+Ensure (openvasd, openvasd_set_alive_test_methods)
+{
+  openvasd_target_t *target;
+  openvasd_alive_test_methods_t methods;
+
+  target = openvasd_target_new ("scan-1", "127.0.0.1", "T:22", NULL, 0, 0);
+
+  methods = (openvasd_alive_test_methods_t){
+    .icmp = TRUE,
+    .tcp_syn = TRUE,
+    .tcp_ack = TRUE,
+    .arp = TRUE,
+    .consider_alive = FALSE,
+    .host_discovery_ipv6 = FALSE,
+  };
+
+  openvasd_target_set_alive_test_methods (target, &methods);
+
+  assert_that (target->alive_test_methods.icmp, is_true);
+  assert_that (target->alive_test_methods.tcp_syn, is_true);
+  assert_that (target->alive_test_methods.tcp_ack, is_true);
+  assert_that (target->alive_test_methods.arp, is_true);
+  assert_that (target->alive_test_methods.consider_alive, is_false);
+  assert_that (target->alive_test_methods.host_discovery_ipv6, is_false);
+
+  openvasd_target_free (target);
+}
+
+Ensure (openvasd, openvasd_set_host_discovery_ipv6_alive_test_method)
+{
+  openvasd_target_t *target;
+  openvasd_alive_test_methods_t methods;
+
+  target = openvasd_target_new ("scan-1", "127.0.0.1", "T:22", NULL, 0, 0);
+
+  methods = (openvasd_alive_test_methods_t){
+    .icmp = TRUE,
+    .tcp_syn = TRUE,
+    .tcp_ack = TRUE,
+    .arp = TRUE,
+    .consider_alive = TRUE,
+    .host_discovery_ipv6 = TRUE,
+  };
+
+  openvasd_target_set_alive_test_methods (target, &methods);
+
+  assert_that (target->alive_test_methods.icmp, is_false);
+  assert_that (target->alive_test_methods.tcp_syn, is_false);
+  assert_that (target->alive_test_methods.tcp_ack, is_false);
+  assert_that (target->alive_test_methods.arp, is_false);
+  assert_that (target->alive_test_methods.consider_alive, is_false);
+  assert_that (target->alive_test_methods.host_discovery_ipv6, is_true);
+
+  openvasd_target_free (target);
+}
+
+Ensure (openvasd, openvasd_build_scan_config_json_with_host_discovery_ipv6)
+{
+  openvasd_target_t *target;
+  openvasd_alive_test_methods_t methods;
+  GHashTable *scan_preferences;
+  gchar *json_str;
+  cJSON *json;
+  cJSON *target_obj;
+  cJSON *alive_test_methods;
+
+  target = openvasd_target_new ("scan-1", "2001:db8::/64", "T:22", NULL, 0, 0);
+
+  methods = (openvasd_alive_test_methods_t){
+    .icmp = TRUE,
+    .tcp_syn = TRUE,
+    .tcp_ack = TRUE,
+    .arp = TRUE,
+    .consider_alive = TRUE,
+    .host_discovery_ipv6 = TRUE,
+  };
+
+  openvasd_target_set_alive_test_methods (target, &methods);
+
+  scan_preferences =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  json_str = openvasd_build_scan_config_json (target, scan_preferences, NULL);
+
+  json = cJSON_Parse (json_str);
+  assert_that (cJSON_IsObject (json), is_true);
+
+  target_obj = cJSON_GetObjectItem (json, "target");
+  assert_that (cJSON_IsObject (target_obj), is_true);
+
+  alive_test_methods = cJSON_GetObjectItem (target_obj, "alive_test_methods");
+  assert_that (cJSON_IsArray (alive_test_methods), is_true);
+
+  assert_that (cJSON_GetArraySize (alive_test_methods), is_equal_to (1));
+
+  const char *method =
+    cJSON_GetStringValue (cJSON_GetArrayItem (alive_test_methods, 0));
+
+  assert_that (method, is_equal_to_string ("host_discovery_ipv6"));
+
+  cJSON_Delete (json);
+  g_free (json_str);
+  g_hash_table_destroy (scan_preferences);
+  openvasd_target_free (target);
+}
+
+Ensure (openvasd, openvasd_build_scan_config_json_with_alive_tests)
+{
+  openvasd_target_t *target;
+  openvasd_alive_test_methods_t methods;
+  GHashTable *scan_preferences;
+  gchar *json_str;
+  cJSON *json;
+  cJSON *target_obj;
+  cJSON *alive_test_methods;
+
+  target = openvasd_target_new ("scan-1", "127.0.0.1", "T:22", NULL, 0, 0);
+
+  methods = (openvasd_alive_test_methods_t){
+    .icmp = TRUE,
+    .tcp_syn = TRUE,
+    .tcp_ack = TRUE,
+    .arp = TRUE,
+    .consider_alive = TRUE,
+    .host_discovery_ipv6 = FALSE,
+  };
+
+  openvasd_target_set_alive_test_methods (target, &methods);
+
+  scan_preferences =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  json_str = openvasd_build_scan_config_json (target, scan_preferences, NULL);
+
+  json = cJSON_Parse (json_str);
+  assert_that (cJSON_IsObject (json), is_true);
+
+  target_obj = cJSON_GetObjectItem (json, "target");
+  assert_that (cJSON_IsObject (target_obj), is_true);
+
+  alive_test_methods = cJSON_GetObjectItem (target_obj, "alive_test_methods");
+  assert_that (cJSON_IsArray (alive_test_methods), is_true);
+
+  assert_that (cJSON_GetArraySize (alive_test_methods), is_equal_to (5));
+
+  assert_that (json_array_contains_string (alive_test_methods, "icmp"),
+               is_true);
+  assert_that (json_array_contains_string (alive_test_methods, "tcp_syn"),
+               is_true);
+  assert_that (json_array_contains_string (alive_test_methods, "tcp_ack"),
+               is_true);
+  assert_that (json_array_contains_string (alive_test_methods, "arp"), is_true);
+  assert_that (
+    json_array_contains_string (alive_test_methods, "consider_alive"), is_true);
+
+  assert_that (
+    json_array_contains_string (alive_test_methods, "host_discovery_ipv6"),
+    is_false);
+
+  cJSON_Delete (json);
+  g_free (json_str);
+  g_hash_table_destroy (scan_preferences);
+  openvasd_target_free (target);
+}
+
+Ensure (openvasd, openvasd_build_scan_config_json_with_host_discovery_ipv6_only)
+{
+  openvasd_target_t *target;
+  openvasd_alive_test_methods_t methods;
+  GHashTable *scan_preferences;
+  gchar *json_str;
+  cJSON *json;
+  cJSON *target_obj;
+  cJSON *alive_test_methods;
+
+  target = openvasd_target_new ("scan-1", "2001:db8::/64", "T:22", NULL, 0, 0);
+
+  methods = (openvasd_alive_test_methods_t){
+    .icmp = TRUE,
+    .tcp_syn = TRUE,
+    .tcp_ack = TRUE,
+    .arp = TRUE,
+    .consider_alive = TRUE,
+    .host_discovery_ipv6 = TRUE,
+  };
+
+  openvasd_target_set_alive_test_methods (target, &methods);
+
+  scan_preferences =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+  json_str = openvasd_build_scan_config_json (target, scan_preferences, NULL);
+
+  json = cJSON_Parse (json_str);
+  assert_that (cJSON_IsObject (json), is_true);
+
+  target_obj = cJSON_GetObjectItem (json, "target");
+  assert_that (cJSON_IsObject (target_obj), is_true);
+
+  alive_test_methods = cJSON_GetObjectItem (target_obj, "alive_test_methods");
+  assert_that (cJSON_IsArray (alive_test_methods), is_true);
+
+  assert_that (cJSON_GetArraySize (alive_test_methods), is_equal_to (1));
+
+  assert_that (
+    json_array_contains_string (alive_test_methods, "host_discovery_ipv6"),
+    is_true);
+
+  assert_that (json_array_contains_string (alive_test_methods, "icmp"),
+               is_false);
+  assert_that (json_array_contains_string (alive_test_methods, "tcp_syn"),
+               is_false);
+  assert_that (json_array_contains_string (alive_test_methods, "tcp_ack"),
+               is_false);
+  assert_that (json_array_contains_string (alive_test_methods, "arp"),
+               is_false);
+  assert_that (
+    json_array_contains_string (alive_test_methods, "consider_alive"),
+    is_false);
+
+  cJSON_Delete (json);
+  g_free (json_str);
+  g_hash_table_destroy (scan_preferences);
+  openvasd_target_free (target);
+}
+
 /* Test suite. */
 int
 main (int argc, char **argv)
@@ -147,6 +394,17 @@ main (int argc, char **argv)
   add_test_with_context (suite, openvasd, openvasd_add_credential_to_scan_json);
   add_test_with_context (suite, openvasd, openvasd_add_port_to_scan_json);
   add_test_with_context (suite, openvasd, openvasd_add_vts_to_scan_json);
+
+  add_test_with_context (suite, openvasd, openvasd_set_alive_test_methods);
+  add_test_with_context (suite, openvasd,
+                         openvasd_set_host_discovery_ipv6_alive_test_method);
+  add_test_with_context (
+    suite, openvasd, openvasd_build_scan_config_json_with_host_discovery_ipv6);
+  add_test_with_context (suite, openvasd,
+                         openvasd_build_scan_config_json_with_alive_tests);
+  add_test_with_context (
+    suite, openvasd,
+    openvasd_build_scan_config_json_with_host_discovery_ipv6_only);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

- Added `host_discovery_ipv6` support for `openvasd`.
- Made `host_discovery_ipv6` exclusive.
     - If it is selected, other alive tests are ignored.
- Added unit tests for the new behavior.

## Why

- `host_discovery_ipv6` cannot be combined with other alive tests.
- The change makes sure the generated openvasd scan config is correct.


## References

GEA-1727

## Checklist

- [x] Tests


