### PR TITLE
add: support plain support bundle downloads

### DIFF
--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -2175,3 +2175,103 @@ agent_controller_download_support_bundle (agent_controller_connector_t conn,
 
   return bundle;
 }
+
+/**
+ * @brief Downloads a decrypted support bundle for a specific agent.
+ *
+ * @param[in] conn Active connector to the Agent Controller.
+ * @param[in] agent_id ID of the agent.
+ * @param[in] days Number of days of logs to include. A value of 0 uses the
+ *                 Agent Controller's configured default.
+ *
+ * @return Newly allocated support bundle on success, NULL on failure.
+ *         Free with agent_controller_support_bundle_free().
+ */
+agent_controller_support_bundle_t
+agent_controller_download_support_bundle_plain (
+  agent_controller_connector_t conn, const gchar *agent_id, int days)
+{
+  gvm_http_headers_t *headers;
+  gvm_http_response_t *response;
+  agent_controller_support_bundle_t bundle;
+  gchar *escaped_agent_id;
+  gchar *path;
+
+  if (!conn || !agent_id || *agent_id == '\0' || days < 0)
+    return NULL;
+
+  escaped_agent_id = g_uri_escape_string (agent_id, NULL, TRUE);
+  if (!escaped_agent_id)
+    return NULL;
+
+  if (days > 0)
+    path = g_strdup_printf (
+      "/agent-control/v2/api/agents/%s/support-bundle/plain?days=%d",
+      escaped_agent_id, days);
+  else
+    path = g_strdup_printf (
+      "/agent-control/v2/api/agents/%s/support-bundle/plain", escaped_agent_id);
+
+  g_free (escaped_agent_id);
+
+  headers = init_custom_header (conn->apikey, FALSE);
+  if (!headers)
+    {
+      g_free (path);
+      return NULL;
+    }
+
+  if (!add_custom_header (headers, "Accept", "application/octet-stream"))
+    {
+      gvm_http_headers_free (headers);
+      g_free (path);
+      return NULL;
+    }
+
+  response =
+    agent_controller_send_request_with_headers (conn, GET, path, NULL, headers);
+
+  gvm_http_headers_free (headers);
+  g_free (path);
+
+  if (!response)
+    return NULL;
+
+  if (response->http_status != 200)
+    {
+      g_warning ("%s: Received HTTP status %ld", __func__,
+                 response->http_status);
+      gvm_http_response_free (response);
+      return NULL;
+    }
+
+  if (!response->data || response->size == 0)
+    {
+      g_warning ("%s: Received an empty support bundle", __func__);
+      gvm_http_response_free (response);
+      return NULL;
+    }
+
+  bundle = agent_controller_support_bundle_new ();
+  if (!bundle)
+    {
+      gvm_http_response_free (response);
+      return NULL;
+    }
+
+  /*
+   * Transfer ownership of the binary buffer from the generic HTTP response
+   * to the Agent Controller support-bundle object.
+   */
+  bundle->data = (guint8 *) response->data;
+  bundle->size = response->size;
+  bundle->filename =
+    content_disposition_filename (response->content_disposition);
+
+  response->data = NULL;
+  response->size = 0;
+
+  gvm_http_response_free (response);
+
+  return bundle;
+}

--- a/agent_controller/agent_controller.c
+++ b/agent_controller/agent_controller.c
@@ -943,6 +943,121 @@ content_disposition_filename (const gchar *content_disposition)
 }
 
 /**
+ * @brief Downloads an encrypted or plain support bundle for an agent.
+ *
+ * @param[in] conn Active connector to the Agent Controller.
+ * @param[in] agent_id ID of the agent.
+ * @param[in] days Number of days of logs to include. A value of 0 uses the
+ *                 Agent Controller's configured default.
+ * @param[in] plain Whether to download the decrypted support bundle.
+ *
+ * @return Newly allocated support bundle on success, NULL on failure.
+ */
+static agent_controller_support_bundle_t
+agent_controller_download_support_bundle_internal (
+  agent_controller_connector_t conn, const gchar *agent_id, int days,
+  gboolean plain)
+{
+  gvm_http_headers_t *headers;
+  gvm_http_response_t *response;
+  agent_controller_support_bundle_t bundle;
+  gchar *escaped_agent_id;
+  gchar *path;
+
+  if (!conn || !agent_id || *agent_id == '\0' || days < 0)
+    return NULL;
+
+  escaped_agent_id = g_uri_escape_string (agent_id, NULL, TRUE);
+  if (!escaped_agent_id)
+    return NULL;
+
+  if (plain)
+    {
+      if (days > 0)
+        path = g_strdup_printf (
+          "/agent-control/v2/api/agents/%s/support-bundle/plain?days=%d",
+          escaped_agent_id, days);
+      else
+        path = g_strdup_printf (
+          "/agent-control/v2/api/agents/%s/support-bundle/plain",
+          escaped_agent_id);
+    }
+  else
+    {
+      if (days > 0)
+        path = g_strdup_printf (
+          "/agent-control/v2/api/agents/%s/support-bundle?days=%d",
+          escaped_agent_id, days);
+      else
+        path = g_strdup_printf (
+          "/agent-control/v2/api/agents/%s/support-bundle", escaped_agent_id);
+    }
+
+  g_free (escaped_agent_id);
+
+  headers = init_custom_header (conn->apikey, FALSE);
+  if (!headers)
+    {
+      g_free (path);
+      return NULL;
+    }
+
+  if (!add_custom_header (headers, "Accept", "application/octet-stream"))
+    {
+      gvm_http_headers_free (headers);
+      g_free (path);
+      return NULL;
+    }
+
+  response =
+    agent_controller_send_request_with_headers (conn, GET, path, NULL, headers);
+
+  gvm_http_headers_free (headers);
+  g_free (path);
+
+  if (!response)
+    return NULL;
+
+  if (response->http_status != 200)
+    {
+      g_warning ("%s: Received HTTP status %ld", __func__,
+                 response->http_status);
+      gvm_http_response_free (response);
+      return NULL;
+    }
+
+  if (!response->data || response->size == 0)
+    {
+      g_warning ("%s: Received an empty support bundle", __func__);
+      gvm_http_response_free (response);
+      return NULL;
+    }
+
+  bundle = agent_controller_support_bundle_new ();
+  if (!bundle)
+    {
+      gvm_http_response_free (response);
+      return NULL;
+    }
+
+  /*
+   * Transfer ownership of the binary buffer from the generic HTTP response
+   * to the Agent Controller support-bundle object.
+   */
+  bundle->data = (guint8 *) response->data;
+  bundle->size = response->size;
+  bundle->filename =
+    content_disposition_filename (response->content_disposition);
+
+  response->data = NULL;
+  response->size = 0;
+
+  gvm_http_response_free (response);
+
+  return bundle;
+}
+
+/**
  * @brief Creates a new Agent Controller connector.
  */
 agent_controller_connector_t
@@ -2077,7 +2192,7 @@ agent_controller_get_installer_instruction (agent_controller_connector_t conn,
 }
 
 /**
- * @brief Downloads a support bundle for a specific agent.
+ * @brief Downloads an encrypted support bundle for a specific agent.
  *
  * @param[in] conn Active connector to the Agent Controller.
  * @param[in] agent_id ID of the agent.
@@ -2091,89 +2206,8 @@ agent_controller_support_bundle_t
 agent_controller_download_support_bundle (agent_controller_connector_t conn,
                                           const gchar *agent_id, int days)
 {
-  gvm_http_headers_t *headers;
-  gvm_http_response_t *response;
-  agent_controller_support_bundle_t bundle;
-  gchar *escaped_agent_id;
-  gchar *path;
-
-  if (!conn || !agent_id || *agent_id == '\0' || days < 0)
-    return NULL;
-
-  escaped_agent_id = g_uri_escape_string (agent_id, NULL, TRUE);
-  if (!escaped_agent_id)
-    return NULL;
-
-  if (days > 0)
-    path =
-      g_strdup_printf ("/agent-control/v2/api/agents/%s/support-bundle?days=%d",
-                       escaped_agent_id, days);
-  else
-    path = g_strdup_printf ("/agent-control/v2/api/agents/%s/support-bundle",
-                            escaped_agent_id);
-
-  g_free (escaped_agent_id);
-
-  headers = init_custom_header (conn->apikey, FALSE);
-  if (!headers)
-    {
-      g_free (path);
-      return NULL;
-    }
-
-  if (!add_custom_header (headers, "Accept", "application/octet-stream"))
-    {
-      gvm_http_headers_free (headers);
-      g_free (path);
-      return NULL;
-    }
-
-  response =
-    agent_controller_send_request_with_headers (conn, GET, path, NULL, headers);
-
-  gvm_http_headers_free (headers);
-  g_free (path);
-
-  if (!response)
-    return NULL;
-
-  if (response->http_status != 200)
-    {
-      g_warning ("%s: Received HTTP status %ld", __func__,
-                 response->http_status);
-      gvm_http_response_free (response);
-      return NULL;
-    }
-
-  if (!response->data || response->size == 0)
-    {
-      g_warning ("%s: Received an empty support bundle", __func__);
-      gvm_http_response_free (response);
-      return NULL;
-    }
-
-  bundle = agent_controller_support_bundle_new ();
-  if (!bundle)
-    {
-      gvm_http_response_free (response);
-      return NULL;
-    }
-
-  /*
-   * Transfer ownership of the binary buffer from the generic HTTP response
-   * to the Agent Controller support-bundle object.
-   */
-  bundle->data = (guint8 *) response->data;
-  bundle->size = response->size;
-  bundle->filename =
-    content_disposition_filename (response->content_disposition);
-
-  response->data = NULL;
-  response->size = 0;
-
-  gvm_http_response_free (response);
-
-  return bundle;
+  return agent_controller_download_support_bundle_internal (conn, agent_id,
+                                                            days, FALSE);
 }
 
 /**
@@ -2191,87 +2225,6 @@ agent_controller_support_bundle_t
 agent_controller_download_support_bundle_plain (
   agent_controller_connector_t conn, const gchar *agent_id, int days)
 {
-  gvm_http_headers_t *headers;
-  gvm_http_response_t *response;
-  agent_controller_support_bundle_t bundle;
-  gchar *escaped_agent_id;
-  gchar *path;
-
-  if (!conn || !agent_id || *agent_id == '\0' || days < 0)
-    return NULL;
-
-  escaped_agent_id = g_uri_escape_string (agent_id, NULL, TRUE);
-  if (!escaped_agent_id)
-    return NULL;
-
-  if (days > 0)
-    path = g_strdup_printf (
-      "/agent-control/v2/api/agents/%s/support-bundle/plain?days=%d",
-      escaped_agent_id, days);
-  else
-    path = g_strdup_printf (
-      "/agent-control/v2/api/agents/%s/support-bundle/plain", escaped_agent_id);
-
-  g_free (escaped_agent_id);
-
-  headers = init_custom_header (conn->apikey, FALSE);
-  if (!headers)
-    {
-      g_free (path);
-      return NULL;
-    }
-
-  if (!add_custom_header (headers, "Accept", "application/octet-stream"))
-    {
-      gvm_http_headers_free (headers);
-      g_free (path);
-      return NULL;
-    }
-
-  response =
-    agent_controller_send_request_with_headers (conn, GET, path, NULL, headers);
-
-  gvm_http_headers_free (headers);
-  g_free (path);
-
-  if (!response)
-    return NULL;
-
-  if (response->http_status != 200)
-    {
-      g_warning ("%s: Received HTTP status %ld", __func__,
-                 response->http_status);
-      gvm_http_response_free (response);
-      return NULL;
-    }
-
-  if (!response->data || response->size == 0)
-    {
-      g_warning ("%s: Received an empty support bundle", __func__);
-      gvm_http_response_free (response);
-      return NULL;
-    }
-
-  bundle = agent_controller_support_bundle_new ();
-  if (!bundle)
-    {
-      gvm_http_response_free (response);
-      return NULL;
-    }
-
-  /*
-   * Transfer ownership of the binary buffer from the generic HTTP response
-   * to the Agent Controller support-bundle object.
-   */
-  bundle->data = (guint8 *) response->data;
-  bundle->size = response->size;
-  bundle->filename =
-    content_disposition_filename (response->content_disposition);
-
-  response->data = NULL;
-  response->size = 0;
-
-  gvm_http_response_free (response);
-
-  return bundle;
+  return agent_controller_download_support_bundle_internal (conn, agent_id,
+                                                            days, TRUE);
 }

--- a/agent_controller/agent_controller.h
+++ b/agent_controller/agent_controller.h
@@ -358,12 +358,16 @@ agent_controller_scan_agent_config_t
 agent_controller_parse_scan_agent_config_string (const gchar *);
 
 agent_controller_installer_instruction_t
-agent_controller_get_installer_instruction (agent_controller_connector_t conn,
-                                            instructions_lang_type_t lang_type,
-                                            const gchar *origin_url);
+agent_controller_get_installer_instruction (agent_controller_connector_t,
+                                            instructions_lang_type_t,
+                                            const gchar *);
 
 agent_controller_support_bundle_t
-agent_controller_download_support_bundle (agent_controller_connector_t conn,
-                                          const gchar *agent_id, int days);
+agent_controller_download_support_bundle (agent_controller_connector_t,
+                                          const gchar *, int);
+
+agent_controller_support_bundle_t
+agent_controller_download_support_bundle_plain (agent_controller_connector_t,
+                                                const gchar *, int);
 
 #endif /* not _GVM_AGENT_CONTROLLER_AGENT_CONTROLLER_H */

--- a/agent_controller/agent_controller_tests.c
+++ b/agent_controller/agent_controller_tests.c
@@ -3905,6 +3905,231 @@ Ensure (agent_controller,
   agent_controller_connector_free (conn);
 }
 
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_data_and_filename)
+{
+  static const guint8 plain_data[] = {0x50, 0x4b, 0x03, 0x04, 0x00,
+                                      0xff, 0x10, 0x20, 0x00, 0x42};
+
+  const gchar *expected_filename = "support-bundle-GAT-29::2d61a736-"
+                                   "20260616T062558Z.tar.gz";
+
+  mock_http_status = 200;
+
+  set_mock_binary_response (plain_data, sizeof (plain_data));
+
+  mock_content_disposition =
+    g_strdup_printf ("attachment; filename=\"%s\"", expected_filename);
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "GAT-29::2d61a736",
+                                                    0);
+
+  assert_that (bundle, is_not_null);
+  assert_that (bundle->data, is_not_null);
+  assert_that (bundle->size, is_equal_to ((gsize) sizeof (plain_data)));
+  assert_that (bundle->filename, is_equal_to_string (expected_filename));
+
+  assert_that (memcmp (bundle->data, plain_data, sizeof (plain_data)),
+               is_equal_to (0));
+
+  assert_that (
+    last_sent_url,
+    is_equal_to_string ("http://localhost:8081/agent-control/v2/api/agents/"
+                        "GAT-29%3A%3A2d61a736/support-bundle/plain"));
+
+  assert_that (last_sent_payload, is_null);
+
+  assert_that (called_headers, is_not_null);
+  assert_that ((int) called_headers->len, is_equal_to (2));
+
+  assert_that ((const gchar *) g_ptr_array_index (called_headers, 0),
+               is_equal_to_string ("X-API-KEY: token"));
+
+  assert_that ((const gchar *) g_ptr_array_index (called_headers, 1),
+               is_equal_to_string ("Accept: application/octet-stream"));
+
+  agent_controller_support_bundle_free (bundle);
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller, download_support_bundle_plain_adds_days_parameter)
+{
+  static const guint8 plain_data[] = {0x01, 0x02, 0x03};
+
+  mock_http_status = 200;
+  set_mock_binary_response (plain_data, sizeof (plain_data));
+
+  mock_content_disposition =
+    g_strdup ("attachment; filename=\"bundle.tar.gz\"");
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "agent-123", 7);
+
+  assert_that (bundle, is_not_null);
+
+  assert_that (
+    last_sent_url,
+    is_equal_to_string ("http://localhost:8081/agent-control/v2/api/agents/"
+                        "agent-123/support-bundle/plain?days=7"));
+
+  agent_controller_support_bundle_free (bundle);
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_allows_missing_content_disposition)
+{
+  static const guint8 plain_data[] = {0x01, 0x02};
+
+  mock_http_status = 200;
+  set_mock_binary_response (plain_data, sizeof (plain_data));
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "agent-123", 0);
+
+  assert_that (bundle, is_not_null);
+  assert_that (bundle->filename, is_null);
+  assert_that (bundle->size, is_equal_to ((gsize) sizeof (plain_data)));
+
+  agent_controller_support_bundle_free (bundle);
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_allows_invalid_content_disposition)
+{
+  static const guint8 plain_data[] = {0x01, 0x02};
+
+  mock_http_status = 200;
+  set_mock_binary_response (plain_data, sizeof (plain_data));
+
+  mock_content_disposition = g_strdup ("attachment");
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "agent-123", 0);
+
+  assert_that (bundle, is_not_null);
+  assert_that (bundle->filename, is_null);
+
+  agent_controller_support_bundle_free (bundle);
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_null_for_null_connection)
+{
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (NULL, "agent-123", 0);
+
+  assert_that (bundle, is_null);
+  assert_that (last_sent_url, is_null);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_null_for_null_agent_id)
+{
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, NULL, 0);
+
+  assert_that (bundle, is_null);
+  assert_that (last_sent_url, is_null);
+
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_null_for_empty_agent_id)
+{
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "", 0);
+
+  assert_that (bundle, is_null);
+  assert_that (last_sent_url, is_null);
+
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_null_for_negative_days)
+{
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "agent-123", -1);
+
+  assert_that (bundle, is_null);
+  assert_that (last_sent_url, is_null);
+
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_null_for_http_error)
+{
+  mock_http_status = 404;
+  mock_response_data = g_strdup ("Agent not found");
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "missing-agent", 0);
+
+  assert_that (bundle, is_null);
+
+  assert_that (last_sent_url,
+               contains_string ("/agent-control/v2/api/agents/"
+                                "missing-agent/support-bundle/plain"));
+
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_null_when_request_fails)
+{
+  mock_http_status = 500;
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "agent-123", 0);
+
+  assert_that (bundle, is_null);
+
+  agent_controller_connector_free (conn);
+}
+
+Ensure (agent_controller,
+        download_support_bundle_plain_returns_null_for_empty_response)
+{
+  mock_http_status = 200;
+  mock_empty_response = TRUE;
+
+  mock_content_disposition =
+    g_strdup ("attachment; filename=\"bundle.tar.gz\"");
+
+  agent_controller_connector_t conn = make_conn ();
+
+  agent_controller_support_bundle_t bundle =
+    agent_controller_download_support_bundle_plain (conn, "agent-123", 0);
+
+  assert_that (bundle, is_null);
+
+  agent_controller_connector_free (conn);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -4340,6 +4565,38 @@ main (int argc, char **argv)
   add_test_with_context (
     suite, agent_controller,
     download_support_bundle_returns_null_for_empty_response);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_data_and_filename);
+  add_test_with_context (suite, agent_controller,
+                         download_support_bundle_plain_adds_days_parameter);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_allows_missing_content_disposition);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_allows_invalid_content_disposition);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_null_for_null_connection);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_null_for_null_agent_id);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_null_for_empty_agent_id);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_null_for_negative_days);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_null_for_http_error);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_null_when_request_fails);
+  add_test_with_context (
+    suite, agent_controller,
+    download_support_bundle_plain_returns_null_for_empty_response);
 
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());


### PR DESCRIPTION
## What

* Add support for downloading decrypted support bundles from the Agent Controller.
* Add support for the optional `days` parameter.
* Add unit tests for the new plain support bundle download function.

## Why

* Allow gvmd to retrieve support bundles without encryption.
* Support the new Agent Controller `/support-bundle/plain` endpoint.


## References

GEA-2040

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


