### PR TITLE
Add: Add vts list to web application scan config.

### DIFF
--- a/web_application_scanner/web_application_scanner.c
+++ b/web_application_scanner/web_application_scanner.c
@@ -28,12 +28,21 @@
 /**
  * @brief Struct holding target information.
  */
-struct web_application_target
+struct web_scanner_target
 {
   gchar *scan_id;      /**  Scan ID */
   gchar *urls;         /** String defining one or many URLs to scan */
   gchar *exclude_urls; /** String defining one or many URLs to exclude */
   GSList *credentials; /** Credentials to use in the scan */
+};
+
+/**
+ * @brief Struct holding vt information
+ */
+struct web_scanner_vt_single
+{
+  gchar *vt_id;
+  GHashTable *vt_values;
 };
 
 // Scan config builder.
@@ -105,16 +114,53 @@ add_scan_preferences_to_scan_json (gpointer key, gpointer val,
 }
 
 /**
+ * @brief Add a VT to the scan json object.
+ *
+ * @param single_vt VT to add.
+ * @param vts_array JSON array to add the VT to.
+ */
+static void
+add_vts_to_scan_json (gpointer single_vt, gpointer vts_array)
+{
+  GHashTableIter vt_data_iter;
+  gchar *vt_param_id, *vt_param_value;
+
+  web_scanner_vt_single_t *vt = single_vt;
+
+  cJSON *vt_obj = cJSON_CreateObject ();
+
+  cJSON_AddStringToObject (vt_obj, "oid", vt->vt_id);
+
+  if (g_hash_table_size (vt->vt_values))
+    {
+      cJSON *params_array = cJSON_CreateArray ();
+
+      g_hash_table_iter_init (&vt_data_iter, vt->vt_values);
+      while (g_hash_table_iter_next (&vt_data_iter, (gpointer *) &vt_param_id,
+                                     (gpointer *) &vt_param_value))
+        {
+          cJSON *param_obj = cJSON_CreateObject ();
+          cJSON_AddNumberToObject (param_obj, "id", atoi (vt_param_id));
+          cJSON_AddStringToObject (param_obj, "value", vt_param_value);
+          cJSON_AddItemToArray (params_array, param_obj);
+        }
+      cJSON_AddItemToObject (vt_obj, "parameters", params_array);
+    }
+  cJSON_AddItemToArray (vts_array, vt_obj);
+}
+
+/**
  * @brief Build a json object with data necessary to start a scan
  *
- * @param target      target
+ * @param target           target
  * @param scan_preferences Scan preferences to be added to the scan config
+ * @param vts              VTS collection to be added to the scan config.
  *
  * @return JSON string on success. Must be freed by caller. NULL on error.
  */
 char *
-web_application_build_scan_config_json (web_application_target_t *target,
-                                        GHashTable *scan_preferences)
+web_scanner_build_scan_config_json (web_scanner_target_t *target,
+                                    GHashTable *scan_preferences, GSList *vts)
 {
   cJSON *scan_obj = NULL;
   cJSON *target_obj = NULL;
@@ -146,7 +192,7 @@ web_application_build_scan_config_json (web_application_target_t *target,
       cJSON_AddItemToArray (urls_array, url_item);
     }
   g_strfreev (urls_list);
-  cJSON_AddItemToObject (target_obj, "urls", urls_array);
+  cJSON_AddItemToObject (target_obj, "hosts", urls_array);
 
   // exclude urls
   if (target->exclude_urls && target->exclude_urls[0] != '\0')
@@ -160,7 +206,7 @@ web_application_build_scan_config_json (web_application_target_t *target,
           cJSON_AddItemToArray (exclude_urls_array, exclude_url_item);
         }
       g_strfreev (exclude_urls_list);
-      cJSON_AddItemToObject (target_obj, "excluded_urls", exclude_urls_array);
+      cJSON_AddItemToObject (target_obj, "excluded_hosts", exclude_urls_array);
     }
 
   // Credentials
@@ -177,6 +223,11 @@ web_application_build_scan_config_json (web_application_target_t *target,
                         scan_prefs_array);
   cJSON_AddItemToObject (scan_obj, "scan_preferences", scan_prefs_array);
 
+  // VTs
+  cJSON *vts_array = cJSON_CreateArray ();
+  g_slist_foreach (vts, add_vts_to_scan_json, vts_array);
+  cJSON_AddItemToObject (scan_obj, "vts", vts_array);
+
   json_str = cJSON_Print (scan_obj);
   cJSON_Delete (scan_obj);
   if (json_str == NULL)
@@ -186,17 +237,17 @@ web_application_build_scan_config_json (web_application_target_t *target,
 }
 
 /**
- * @brief Create a new web application target.
+ * @brief Create a new web scanner target.
  *
  * @param scanid         Scan ID.
  * @param urls           The URLs of the target.
  * @param exclude_urls   The excluded URLs of the target.
  *
- * @return The newly allocated web_application_target_t. Null on error.
+ * @return The newly allocated web_scanner_target_t. Null on error.
  */
-web_application_target_t *
-web_application_target_new (const gchar *scanid, const gchar *urls,
-                            const gchar *exclude_urls)
+web_scanner_target_t *
+web_scanner_target_new (const gchar *scanid, const gchar *urls,
+                        const gchar *exclude_urls)
 {
   if (!urls || urls[0] == '\0')
     {
@@ -204,8 +255,8 @@ web_application_target_new (const gchar *scanid, const gchar *urls,
       return NULL;
     }
 
-  web_application_target_t *new_target;
-  new_target = g_malloc0 (sizeof (web_application_target_t));
+  web_scanner_target_t *new_target;
+  new_target = g_malloc0 (sizeof (web_scanner_target_t));
 
   if (scanid && *scanid)
     new_target->scan_id = g_strdup (scanid);
@@ -217,12 +268,12 @@ web_application_target_new (const gchar *scanid, const gchar *urls,
 }
 
 /**
- * @brief Free a web application target, including all added credentials.
+ * @brief Free a web scanner target, including all added credentials.
  *
- * @param target  The web application target to free.
+ * @param target  The web scanner target to free.
  */
 void
-web_application_target_free (web_application_target_t *target)
+web_scanner_target_free (web_scanner_target_t *target)
 {
   if (!target)
     return;
@@ -237,14 +288,14 @@ web_application_target_free (web_application_target_t *target)
 }
 
 /**
- * @brief Add a credential to a web application target.
+ * @brief Add a credential to a web scanner target.
  *
- * @param target       The web application target to add the credential to.
+ * @param target       The web scanner target to add the credential to.
  * @param credential   The credential to add. Will be freed with target.
  */
 void
-web_application_target_add_credential (web_application_target_t *target,
-                                       scan_credential_t *credential)
+web_scanner_target_add_credential (web_scanner_target_t *target,
+                                   scan_credential_t *credential)
 {
   if (!target || !credential)
     return;

--- a/web_application_scanner/web_application_scanner.h
+++ b/web_application_scanner/web_application_scanner.h
@@ -16,20 +16,21 @@
 #include <glib.h>
 
 /* Target builder */
-typedef struct web_application_target web_application_target_t;
+typedef struct web_scanner_target web_scanner_target_t;
 
-web_application_target_t *
-web_application_target_new (const gchar *, const gchar *, const gchar *);
+typedef struct web_scanner_vt_single web_scanner_vt_single_t;
+
+web_scanner_target_t *
+web_scanner_target_new (const gchar *, const gchar *, const gchar *);
 
 void
-web_application_target_free (web_application_target_t *);
+web_scanner_target_free (web_scanner_target_t *);
 
 void
-web_application_target_add_credential (web_application_target_t *,
-                                       scan_credential_t *);
+web_scanner_target_add_credential (web_scanner_target_t *, scan_credential_t *);
 
 char *
-web_application_build_scan_config_json (web_application_target_t *target,
-                                        GHashTable *scan_preferences);
+web_scanner_build_scan_config_json (web_scanner_target_t *target,
+                                    GHashTable *scan_preferences, GSList *vts);
 
 #endif /* not _GVM_WEB_APPLICATION_SCANNER_H */

--- a/web_application_scanner/web_application_scanner_tests.c
+++ b/web_application_scanner/web_application_scanner_tests.c
@@ -22,22 +22,21 @@ AfterEach (web_application_scanner)
 
 Ensure (web_application_scanner, new_web_application_scanner_target_has_urls)
 {
-  web_application_target_t *target =
-    web_application_target_new (NULL, NULL, NULL);
+  web_scanner_target_t *target = web_scanner_target_new (NULL, NULL, NULL);
 
   assert_that (target, is_equal_to (NULL));
-  web_application_target_free (target);
+  web_scanner_target_free (target);
 
   const gchar *scanid = "TEST-SCAN-ID";
   const gchar *urls = "http://example.com1,http://example.com2";
   const gchar *exclude_urls = "http://exclude.example.com";
-  target = web_application_target_new (scanid, urls, exclude_urls);
+  target = web_scanner_target_new (scanid, urls, exclude_urls);
 
   assert_that (target, is_not_equal_to (NULL));
   assert_that (target->scan_id, is_equal_to_string (scanid));
   assert_that (target->urls, is_equal_to_string (urls));
   assert_that (target->exclude_urls, is_equal_to_string (exclude_urls));
-  web_application_target_free (target);
+  web_scanner_target_free (target);
 }
 
 Ensure (web_application_scanner,
@@ -116,48 +115,47 @@ Ensure (web_application_scanner,
 
 Ensure (web_application_scanner, web_application_scanner_target_add_credentials)
 {
-  web_application_target_t *target =
-    web_application_target_new (NULL, "hosts", NULL);
+  web_scanner_target_t *target = web_scanner_target_new (NULL, "hosts", NULL);
 
   scan_credential_t *credential = scan_credential_new ("test", "generic", "0");
 
   // Invalid calls, no credentials added
-  web_application_target_add_credential (NULL, NULL);
-  web_application_target_add_credential (target, NULL);
-  web_application_target_add_credential (NULL, credential);
+  web_scanner_target_add_credential (NULL, NULL);
+  web_scanner_target_add_credential (target, NULL);
+  web_scanner_target_add_credential (NULL, credential);
 
   scan_credential_free (credential);
 
   // Add valid credentials
-  web_application_target_add_credential (
-    target, scan_credential_new (NULL, NULL, NULL));
-  web_application_target_add_credential (
+  web_scanner_target_add_credential (target,
+                                     scan_credential_new (NULL, NULL, NULL));
+  web_scanner_target_add_credential (
     target, scan_credential_new ("up", "generic", "0"));
-  web_application_target_add_credential (
-    target, scan_credential_new ("ssh", NULL, NULL));
-  web_application_target_add_credential (
-    target, scan_credential_new (NULL, "docker", "0"));
+  web_scanner_target_add_credential (target,
+                                     scan_credential_new ("ssh", NULL, NULL));
+  web_scanner_target_add_credential (target,
+                                     scan_credential_new (NULL, "docker", "0"));
 
   assert_that (g_slist_length (target->credentials), is_equal_to (4));
 
-  web_application_target_free (target);
+  web_scanner_target_free (target);
 }
 
 Ensure (web_application_scanner, emit_simple_scan_json)
 {
-  web_application_target_t *target = web_application_target_new (
+  web_scanner_target_t *target = web_scanner_target_new (
     "TEST-ID", "http://example1.com,http://example2.com",
     "http://exclude.example.com");
 
   scan_credential_t *credential = scan_credential_new ("up", "generic", NULL);
   scan_credential_set_auth_data (credential, "username", "password");
 
-  web_application_target_add_credential (target, credential);
+  web_scanner_target_add_credential (target, credential);
 
   GHashTable *preferences = g_hash_table_new (g_str_hash, g_str_equal);
   g_hash_table_insert (preferences, "key1", "true");
 
-  gchar *json = web_application_build_scan_config_json (target, preferences);
+  gchar *json = web_scanner_build_scan_config_json (target, preferences, NULL);
 
   assert_that (
     json,
@@ -165,8 +163,8 @@ Ensure (web_application_scanner, emit_simple_scan_json)
       "{\n"
       "\t\"scan_id\":\t\"TEST-ID\",\n"
       "\t\"target\":\t{\n"
-      "\t\t\"urls\":\t[\"http://example1.com\", \"http://example2.com\"],\n"
-      "\t\t\"excluded_urls\":\t[\"http://exclude.example.com\"],\n"
+      "\t\t\"hosts\":\t[\"http://example1.com\", \"http://example2.com\"],\n"
+      "\t\t\"excluded_hosts\":\t[\"http://exclude.example.com\"],\n"
       "\t\t\"credentials\":\t[{\n"
       "\t\t\t\t\"service\":\t\"generic\",\n"
       "\t\t\t\t\"up\":\t{\n"
@@ -177,12 +175,13 @@ Ensure (web_application_scanner, emit_simple_scan_json)
       "\t\"scan_preferences\":\t[{\n"
       "\t\t\t\"id\":\t\"key1\",\n"
       "\t\t\t\"value\":\t\"true\"\n"
-      "\t\t}]\n"
+      "\t\t}],\n"
+      "\t\"vts\":\t[]\n"
       "}"));
 
   g_free (json);
   g_hash_table_destroy (preferences);
-  web_application_target_free (target);
+  web_scanner_target_free (target);
 }
 
 /* Test suite. */


### PR DESCRIPTION
## What

- Add `vts` list to web application scan config.
- Rename scanner target name to `web_scanner_target`
- Use `hosts` and `excluded_hosts` in scan config instead of `urls` and `excluded_urls`

## Why
For consistency with the scanner API.
Renaming scanner target to avoid conflict with gvmd's target.

## References
GEA-1784


