### PR TITLE
Prevent gvm_uncompress (..) from spinning forever.

### DIFF
--- a/base/drop_privileges.c
+++ b/base/drop_privileges.c
@@ -57,8 +57,7 @@ drop_privileges_error (GError **error, gint errorcode, const gchar *message)
 int
 drop_privileges (gchar *username, GError **error)
 {
-  g_return_val_if_fail (error == NULL || *error == NULL,
-                        GVM_DROP_PRIVILEGES_ERROR_ALREADY_SET);
+  g_return_val_if_fail (*error == NULL, GVM_DROP_PRIVILEGES_ERROR_ALREADY_SET);
 
   if (username == NULL)
     username = "nobody";

--- a/base/drop_privileges.c
+++ b/base/drop_privileges.c
@@ -57,7 +57,8 @@ drop_privileges_error (GError **error, gint errorcode, const gchar *message)
 int
 drop_privileges (gchar *username, GError **error)
 {
-  g_return_val_if_fail (*error == NULL, GVM_DROP_PRIVILEGES_ERROR_ALREADY_SET);
+  g_return_val_if_fail (error == NULL || *error == NULL,
+                        GVM_DROP_PRIVILEGES_ERROR_ALREADY_SET);
 
   if (username == NULL)
     username = "nobody";

--- a/util/compressutils.c
+++ b/util/compressutils.c
@@ -110,10 +110,18 @@ gvm_compress (const void *src, unsigned long srclen, unsigned long *dstlen)
 void *
 gvm_uncompress (const void *src, unsigned long srclen, unsigned long *dstlen)
 {
-  unsigned long buflen = srclen * 2;
+  unsigned long buflen;
 
-  if (src == NULL || dstlen == NULL)
+  if (src == NULL || dstlen == NULL || srclen == 0)
     return NULL;
+
+  if (srclen >= SSIZE_MAX)
+    return NULL;
+
+  if (srclen > SSIZE_MAX / 2)
+    buflen = SSIZE_MAX;
+  else
+    buflen = srclen * 2;
 
   while (1)
     {
@@ -158,7 +166,12 @@ gvm_uncompress (const void *src, unsigned long srclen, unsigned long *dstlen)
           /* Fallthrough. */
         case Z_BUF_ERROR:
           g_free (buffer);
-          buflen *= 2;
+          if (buflen >= SSIZE_MAX)
+            return NULL;
+          else if (srclen > SSIZE_MAX / 2)
+            buflen = SSIZE_MAX;
+          else
+            buflen *= 2;
           break;
 
         default:


### PR DESCRIPTION
## What
Prevent gvm_uncompress (..) from spinning forever and add overflow checks during growth.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This were two potential bugs.
<!-- Describe why are these changes necessary? -->

## References
GEA-1987
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


