### PR TITLE
fix: use configured security intelligence URL without host fields

### DIFF
--- a/security_intelligence/security_intelligence.c
+++ b/security_intelligence/security_intelligence.c
@@ -102,9 +102,9 @@ security_intelligence_send_request (security_intelligence_connector_t conn,
       return NULL;
     }
 
-  if (!conn->protocol || !conn->host)
+  if (!conn->url && (!conn->protocol || !conn->host))
     {
-      g_warning ("%s: Missing URL components", __func__);
+      g_warning ("%s: Missing URL or URL components", __func__);
       return NULL;
     }
 

--- a/security_intelligence/security_intelligence_tests.c
+++ b/security_intelligence/security_intelligence_tests.c
@@ -647,6 +647,24 @@ Ensure (security_intelligence,
   security_intelligence_connector_free (conn);
 }
 
+Ensure (security_intelligence, send_request_uses_url_without_protocol_or_host)
+{
+  security_intelligence_connector_t conn =
+    security_intelligence_connector_new ();
+
+  conn->url = g_strdup ("https://example.test/base");
+
+  gvm_http_response_t *resp = security_intelligence_send_request (
+    conn, GET, "/resource", NULL, CONTENT_TYPE_JSON);
+
+  assert_that (resp, is_not_null);
+  assert_that (last_sent_url,
+               is_equal_to_string ("https://example.test/base/resource"));
+
+  gvm_http_response_free (resp);
+  security_intelligence_connector_free (conn);
+}
+
 Ensure (security_intelligence, send_request_uses_prebuilt_base_url_when_present)
 {
   security_intelligence_connector_t conn = make_conn ();
@@ -3533,6 +3551,8 @@ main (int argc, char **argv)
   add_test_with_context (
     suite, security_intelligence,
     send_request_builds_url_from_protocol_host_port_and_path);
+  add_test_with_context (suite, security_intelligence,
+                         send_request_uses_url_without_protocol_or_host);
   add_test_with_context (suite, security_intelligence,
                          send_request_uses_prebuilt_base_url_when_present);
   add_test_with_context (suite, security_intelligence,


### PR DESCRIPTION
## What

* Fix Security Intelligence URL validation.
* Allow requests to use `conn->url` without requiring `protocol` and `host`.
* Add a test for connectors configured only with a prebuilt URL.

## Why

A prebuilt URL is already supported when sending requests, but the previous validation rejected the connection when `protocol` or `host` was missing. This prevented valid URL-only configurations from working.


## References

GEA-1616

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


