### PR TITLE
Fix: Handle empty strings in gvm_hosts_allowed_only

### DIFF
--- a/base/hosts.c
+++ b/base/hosts.c
@@ -1684,12 +1684,23 @@ gvm_hosts_allowed_only (gvm_hosts_t *hosts, const char *deny_hosts_str,
   // Prepare list of denied and allowed hosts
   denied_hosts = gvm_hosts_new_with_max (deny_hosts_str, 0);
   allowed_hosts = gvm_hosts_new_with_max (allow_hosts_str, 0);
+
+  if (gvm_hosts_count (denied_hosts) == 0)
+    {
+      gvm_hosts_free (denied_hosts);
+      denied_hosts = NULL;
+    }
+
+  if (gvm_hosts_count (allowed_hosts) == 0)
+    {
+      gvm_hosts_free (allowed_hosts);
+      allowed_hosts = NULL;
+    }
+
   if (denied_hosts == NULL && allowed_hosts == NULL)
     return NULL;
 
-  if (gvm_hosts_count (denied_hosts) == 0)
-    gvm_hosts_free (denied_hosts);
-  else
+  if (denied_hosts)
     {
       /* Hash host values from denied hosts list. */
       name_deny_table =
@@ -1703,9 +1714,8 @@ gvm_hosts_allowed_only (gvm_hosts_t *hosts, const char *deny_hosts_str,
             g_hash_table_insert (name_deny_table, name, hosts);
         }
     }
-  if (gvm_hosts_count (allowed_hosts) == 0)
-    gvm_hosts_free (allowed_hosts);
-  else
+
+  if (allowed_hosts)
     {
       /* Hash host values from allowed hosts list. */
       name_allow_table =
@@ -1729,7 +1739,7 @@ gvm_hosts_allowed_only (gvm_hosts_t *hosts, const char *deny_hosts_str,
       name = gvm_host_value_str (hosts->hosts[i]);
       if (name)
         {
-          if (denied_hosts != NULL
+          if (name_deny_table != NULL
               && g_hash_table_lookup (name_deny_table, name))
             {
               gvm_host_free (hosts->hosts[i]);
@@ -1738,7 +1748,7 @@ gvm_hosts_allowed_only (gvm_hosts_t *hosts, const char *deny_hosts_str,
               removed = g_slist_prepend (removed, name);
               continue;
             }
-          else if (allowed_hosts != NULL
+          else if (name_allow_table != NULL
                    && !g_hash_table_lookup (name_allow_table, name))
             {
               gvm_host_free (hosts->hosts[i]);

--- a/base/hosts_tests.c
+++ b/base/hosts_tests.c
@@ -329,37 +329,141 @@ Ensure (hosts, gvm_hosts_move_host_to_end)
   gvm_hosts_free (hosts);
 }
 
-Ensure (hosts, gvm_hosts_allowed_only)
+#define ASSERT_SLIST_HOST_EQUALS(list_var, index, host_str) \
+  assert_that (g_slist_nth_data (list_var, index),          \
+               is_equal_to_string (host_str));
+
+Ensure (hosts, gvm_hosts_allowed_only_handles_noop)
 {
   gvm_hosts_t *hosts = NULL;
-  gvm_host_t *host = NULL;
+  GSList *removed = NULL;
+
+  // NULL allow_hosts and deny_hosts
+  hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  removed = gvm_hosts_allowed_only (hosts, NULL, NULL);
+
+  assert_that (gvm_hosts_count (hosts), is_equal_to (3));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
+  ASSERT_HOST_EQUALS (hosts, 1, "192.168.0.2");
+  ASSERT_HOST_EQUALS (hosts, 2, "192.168.0.3");
+  assert_that (removed, is_null);
+
+  g_slist_free_full (removed, g_free);
+  gvm_hosts_free (hosts);
+
+  // NULL allow_hosts and deny_hosts
+  hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  removed = gvm_hosts_allowed_only (hosts, NULL, NULL);
+
+  assert_that (gvm_hosts_count (hosts), is_equal_to (3));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
+  ASSERT_HOST_EQUALS (hosts, 1, "192.168.0.2");
+  ASSERT_HOST_EQUALS (hosts, 2, "192.168.0.3");
+  assert_that (removed, is_null);
+
+  g_slist_free_full (removed, g_free);
+  gvm_hosts_free (hosts);
+
+  // Empty allow_hosts and deny_hosts strings
+  hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  removed = gvm_hosts_allowed_only (hosts, "", "");
+
+  assert_that (gvm_hosts_count (hosts), is_equal_to (3));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
+  ASSERT_HOST_EQUALS (hosts, 1, "192.168.0.2");
+  ASSERT_HOST_EQUALS (hosts, 2, "192.168.0.3");
+  assert_that (removed, is_null);
+
+  g_slist_free_full (removed, g_free);
+  gvm_hosts_free (hosts);
+}
+
+Ensure (hosts, gvm_hosts_allowed_only_handles_deny)
+{
+  gvm_hosts_t *hosts = NULL;
+  GSList *removed = NULL;
+
+  // deny_hosts with NULL allow_hosts
+  hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  removed = gvm_hosts_allowed_only (hosts, "192.168.0.2", NULL);
+
+  assert_that (gvm_hosts_count (hosts), is_equal_to (2));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
+  ASSERT_HOST_EQUALS (hosts, 1, "192.168.0.3");
+  assert_that (g_slist_length (removed), is_equal_to (1));
+  ASSERT_SLIST_HOST_EQUALS (removed, 0, "192.168.0.2");
+
+  g_slist_free_full (removed, g_free);
+  gvm_hosts_free (hosts);
+
+  // deny_hosts with empty allow_hosts string
+  hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  removed = gvm_hosts_allowed_only (hosts, "192.168.0.2", "");
+  assert_that (gvm_hosts_count (hosts), is_equal_to (2));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.1");
+  ASSERT_HOST_EQUALS (hosts, 1, "192.168.0.3");
+  assert_that (g_slist_length (removed), is_equal_to (1));
+  ASSERT_SLIST_HOST_EQUALS (removed, 0, "192.168.0.2");
+
+  g_slist_free_full (removed, g_free);
+  gvm_hosts_free (hosts);
+}
+
+Ensure (hosts, gvm_hosts_allowed_only_handles_allow)
+{
+  gvm_hosts_t *hosts = NULL;
   int totalhosts;
   GSList *removed = NULL;
-  gchar *value;
 
+  // allow_hosts with NULL deny_hosts
   hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
-
-  removed = gvm_hosts_allowed_only (hosts, NULL, NULL);
-  totalhosts = gvm_hosts_count (hosts);
-  assert_that (totalhosts, is_equal_to (3));
-
-  removed = gvm_hosts_allowed_only (hosts, "192.168.0.2", NULL);
-  totalhosts = gvm_hosts_count (hosts);
-  assert_that (totalhosts, is_equal_to (2));
-  assert_that (g_slist_length (removed), is_equal_to (1));
-  g_slist_free_full (removed, g_free);
-
   removed = gvm_hosts_allowed_only (hosts, NULL, "192.168.0.3");
+
   totalhosts = gvm_hosts_count (hosts);
   assert_that (totalhosts, is_equal_to (1));
-  assert_that (g_slist_length (removed), is_equal_to (1));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.3");
+  assert_that (g_slist_length (removed), is_equal_to (2));
+  ASSERT_SLIST_HOST_EQUALS (removed, 1, "192.168.0.1");
+  ASSERT_SLIST_HOST_EQUALS (removed, 0, "192.168.0.2");
+
   g_slist_free_full (removed, g_free);
+  gvm_hosts_free (hosts);
 
-  host = gvm_hosts_next (hosts);
-  value = gvm_host_value_str (host);
-  assert_that (g_strcmp0 (value, "192.168.0.3"), is_equal_to (0));
-  g_free (value);
+  // allow_hosts with empty deny_hosts string
+  hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  removed = gvm_hosts_allowed_only (hosts, "", "192.168.0.3");
 
+  totalhosts = gvm_hosts_count (hosts);
+  assert_that (totalhosts, is_equal_to (1));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.3");
+  assert_that (g_slist_length (removed), is_equal_to (2));
+  ASSERT_SLIST_HOST_EQUALS (removed, 1, "192.168.0.1");
+  ASSERT_SLIST_HOST_EQUALS (removed, 0, "192.168.0.2");
+
+  g_slist_free_full (removed, g_free);
+  gvm_hosts_free (hosts);
+}
+
+Ensure (hosts, gvm_hosts_allowed_only_handles_both)
+{
+  gvm_hosts_t *hosts = NULL;
+  int totalhosts;
+  GSList *removed = NULL;
+
+  // Both allow_hosts and deny_hosts
+  // Deny should have higher priority than allow
+  hosts = gvm_hosts_new ("192.168.0.1,192.168.0.2,192.168.0.3");
+  removed =
+    gvm_hosts_allowed_only (hosts, "192.168.0.2", "192.168.0.2,192.168.0.3");
+
+  totalhosts = gvm_hosts_count (hosts);
+  assert_that (totalhosts, is_equal_to (1));
+  ASSERT_HOST_EQUALS (hosts, 0, "192.168.0.3");
+  assert_that (g_slist_length (removed), is_equal_to (2));
+  ASSERT_SLIST_HOST_EQUALS (removed, 1, "192.168.0.1");
+  ASSERT_SLIST_HOST_EQUALS (removed, 0, "192.168.0.2");
+
+  g_slist_free_full (removed, g_free);
   gvm_hosts_free (hosts);
 }
 
@@ -437,7 +541,11 @@ main (int argc, char **argv)
                          gvm_hosts_new_with_max_handles_range_edge_cases);
 
   add_test_with_context (suite, hosts, gvm_hosts_move_host_to_end);
-  add_test_with_context (suite, hosts, gvm_hosts_allowed_only);
+
+  add_test_with_context (suite, hosts, gvm_hosts_allowed_only_handles_noop);
+  add_test_with_context (suite, hosts, gvm_hosts_allowed_only_handles_deny);
+  add_test_with_context (suite, hosts, gvm_hosts_allowed_only_handles_allow);
+  add_test_with_context (suite, hosts, gvm_hosts_allowed_only_handles_both);
 
   add_test_with_context (suite, hosts, gvm_hosts_reverse_moves_hosts);
 


### PR DESCRIPTION
## What
In `gvm_hosts_allowed_only`, values for `deny_hosts_str` and `allow_hosts_str` that result in empty lists are now handled like NULL more consistently.

The unit tests for this function have been extended to cover more cases.

## Why
This fixes use-after-free errors if one or both of the lists were empty.

## References
GEA-1979

## Checklist
- [x] Tests


