### PR TITLE
Fix: always free response body from http_scanner_send_request

### DIFF
--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -1166,6 +1166,7 @@ http_scanner_get_scan_status (http_scanner_connector_t conn)
 
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
   else

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -800,6 +800,7 @@ http_scanner_stop_scan (http_scanner_connector_t conn)
 
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
 

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -1300,6 +1300,7 @@ http_scanner_get_health_ready (http_scanner_connector_t conn)
 
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
   else

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -850,6 +850,7 @@ http_scanner_get_scan_results (http_scanner_connector_t conn, long first,
 
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
   else

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -1607,6 +1607,7 @@ http_scanner_get_scan_preferences (http_scanner_connector_t conn)
 
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
   else

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -1260,6 +1260,7 @@ http_scanner_get_health_alive (http_scanner_connector_t conn)
 
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
   else

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -687,6 +687,7 @@ http_scanner_create_scan (http_scanner_connector_t conn, gchar *data)
     {
       const gchar *error_ptr = cJSON_GetErrorPtr ();
       g_warning ("%s: Error parsing json string to get the scan ID", __func__);
+      g_free (response->body);
       if (error_ptr != NULL)
         {
           response->body = g_strdup_printf ("{\"error\": \"%s\"}", error_ptr);
@@ -706,6 +707,7 @@ http_scanner_create_scan (http_scanner_connector_t conn, gchar *data)
   conn->scan_id = g_strdup (cJSON_GetStringValue (parser));
 
   cJSON_Delete (parser);
+  g_free (response->body);
   response->body = g_strdup (http_scanner_stream_str (conn));
   http_scanner_reset_stream (conn);
   return response;

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -1343,6 +1343,7 @@ http_scanner_get_health_started (http_scanner_connector_t conn)
 
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
   else

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -757,6 +757,7 @@ http_scanner_start_scan (http_scanner_connector_t conn)
       return response;
     }
 
+  g_free (response->body);
   response->body = g_strdup (http_scanner_stream_str (conn));
   http_scanner_reset_stream (conn);
   return response;

--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -1217,6 +1217,7 @@ http_scanner_delete_scan (http_scanner_connector_t conn)
                                         NULL, NULL);
   g_string_free (path, TRUE);
 
+  g_free (response->body);
   if (response->code != RESP_CODE_ERR)
     response->body = g_strdup (http_scanner_stream_str (conn));
   else


### PR DESCRIPTION
## What

Always free the body in the response returned from `http_scanner_send_request`.

## Why

These were leaking the body.

## Testing

I ran GMP commands and C tests on main that produced Asan warnings for the leaks.
I ran the same with the PR patches and the warnings were gone.