### PR TITLE
Fix: Return error for early EOF in XML iterator

### DIFF
--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -3014,6 +3014,7 @@ xml_file_iterator_next (xml_file_iterator_t iterator, gchar **error)
   while (continue_read && g_queue_is_empty (iterator->element_queue))
     {
       int chars_read;
+      int ret;
       char buffer[XML_FILE_ITERATOR_BUFFER_SIZE];
 
       chars_read =
@@ -3031,25 +3032,22 @@ xml_file_iterator_next (xml_file_iterator_t iterator, gchar **error)
               return NULL;
             }
         }
-      else
-        {
-          int ret;
-          ret = xmlParseChunk (iterator->parser_ctxt, buffer, chars_read,
-                               continue_read == 0);
-          if (ret)
-            {
-              if (error)
-                {
-                  const xmlError *xml_error;
-                  xml_error = xmlCtxtGetLastError (iterator->parser_ctxt);
-                  *error = g_strdup_printf ("error parsing XML"
-                                            " (line %d column %d): %s",
-                                            xml_error->line, xml_error->int2,
-                                            xml_error->message);
-                }
 
-              return NULL;
+      ret = xmlParseChunk (iterator->parser_ctxt, buffer, chars_read,
+                           continue_read == 0);
+      if (ret)
+        {
+          if (error)
+            {
+              const xmlError *xml_error;
+              xml_error = xmlCtxtGetLastError (iterator->parser_ctxt);
+              *error = g_strdup_printf ("error parsing XML"
+                                        " (line %d column %d): %s",
+                                        xml_error->line, xml_error->int2,
+                                        xml_error->message);
             }
+
+          return NULL;
         }
     }
 

--- a/util/xmlutils_tests.c
+++ b/util/xmlutils_tests.c
@@ -714,6 +714,38 @@ Ensure (xmlutils, rewind_resets_state)
   g_free (path);
 }
 
+Ensure (xmlutils, iterator_fails_on_unexpected_eof)
+{
+  const char *xml = "<root><inner><x>1</x></inner></";
+  gchar *path = write_temp_xml (xml);
+  assert_that (path, is_not_null);
+
+  xml_file_iterator_t it = xml_file_iterator_new ();
+  assert_that (xml_file_iterator_init_from_file_path (it, path, 2),
+               is_equal_to (0));
+
+  gchar *err = NULL;
+  element_t e;
+
+  e = xml_file_iterator_next (it, &err);
+  assert_that (element_name (e), is_equal_to_string ("x"));
+  assert_that (err, is_null);
+  element_free (e);
+
+  e = xml_file_iterator_next (it, &err);
+  assert_that (e, is_null);
+  assert_that (err, contains_string ("Opening and ending tag mismatch"));
+
+  g_free (err);
+  err = NULL;
+
+  e = xml_file_iterator_next (it, &err);
+  assert_that (e, is_null);
+  assert_that (err, contains_string ("Opening and ending tag mismatch"));
+
+  element_free (e);
+}
+
 /* Test suite. */
 
 int
@@ -757,6 +789,7 @@ main (int argc, char **argv)
   add_test_with_context (suite, xmlutils, depth2_returns_grandchildren);
 
   add_test_with_context (suite, xmlutils, rewind_resets_state);
+  add_test_with_context (suite, xmlutils, iterator_fails_on_unexpected_eof);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What
If an XML iterator reaches EOF, it will now try to parse the chunk
and finalize the parser.

## Why
This will allow the parser to catch errors like reaching EOF before
the root element is closed.

## References
GEA-1988

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


