### PR TITLE
Change: Tweak and document logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,8 @@ if(BUILD_TESTS AND NOT SKIP_SRC)
   set(
     TESTS
     array-test
+    authutils-test
+    boreas-arp-test
     boreas-alivedetection-test
     boreas-cli-test
     boreas-error-test
@@ -245,19 +247,34 @@ if(BUILD_TESTS AND NOT SKIP_SRC)
     boreas-sniffer-test
     compressutils-test
     cpeutils-test
+    credentials-test
+    credentialutils-test
     cvss-test
+    fileutils-test
+    gmp-test
     hosts-test
     json-test
     jsonpull-test
+    kb-test
     logging-test
     logging-domain-test
+    mqtt-test
     networking-test
     nvti-test
     osp-test
     passwordbasedauthentication-test
+    pidfile-test
+    prefs-test
+    pwpolicy-test
+    radiusutils-test
+    serverutils-test
+    settings-test
+    sshutils-test
     streamvalidator-test
+    strings-test
     test-hosts
     util-test
+    uuidutils-test
     version-test
     versionutils-test
     xmlutils-test

--- a/README.md
+++ b/README.md
@@ -59,6 +59,98 @@ The `gvm-libs` module consists of the following libraries:
 For more information on using the functionality provided by the `gvm-libs`
 module please refer to the source code documentation.
 
+## Logging configuration
+
+The `base` module of `gvm-libs` contains routines for logging, they
+can be configured with a file on the following format.
+
+The log configuration is divided into domains like these:
+
+```
+[log domain name]
+level=debug
+
+[*]
+prepend=%t %p
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=/var/log/gvm/filename.log
+level=info
+```
+
+Each heading (text in square brackets) controls log messages emitted
+for that log domain name. The heading for log domain name `*` defines
+defaults for most values.
+
+Valid labels under each log domain name heading are:
+
+- prepend
+- separator
+- prepend\_time\_format
+- file
+- level
+- syslog\_facility
+- syslog\_ident
+
+Labels without definition in a log domain will default to the value
+set in the default log domain named `*` with one exception:
+
+syslog\_ident defaults to the log domain name.
+
+Labels without definition in either the log domain for a particular
+log message or the default log domain have these defaults:
+
+- prepend: "%t %s %p - "
+- separator: ":"
+- prepend\_time\_format: "%Y-%m-%d %Hh%M.%S %Z"
+- file: "-"
+- level: "debug"
+- syslog\_facility: "local0"
+- syslog\_ident: null (which causes openlog to use the program name if
+  file specifies to log through syslog)
+
+The value of `prepend` is formatted and prepended to each log message,
+valid format sequences are:
+
+- %p: pid
+- %t: time (as formatted by prepend_time_format)
+- %s: separator (as specified by separator)
+
+Valid values for `separator` are most strings.
+
+Valid values for `prepend\_time\_format` are format specifications for
+strftime(3).
+
+The value of `file` controls where the logs are sent:
+
+- null (not specified for the log domain of a particular message or
+  for the default log domain): log to stderr
+- "" (the empty string): log to stderr
+- "-": log to stderr
+- "syslog": log to syslog
+- all other values: treat the value as a path and try to append to the
+  file specified
+
+The `level` label controls what log levels are output, example values:
+
+- "error", "4": errors
+- "critical", "8": critical situation
+- "warning", "16": warnings
+- "message", "32": messages
+- "info", "64": information
+- "debug", "128": debug (lots of output)
+
+Enabling any level includes all the levels above it. So enabling
+information will include warnings, critical situations and errors.
+
+To get absolutely all logging, set the level to debug for all domains
+in the configuration file.
+
+Valid values for `syslog\_facility` are "auth", "authpriv", "cron",
+"daemon", "ftp", "kern", "lpr", "mail", "mark", "news", "security",
+"syslog", "user", "uucp" and "local0" through "local7".
+
+Valid values for `syslog\_ident` are most strings.
+
 ## Support
 
 For any question on the usage of `gvm-libs` please use the [Greenbone Community

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ can be configured with a file on the following format.
 The log configuration is divided into domains like these:
 
 ```ini
+# Comment
+
 [log domain name]
 level=debug
 
@@ -151,6 +153,9 @@ Valid values for `syslog\_facility` are "auth", "authpriv", "cron",
 "syslog", "user", "uucp" and "local0" through "local7".
 
 Valid values for `syslog\_ident` are most strings.
+
+Empty lines and lines beginning with the hash symbol ("#") are treated
+as comments.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,99 @@ The `gvm-libs` module consists of the following libraries:
 For more information on using the functionality provided by the `gvm-libs`
 module please refer to the source code documentation.
 
+## Logging configuration
+
+The `base` module of `gvm-libs` contains routines for logging, they
+can be configured with a file on the following format.
+
+The log configuration is divided into domains like these:
+
+```ini
+[log domain name]
+level=debug
+
+[*]
+prepend=%t %p
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=/var/log/gvm/filename.log
+level=info
+```
+
+Each heading (text in square brackets) controls log messages emitted
+for that log domain name. The heading for log domain name `*` defines
+defaults for most values.
+
+Valid labels under each log domain name heading are:
+
+- prepend
+- separator
+- prepend\_time\_format
+- file
+- level
+- syslog\_facility
+- syslog\_ident
+
+Labels without definition in a log domain will default to the value
+set in the default log domain named `*` with one exception:
+
+syslog\_ident defaults to the log domain name.
+
+Labels without definition in either the log domain for a particular
+log message or the default log domain have these defaults:
+
+- prepend: "%t %s %p - "
+- separator: ":"
+- prepend\_time\_format: "%Y-%m-%d %Hh%M.%S %Z"
+- file: "-"
+- level: "debug"
+- syslog\_facility: "local0"
+- syslog\_ident: *log domain name*
+
+The value of `prepend` is formatted and prepended to each log message
+sent to file or stderr, valid format sequences are:
+
+- %p: pid
+- %t: time (as formatted by prepend_time_format)
+- %s: separator (as specified by separator)
+
+Valid values for `separator` are most strings.
+
+Valid values for `prepend\_time\_format` are format specifications for
+strftime(3).
+
+The value of `file` controls where the logs are sent:
+
+- null (not specified for the log domain of a particular message or
+  for the default log domain): log to stderr
+- "" (the empty string): log to stderr
+- "-": log to stderr
+- "syslog": log to syslog
+- all other values: treat the value as a path and try to append to the
+  file specified
+
+The `level` label controls what log levels are output, example values:
+
+- "error", "4": errors
+- "critical", "8": critical situation
+- "warning", "16": warnings
+- "message", "32": messages
+- "info", "64": information
+- "debug", "128": debug (lots of output)
+
+Enabling any level includes all the levels above it. So enabling
+information will include warnings, critical situations and errors.
+
+To get absolutely all logging, set the level to debug for all domains
+in the configuration file. Do note warnings though about sensitive
+information in log messages in comments at the start of some config
+files as shipped from dependent projects.
+
+Valid values for `syslog\_facility` are "auth", "authpriv", "cron",
+"daemon", "ftp", "kern", "lpr", "mail", "mark", "news", "security",
+"syslog", "user", "uucp" and "local0" through "local7".
+
+Valid values for `syslog\_ident` are most strings.
+
 ## Support
 
 For any question on the usage of `gvm-libs` please use the [Greenbone Community

--- a/base/logging.c
+++ b/base/logging.c
@@ -249,9 +249,6 @@ load_log_configuration (const gchar *config_file)
             log_domain_entry,
             g_key_file_get_value (key_file, *group, "syslog_facility", &error));
         }
-      else
-        gvm_logging_domain_set_syslog_facility (log_domain_entry,
-                                                g_strdup ("local0"));
 
       /* Look for the syslog_ident string. */
       if (g_key_file_has_key (key_file, *group, "syslog_ident", &error))

--- a/base/logging.c
+++ b/base/logging.c
@@ -297,7 +297,7 @@ free_log_configuration (GSList *log_domain_list)
     {
       gvm_logging_domain_t *log_domain_entry;
 
-      /* Get the list data which is an gvm_logging_t struct. */
+      /* Get the list data which is an gvm_logging_domain_t struct. */
       log_domain_entry = log_domain_list_tmp->data;
 
       /* Free the struct contents. */
@@ -523,7 +523,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
                                   log_domain)
               == 0)
             {
-              /* Get the list data which is an gvm_logging_t struct. */
+              /* Get the list data which is an gvm_logging_domain_t struct. */
               log_domain_entry = entry;
 
               /* Get the struct contents. */
@@ -922,7 +922,7 @@ setup_log_handlers_internal (GSList *gvm_log_config_list, GLogFunc log_func,
         {
           gvm_logging_domain_t *log_domain_entry;
 
-          /* Get the list data which is an gvm_logging_t struct. */
+          /* Get the list data which is an gvm_logging_domain_t struct. */
           log_domain_entry = log_domain_list_tmp->data;
 
           err = check_log_file (log_domain_entry);

--- a/base/logging.c
+++ b/base/logging.c
@@ -448,7 +448,7 @@ gvm_log_func (const char *log_domain, GLogLevelFlags log_level,
   gchar *log_file = "-";
   GLogLevelFlags default_level = G_LOG_LEVEL_DEBUG;
   gchar *syslog_facility = "local0";
-  gchar *syslog_ident = NULL;
+  const gchar *syslog_ident = log_domain;
 
   /* Let's load the default configuration file directives from the
    * linked list. Scanning the link list twice is inefficient but

--- a/base/logging_domain.c
+++ b/base/logging_domain.c
@@ -6,7 +6,7 @@
 #include "logging_domain.h"
 
 /**
- * @struct gvm_logging_t
+ * @struct gvm_logging_domain_t
  * @brief Logging stores the parameters loaded from a log configuration
  * @brief file, to be used internally by the gvm_logging module only.
  */
@@ -34,7 +34,7 @@ struct gvm_logging_domain
  * @param log_domain A string containing the log domain to be used.
  *                   Gets owned by the logging domain and must not be freed.
  *
- * @return gvm_logging_t* Pointer to the new logging struct.
+ * @return gvm_logging_domain_t* Pointer to the new logging struct.
  */
 gvm_logging_domain_t *
 gvm_logging_domain_new (gchar *log_domain)
@@ -64,8 +64,8 @@ gvm_logging_domain_new (gchar *log_domain)
  * This function should be called when the logging domain is no longer needed
  * to ensure that all allocated resources are properly released.
  *
- * @param log_domain A pointer to a gvm_logging_t structure representing the
- *                   logging domain to be freed.
+ * @param log_domain A pointer to a gvm_logging_domain_t structure
+ *                   representing the logging domain to be freed.
  *
  */
 void

--- a/base/logging_tests.c
+++ b/base/logging_tests.c
@@ -134,14 +134,20 @@ Ensure (logging, should_load_log_configuration)
   /* Create a temporary configuration file */
   FILE *file = fopen (config_file, "w");
   assert_that (file, is_not_null);
-  fprintf (file, "[*]\n"
+  fprintf (file, "[bar]\n"
+                 "file=syslog\n"
+                 "syslog_facility=kern\n"
+                 "syslog_ident=test_ident\n"
+                 "\n"
+                 "[foo]\n"
+                 "level=debug\n"
+                 "\n"
+                 "[*]\n"
                  "prepend=%%t %%s %%p - \n"
                  "separator=:\n"
                  "prepend_time_format=%%Y-%%m-%%d %%H:%%M:%%S\n"
                  "file=-\n"
-                 "level=debug\n"
-                 "syslog_facility=local0\n"
-                 "syslog_ident=test_ident\n");
+                 "level=info\n");
   fclose (file);
 
   /* Load the configuration */
@@ -151,6 +157,8 @@ Ensure (logging, should_load_log_configuration)
   /* Verify the configuration */
   gvm_logging_domain_t *log_domain_entry =
     (gvm_logging_domain_t *) log_config_list->data;
+  assert_that (gvm_logging_domain_get_log_domain (log_domain_entry),
+               is_equal_to_string("*"));
   assert_that (gvm_logging_domain_get_prepend_string (log_domain_entry),
                is_equal_to_string ("%t %s %p - "));
   assert_that (gvm_logging_domain_get_prepend_separator (log_domain_entry),
@@ -160,11 +168,56 @@ Ensure (logging, should_load_log_configuration)
   assert_that (gvm_logging_domain_get_log_file (log_domain_entry),
                is_equal_to_string ("-"));
   assert_that (*gvm_logging_domain_get_default_level (log_domain_entry),
+               is_equal_to (G_LOG_LEVEL_INFO));
+  assert_that (gvm_logging_domain_get_syslog_facility (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_syslog_ident (log_domain_entry),
+               is_equal_to_string ("*"));
+
+  log_config_list = g_slist_next (log_config_list);
+  assert_that (log_config_list, is_not_null);
+  log_domain_entry =
+      (gvm_logging_domain_t *) log_config_list->data;
+  assert_that (gvm_logging_domain_get_log_domain (log_domain_entry),
+               is_equal_to_string ("foo"));
+  assert_that (gvm_logging_domain_get_prepend_string (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_prepend_separator (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_prepend_time_format (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_log_file (log_domain_entry),
+               is_null);
+  assert_that (*gvm_logging_domain_get_default_level (log_domain_entry),
                is_equal_to (G_LOG_LEVEL_DEBUG));
   assert_that (gvm_logging_domain_get_syslog_facility (log_domain_entry),
-               is_equal_to_string ("local0"));
+               is_null);
+  assert_that (gvm_logging_domain_get_syslog_ident (log_domain_entry),
+               is_equal_to_string ("foo"));
+
+  log_config_list = g_slist_next (log_config_list);
+  assert_that (log_config_list, is_not_null);
+  log_domain_entry =
+      (gvm_logging_domain_t *) log_config_list->data;
+  assert_that (gvm_logging_domain_get_log_domain (log_domain_entry),
+               is_equal_to_string ("bar"));
+  assert_that (gvm_logging_domain_get_prepend_string (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_prepend_separator (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_prepend_time_format (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_log_file (log_domain_entry),
+               is_equal_to_string ("syslog"));
+  assert_that (gvm_logging_domain_get_default_level (log_domain_entry),
+               is_null);
+  assert_that (gvm_logging_domain_get_syslog_facility (log_domain_entry),
+               is_equal_to_string ("kern"));
   assert_that (gvm_logging_domain_get_syslog_ident (log_domain_entry),
                is_equal_to_string ("test_ident"));
+
+  log_config_list = g_slist_next (log_config_list);
+  assert_that (log_config_list, is_null);
 
   /* Clean up */
   free_log_configuration (log_config_list);

--- a/base/logging_tests.c
+++ b/base/logging_tests.c
@@ -98,6 +98,7 @@ Ensure (logging, should_convert_facility_int_from_string)
 {
   assert_that (facility_int_from_string (NULL), is_equal_to (LOG_LOCAL0));
   assert_that (facility_int_from_string (""), is_equal_to (LOG_LOCAL0));
+  assert_that (facility_int_from_string ("unknown"), is_equal_to (LOG_LOCAL0));
 
   assert_that (facility_int_from_string ("auth"), is_equal_to (LOG_AUTH));
   assert_that (facility_int_from_string ("authpriv"),
@@ -121,8 +122,6 @@ Ensure (logging, should_convert_facility_int_from_string)
   assert_that (facility_int_from_string ("local5"), is_equal_to (LOG_LOCAL5));
   assert_that (facility_int_from_string ("local6"), is_equal_to (LOG_LOCAL6));
   assert_that (facility_int_from_string ("local7"), is_equal_to (LOG_LOCAL7));
-
-  assert_that (facility_int_from_string ("unknown"), is_equal_to (LOG_LOCAL0));
 }
 
 Ensure (logging, should_load_log_configuration)

--- a/base/logging_tests.c
+++ b/base/logging_tests.c
@@ -132,7 +132,9 @@ Ensure (logging, should_load_log_configuration)
   /* Create a temporary configuration file */
   FILE *file = fopen (config_file, "w");
   assert_that (file, is_not_null);
-  fprintf (file, "[bar]\n"
+  fprintf (file, "# comment\n"
+                 "\n"
+                 "[bar]\n"
                  "file=syslog\n"
                  "syslog_facility=kern\n"
                  "syslog_ident=test_ident\n"

--- a/base/logging_tests.c
+++ b/base/logging_tests.c
@@ -122,7 +122,6 @@ Ensure (logging, should_convert_facility_int_from_string)
   assert_that (facility_int_from_string ("local6"), is_equal_to (LOG_LOCAL6));
   assert_that (facility_int_from_string ("local7"), is_equal_to (LOG_LOCAL7));
 
-  assert_that (facility_int_from_string (NULL), is_equal_to (LOG_LOCAL0));
   assert_that (facility_int_from_string ("unknown"), is_equal_to (LOG_LOCAL0));
 }
 


### PR DESCRIPTION
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Make syslog_facility and syslog_ident in logging configuration behave more intuitively.

Document logging configuration in readme.

Extend test should_load_log_configuration.

Extend the tests set in cmakelists.

Deduplicate and rearrange assert_thats in test should_convert_facility_int_from_string.

## Why

<!-- Describe why are these changes necessary? -->

To pass syslog_facility according to configuration for all log domains, even those not explicitly named in configuration. (At present the compiled in default of "local0" supersedes the configuration for log domain "*".)

To pass ident to openlog for all log domains, even those not explicitly named in configuration.

To set expectations and lower the surprise factor.

To test logging configuration more thoroughly.

To make `make tests` compile/link all tests that `make test` expects to find.

To make the test should_convert_facility_int_from_string marginally easier to read.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests

## Notes for reviewers

I'd be happy to get feedback, in particular on the correctness and readability of the new readme section and if the changes of behaviour in "Change: Remove syslog_facility fallback in load_log_configuration" and "Change: Make syslog_ident default to log_domain" are big enough to warrant the change prefix.

I'd also like to note that C programming is not my forte so please review carefully.

I've made an effort to ensure that everything i documented is tested. Please let me know if you see something i missed.