### PR TITLE
Fix: Avoid overflow in gvm_hosts_new_with_max

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1189,7 +1189,7 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
 
             /* Add addresses from first to last as single hosts. */
             current = first.s_addr;
-            while (ntohl (current) <= ntohl (last.s_addr))
+            while (1)
               {
                 gvm_host_t *host;
                 if (max_hosts > 0 && hosts->count > max_hosts)
@@ -1202,6 +1202,11 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
                 host->type = HOST_TYPE_IPV4;
                 host->addr.s_addr = current;
                 gvm_hosts_add (hosts, host);
+                /* Exit loop if range end has been reached.
+                 * Check is done before increment to avoid possible overflow.
+                 */
+                if (ntohl (current) >= ntohl (last.s_addr))
+                  break;
                 /* Next IP address. */
                 current = htonl (ntohl (current) + 1);
               }
@@ -1232,7 +1237,7 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
 
             /* Add addresses from first to last as single hosts. */
             memcpy (current, &first.s6_addr, 16);
-            while (memcmp (current, &last.s6_addr, 16) <= 0)
+            while (1)
               {
                 int i;
                 gvm_host_t *host;
@@ -1247,6 +1252,13 @@ gvm_hosts_new_with_max (const gchar *hosts_str, unsigned int max_hosts)
                 host->type = HOST_TYPE_IPV6;
                 memcpy (host->addr6.s6_addr, current, 16);
                 gvm_hosts_add (hosts, host);
+
+                /* Exit loop if range end has been reached.
+                 * Check is done before increment to avoid possible overflow.
+                 */
+                if (memcmp (current, &last.s6_addr, 16) >= 0)
+                  break;
+
                 /* Next IPv6 address. */
                 for (i = 15; i >= 0; --i)
                   if (current[i] < 255)

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -225,6 +225,23 @@ Ensure (hosts, gvm_hosts_new_with_max_returns_error)
   assert_that (gvm_hosts_new_with_max ("127.0.0.1|127.0.0.2", 2), is_null);
 }
 
+Ensure (hosts, gvm_hosts_new_with_max_handles_range_edge_cases)
+{
+  gvm_hosts_t *max_ipv4_host =
+    gvm_hosts_new_with_max ("255.255.255.255-255.255.255.255", 10);
+  assert_that (max_ipv4_host, is_not_null);
+  assert_that (max_ipv4_host->count, is_equal_to (1));
+  gvm_hosts_free (max_ipv4_host);
+
+  gvm_hosts_t *max_ipv6_host =
+    gvm_hosts_new_with_max ("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+                            "-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+                            10);
+  assert_that (max_ipv6_host, is_not_null);
+  assert_that (max_ipv6_host->count, is_equal_to (1));
+  gvm_hosts_free (max_ipv6_host);
+}
+
 // This is a macro so the line number below is clear on failure.
 #define ASSERT_HOST_EQUALS(hosts_var, i, string)                               \
   {                                                                            \
@@ -416,6 +433,8 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, hosts, gvm_hosts_new_with_max_returns_error);
   add_test_with_context (suite, hosts, gvm_hosts_new_with_max_returns_success);
+  add_test_with_context (suite, hosts,
+                         gvm_hosts_new_with_max_handles_range_edge_cases);
 
   add_test_with_context (suite, hosts, gvm_hosts_move_host_to_end);
   add_test_with_context (suite, hosts, gvm_hosts_allowed_only);


### PR DESCRIPTION
## What
The gvm_hosts_new_with_max function now checks if the the end of an IP address range has been reached in a way that avoids overflows in case it is the maximum possible IPv4 or IPv6 address (255.255.255.255 or ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff).

## Why
The overflow could result in a wrap-around where too many hosts are added to the expanded hosts list. 
If the number of hosts is unlimited, this could cause an endless loop which eventually runs out of memory.

## References
GEA-1980

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


