### PR TITLE
Fix: Handle empty lists in gvm_hosts_reverse

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1431,7 +1431,7 @@ void
 gvm_hosts_reverse (gvm_hosts_t *hosts)
 {
   size_t i, j;
-  if (hosts == NULL)
+  if (hosts == NULL || hosts->count < 2)
     return;
 
   for (i = 0, j = hosts->count - 1; i < j; i++, j--)

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -226,15 +226,15 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
 }
 
 // This is a macro so the line number below is clear on failure.
-#define ASSERT_HOST_EQUALS(hosts, i, string)                                 \
-  {                                                                          \
-    gchar *value;                                                            \
-                                                                             \
-    value = gvm_host_value_str (hosts->hosts[i]);                            \
-    assert_true_with_message (                                               \
-      g_strcmp0 (value, string) == 0,                                        \
-      "Expected hosts->hosts[%d] to be %s but it was %s", i, string, value); \
-    g_free (value);                                                          \
+#define ASSERT_HOST_EQUALS(hosts_var, i, string)                               \
+  {                                                                            \
+    gchar *value;                                                              \
+                                                                               \
+    value = gvm_host_value_str (hosts_var->hosts[i]);                          \
+    assert_true_with_message (g_strcmp0 (value, string) == 0,                  \
+                              "Expected %s->hosts[%d] to be %s but it was %s", \
+                              G_STRINGIFY (hosts_var), i, string, value);      \
+    g_free (value);                                                            \
   }
 
 static int
@@ -346,6 +346,43 @@ Ensure (hosts, gvm_hosts_allowed_only)
   gvm_hosts_free (hosts);
 }
 
+Ensure (hosts, gvm_hosts_reverse_moves_hosts)
+{
+  gvm_hosts_t *empty_hosts = NULL;
+  gvm_hosts_t *single_host = NULL;
+  gvm_hosts_t *odd_hosts = NULL;
+  gvm_hosts_t *even_hosts = NULL;
+
+  empty_hosts = gvm_hosts_new ("");
+  gvm_hosts_reverse (empty_hosts);
+  assert_that (empty_hosts->count, is_equal_to (0));
+  gvm_hosts_free (empty_hosts);
+
+  single_host = gvm_hosts_new ("192.168.0.1");
+  gvm_hosts_reverse (single_host);
+  assert_that (single_host->count, is_equal_to (1));
+  ASSERT_HOST_EQUALS (single_host, 0, "192.168.0.1");
+  gvm_hosts_free (single_host);
+
+  odd_hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  gvm_hosts_reverse (odd_hosts);
+  assert_that (odd_hosts->count, is_equal_to (3));
+  ASSERT_HOST_EQUALS (odd_hosts, 0, "192.168.0.3");
+  ASSERT_HOST_EQUALS (odd_hosts, 1, "192.168.0.2");
+  ASSERT_HOST_EQUALS (odd_hosts, 2, "192.168.0.1");
+  gvm_hosts_free (odd_hosts);
+
+  even_hosts =
+    gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3,192.168.0.4");
+  gvm_hosts_reverse (even_hosts);
+  assert_that (even_hosts->count, is_equal_to (4));
+  ASSERT_HOST_EQUALS (even_hosts, 0, "192.168.0.4");
+  ASSERT_HOST_EQUALS (even_hosts, 1, "192.168.0.3");
+  ASSERT_HOST_EQUALS (even_hosts, 2, "192.168.0.2");
+  ASSERT_HOST_EQUALS (even_hosts, 3, "192.168.0.1");
+  gvm_hosts_free (even_hosts);
+}
+
 /* Test suite. */
 
 int
@@ -382,6 +419,8 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, hosts, gvm_hosts_move_host_to_end);
   add_test_with_context (suite, hosts, gvm_hosts_allowed_only);
+
+  add_test_with_context (suite, hosts, gvm_hosts_reverse_moves_hosts);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What
If gvm_hosts_reverse is given an empty or single-item list, it will now return early, which fixes an out-of-bounds error in case of empty lists.

Tests for the function are also added.

## Why

<!-- Describe why are these changes necessary? -->

## References
GEA-1981

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


