### PR TITLE
Fix: free scan_id before assignment in http_scanner_create_scan

### DIFF
--- a/http_scanner/http_scanner.c
+++ b/http_scanner/http_scanner.c
@@ -704,6 +704,7 @@ http_scanner_create_scan (http_scanner_connector_t conn, gchar *data)
       return response;
     }
 
+  g_free (conn->scan_id);
   conn->scan_id = g_strdup (cJSON_GetStringValue (parser));
 
   cJSON_Delete (parser);


### PR DESCRIPTION
## What
Free `scan_id` before assignment in `http_scanner_create_scan`.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
`scan_id` was leaking.
<!-- Describe why are these changes necessary? -->

## Testing

I ran GMP commands on main that produced Asan leak warnings.
I ran the same with the patch and the warnings were gone.
