### PR TITLE
Fix: Fix request method setup and improve error handling.

### DIFF
--- a/http/CMakeLists.txt
+++ b/http/CMakeLists.txt
@@ -59,6 +59,7 @@ if(BUILD_TESTS)
     ${CJSON_LDFLAGS}
     ${CURL_LDFLAGS}
     ${LINKER_HARDENING_FLAGS}
+    "-Wl,-wrap,curl_easy_setopt"
   )
 endif(BUILD_TESTS)
 

--- a/http/httputils.c
+++ b/http/httputils.c
@@ -116,6 +116,20 @@ gvm_http_new_internal (const gchar *url, gvm_http_method_t method,
                        const gchar *client_key, const gchar *unix_socket_path,
                        gvm_http_response_stream_t res)
 {
+  if (!url || !res)
+    {
+      g_warning ("%s: Invalid url or response stream", __func__);
+      return NULL;
+    }
+
+  if ((client_cert && !client_key) || (!client_cert && client_key))
+    {
+      g_warning ("%s: Both client certificate and private key must be provided "
+                 "for mutual TLS",
+                 __func__);
+      return NULL;
+    }
+
   CURL *curl = curl_easy_init ();
   CURLcode ret = CURLE_OK;
 
@@ -213,32 +227,37 @@ gvm_http_new_internal (const gchar *url, gvm_http_method_t method,
   switch (method)
     {
     case POST:
-      if (payload && payload[0] != '\0')
+      curl_easy_setopt (curl, CURLOPT_POST, 1L);
+      if (payload)
         {
           curl_easy_setopt (curl, CURLOPT_POSTFIELDS, payload);
-          curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE, strlen (payload));
+          curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE,
+                            (long) strlen (payload));
         }
       break;
     case PUT:
-      if (payload && payload[0] != '\0')
+      curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "PUT");
+      if (payload)
         {
-          curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "PUT");
           curl_easy_setopt (curl, CURLOPT_POSTFIELDS, payload);
-          curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE, strlen (payload));
+          curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE,
+                            (long) strlen (payload));
         }
       break;
     case PATCH:
-      if (payload && payload[0] != '\0')
+      curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+      if (payload)
         {
-          curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "PATCH");
           curl_easy_setopt (curl, CURLOPT_POSTFIELDS, payload);
-          curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE, strlen (payload));
+          curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE,
+                            (long) strlen (payload));
         }
       break;
     case DELETE:
       curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "DELETE");
       break;
     case HEAD:
+      curl_easy_setopt (curl, CURLOPT_NOBODY, 1L);
       curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "HEAD");
       break;
     case GET:

--- a/http/httputils_tests.c
+++ b/http/httputils_tests.c
@@ -8,10 +8,110 @@
 #include <cgreen/cgreen.h>
 #include <curl/curl.h>
 
+static gboolean post_request_called = FALSE;
+static gboolean get_request_called = FALSE;
+static gboolean put_request_called = FALSE;
+static gboolean patch_request_called = FALSE;
+static gboolean delete_request_called = FALSE;
+static gboolean head_request_called = FALSE;
+static const char *last_postfields = NULL;
+static long last_postfieldsize = -1;
+
+/* Mocks */
+
+CURLcode
+__wrap_curl_easy_setopt (CURL *handle, CURLoption option, ...);
+
+CURLcode
+__wrap_curl_easy_setopt (CURL *handle, CURLoption option, ...)
+{
+  (void) handle;
+  va_list args;
+  va_start (args, option);
+  switch (option)
+    {
+    case CURLOPT_HTTPGET:
+      if (va_arg (args, long) == 1L)
+        get_request_called = TRUE;
+      break;
+    case CURLOPT_POST:
+      if (va_arg (args, long) == 1L)
+        post_request_called = TRUE;
+      break;
+    case CURLOPT_CUSTOMREQUEST:
+      {
+        const char *method = va_arg (args, const char *);
+        if (g_strcmp0 (method, "PUT") == 0)
+          put_request_called = TRUE;
+        else if (g_strcmp0 (method, "PATCH") == 0)
+          patch_request_called = TRUE;
+        else if (g_strcmp0 (method, "DELETE") == 0)
+          delete_request_called = TRUE;
+      }
+      break;
+    case CURLOPT_NOBODY:
+      if (va_arg (args, long) == 1L)
+        head_request_called = TRUE;
+      break;
+    case CURLOPT_POSTFIELDS:
+      last_postfields = va_arg (args, const char *);
+      break;
+    case CURLOPT_POSTFIELDSIZE:
+      last_postfieldsize = va_arg (args, long);
+      break;
+    default:
+      (void) option;
+      break;
+    }
+  va_end (args);
+  return CURLE_OK;
+}
+
+/* Helper functions */
+
+static void
+assert_method_and_payload (gvm_http_method_t method, const gchar *payload,
+                           gvm_http_method_t expected_method)
+{
+  gvm_http_response_stream_t s = gvm_http_response_stream_new ();
+  gvm_http_t *http = gvm_http_new ("http://example.com", method, payload, NULL,
+                                   NULL, NULL, NULL, s);
+
+  assert_that (http, is_not_null);
+  assert_that (post_request_called, is_equal_to (expected_method == POST));
+  assert_that (get_request_called, is_equal_to (expected_method == GET));
+  assert_that (put_request_called, is_equal_to (expected_method == PUT));
+  assert_that (patch_request_called, is_equal_to (expected_method == PATCH));
+  assert_that (delete_request_called, is_equal_to (expected_method == DELETE));
+  assert_that (head_request_called, is_equal_to (expected_method == HEAD));
+
+  if (payload == NULL)
+    {
+      assert_that (last_postfields, is_null);
+      assert_that (last_postfieldsize, is_equal_to (-1));
+    }
+  else
+    {
+      assert_that (last_postfields, is_equal_to_string (payload));
+      assert_that (last_postfieldsize, is_equal_to ((long) strlen (payload)));
+    }
+
+  gvm_http_free (http);
+  gvm_http_response_stream_free (s);
+}
+
 Describe (gvm_http);
 
 BeforeEach (gvm_http)
 {
+  post_request_called = FALSE;
+  get_request_called = FALSE;
+  put_request_called = FALSE;
+  patch_request_called = FALSE;
+  delete_request_called = FALSE;
+  head_request_called = FALSE;
+  last_postfields = NULL;
+  last_postfieldsize = -1;
 }
 
 AfterEach (gvm_http)
@@ -219,6 +319,69 @@ Ensure (gvm_http, store_response_header_trims_value)
   g_free (response.content_disposition);
 }
 
+Ensure (gvm_http, post_request_empty_payload_sets_post_method)
+{
+  assert_method_and_payload (POST, "", POST);
+}
+
+Ensure (gvm_http, post_request_null_payload_sets_post_method)
+{
+  assert_method_and_payload (POST, NULL, POST);
+}
+
+Ensure (gvm_http, post_request_nonempty_payload_sets_post_method)
+{
+  const gchar *payload = "{\"key\": \"value\"}";
+  assert_method_and_payload (POST, payload, POST);
+}
+
+Ensure (gvm_http, put_request_empty_payload_sets_put_method)
+{
+  assert_method_and_payload (PUT, "", PUT);
+}
+
+Ensure (gvm_http, put_request_null_payload_sets_put_method)
+{
+  assert_method_and_payload (PUT, NULL, PUT);
+}
+
+Ensure (gvm_http, put_request_nonempty_payload_sets_put_method)
+{
+  const gchar *payload = "{\"key\": \"value\"}";
+  assert_method_and_payload (PUT, payload, PUT);
+}
+
+Ensure (gvm_http, patch_request_empty_payload_sets_patch_method)
+{
+  assert_method_and_payload (PATCH, "", PATCH);
+}
+
+Ensure (gvm_http, patch_request_null_payload_sets_patch_method)
+{
+  assert_method_and_payload (PATCH, NULL, PATCH);
+}
+
+Ensure (gvm_http, patch_request_nonempty_payload_sets_patch_method)
+{
+  const gchar *payload = "{\"key\": \"value\"}";
+  assert_method_and_payload (PATCH, payload, PATCH);
+}
+
+Ensure (gvm_http, get_request_sets_get_method)
+{
+  assert_method_and_payload (GET, NULL, GET);
+}
+
+Ensure (gvm_http, head_request_sets_head_method)
+{
+  assert_method_and_payload (HEAD, NULL, HEAD);
+}
+
+Ensure (gvm_http, delete_request_sets_delete_method)
+{
+  assert_method_and_payload (DELETE, NULL, DELETE);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -255,6 +418,31 @@ main (int argc, char **argv)
   add_test_with_context (suite, gvm_http,
                          store_response_header_matches_case_insensitively);
   add_test_with_context (suite, gvm_http, store_response_header_trims_value);
+
+  add_test_with_context (suite, gvm_http,
+                         post_request_empty_payload_sets_post_method);
+  add_test_with_context (suite, gvm_http,
+                         post_request_null_payload_sets_post_method);
+  add_test_with_context (suite, gvm_http,
+                         post_request_nonempty_payload_sets_post_method);
+
+  add_test_with_context (suite, gvm_http,
+                         put_request_empty_payload_sets_put_method);
+  add_test_with_context (suite, gvm_http,
+                         put_request_null_payload_sets_put_method);
+  add_test_with_context (suite, gvm_http,
+                         put_request_nonempty_payload_sets_put_method);
+
+  add_test_with_context (suite, gvm_http,
+                         patch_request_empty_payload_sets_patch_method);
+  add_test_with_context (suite, gvm_http,
+                         patch_request_null_payload_sets_patch_method);
+  add_test_with_context (suite, gvm_http,
+                         patch_request_nonempty_payload_sets_patch_method);
+
+  add_test_with_context (suite, gvm_http, get_request_sets_get_method);
+  add_test_with_context (suite, gvm_http, head_request_sets_head_method);
+  add_test_with_context (suite, gvm_http, delete_request_sets_delete_method);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What
Keep `POST`, `PUT` and `PATCH` method selection independent of payload.
Use `CURLOPT_NOBODY = 1L` for `HEAD` requests.

## Why
Fix body-less `POST`/`PUT`/`PATCH` requests incorrectly converting to `GET` requests.

## References
GEA-1984