### PR TITLE
Change dependabot config for updating github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,11 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "*"
+          - "actions/*"
+    ignore:
+      - dependency-name: "greenbone/actions"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    commit-message:
+      prefix: "Deps"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,4 +1,4 @@
-name: 'Build Documentation'
+name: "Build Documentation"
 
 on:
   push:
@@ -20,20 +20,20 @@ jobs:
     container: greenbone/doxygen
     steps:
       - name: Check out gvmd
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Generate documentation (XML)
         run: |
-             mkdir build
-             cd build
-             cmake -DSKIP_SRC=1 ..
-             make doc-xml 2> ~/doxygen-stderr.txt
+          mkdir build
+          cd build
+          cmake -DSKIP_SRC=1 ..
+          make doc-xml 2> ~/doxygen-stderr.txt
       - name: Upload doxygen error output as artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
         with:
           name: doxygen-stderr.txt
           path: ~/doxygen-stderr.txt
       - name: Upload XML documentation as artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
         with:
           name: xml-doc
           path: build/doc/generated/xml/

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,10 +6,10 @@ on:
 jobs:
   changelog:
     name: Show changelog since last release
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false

--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check C Source Code Formatting
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Check Source Format
         id: check
         run: |
@@ -36,7 +36,7 @@ jobs:
     name: Check CMake Formatting
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - uses: greenbone/actions/uv@v3
         with:
           install: gersemi
@@ -63,7 +63,7 @@ jobs:
     runs-on: "ubuntu-latest"
     container: debian:stable-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Set git safe.directory
@@ -79,7 +79,7 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE=1 cmake --build build -- tests test coverage-xml
       - name: Upload test coverage to Codecov
         if: github.repository == 'greenbone/gvm-libs'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # 7.0.0
         with:
           files: build/coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: "ubuntu-latest"
     container: debian:stable-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Install build dependencies
         run: sh .github/install-dependencies.sh .github/build-dependencies.list
       - name: Install clang tools
@@ -103,7 +103,7 @@ jobs:
           scan-build -o ~/scan-build-report cmake --build build
       - name: Upload scan-build report
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
         with:
           name: scan-build-report
           path: ~/scan-build-report/

--- a/.github/workflows/codeql-analysis-c.yml
+++ b/.github/workflows/codeql-analysis-c.yml
@@ -8,10 +8,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
+      - "**/*.md"
+      - "**/*.txt"
   schedule:
-    - cron: '30 5 * * 0' # 5:30h on Sundays
+    - cron: "30 5 * * 0" # 5:30h on Sundays
 
 jobs:
   analyze:
@@ -27,25 +27,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'c' ]
+        language: ["c"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
 
-    - name: Install build dependencies
-      run: sh .github/install-dependencies.sh .github/build-dependencies.list
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-      # build between init and analyze ...
-    - name: Configure and Compile gvm-libs
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug ..
-        make install
-      working-directory: ${{ github.WORKSPACE }}
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      - name: Install build dependencies
+        run: sh .github/install-dependencies.sh .github/build-dependencies.list
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # 4.27.5
+        with:
+          languages: ${{ matrix.language }}
+        # build between init and analyze ...
+      - name: Configure and Compile gvm-libs
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug ..
+          make install
+        working-directory: ${{ github.WORKSPACE }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # 4.27.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           release-type-input: ${{ inputs.release-type }}
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false


### PR DESCRIPTION

## What

Change dependabot config for updating github-actions

## Why

Only update greenbone actions for major updates because we trust these tags and don't want to get PRs for each bugfix or minor releases.

Also group updates for github's native actions in one PR to allow for less required reviews.



