### PR TITLE
Add `gvm_is_valid_xml` function

### DIFF
--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -3058,3 +3058,40 @@ xml_file_iterator_next (xml_file_iterator_t iterator, gchar **error)
 
   return NULL;
 }
+
+/**
+ * @brief Check if a string is valid XML.
+ *
+ * @param[in] str  The string to check.
+ */
+int
+gvm_is_valid_xml (const char *str, gchar **error_message)
+{
+  xmlSAXHandler sax_handler;
+  int ret;
+
+  memset (&sax_handler, 0, sizeof (xmlSAXHandler));
+  sax_handler.initialized = XML_SAX2_MAGIC;
+  if (error_message)
+    *error_message = NULL;
+
+  xmlParserCtxt *ctx =
+    xmlCreatePushParserCtxt (&sax_handler, NULL, NULL, 0, NULL);
+
+  ret = xmlParseChunk (ctx, str, strlen (str), 1);
+  if (ret)
+    {
+      if (error_message)
+        {
+          const xmlError *xml_error;
+          xml_error = xmlCtxtGetLastError (ctx);
+          *error_message =
+            g_strdup_printf ("%s (line %d column %d)", xml_error->message,
+                             xml_error->line, xml_error->int2);
+        }
+      xmlFreeParserCtxt (ctx);
+      return 0;
+    }
+  xmlFreeParserCtxt (ctx);
+  return 1;
+}

--- a/util/xmlutils.c
+++ b/util/xmlutils.c
@@ -3062,7 +3062,10 @@ xml_file_iterator_next (xml_file_iterator_t iterator, gchar **error)
 /**
  * @brief Check if a string is valid XML.
  *
- * @param[in] str  The string to check.
+ * @param[in]   str             The string to check.
+ * @param[out]  error_message   Optional error message output.
+ *
+ * @return 1 if string is valid XML, 0 if not.
  */
 int
 gvm_is_valid_xml (const char *str, gchar **error_message)
@@ -3070,10 +3073,18 @@ gvm_is_valid_xml (const char *str, gchar **error_message)
   xmlSAXHandler sax_handler;
   int ret;
 
-  memset (&sax_handler, 0, sizeof (xmlSAXHandler));
-  sax_handler.initialized = XML_SAX2_MAGIC;
   if (error_message)
     *error_message = NULL;
+
+  if (str == NULL)
+    {
+      if (error_message)
+        *error_message = g_strdup ("Given string is NULL");
+      return 0;
+    }
+
+  memset (&sax_handler, 0, sizeof (xmlSAXHandler));
+  sax_handler.initialized = XML_SAX2_MAGIC;
 
   xmlParserCtxt *ctx =
     xmlCreatePushParserCtxt (&sax_handler, NULL, NULL, 0, NULL);

--- a/util/xmlutils.h
+++ b/util/xmlutils.h
@@ -200,4 +200,8 @@ int xml_file_iterator_rewind (xml_file_iterator_t);
 element_t
 xml_file_iterator_next (xml_file_iterator_t, gchar **);
 
+/* Simple XML validation */
+int
+gvm_is_valid_xml (const char *, gchar **);
+
 #endif /* not _GVM_UTIL_XMLUTILS_H */

--- a/util/xmlutils_tests.c
+++ b/util/xmlutils_tests.c
@@ -773,6 +773,15 @@ Ensure (xmlutils, gvm_is_valid_xml_rejects_invalid_xml)
   g_free (error_message);
 }
 
+Ensure (xmlutils, gvm_is_valid_xml_rejects_null)
+{
+  gchar *error_message;
+
+  assert_that (gvm_is_valid_xml (NULL, &error_message), is_false);
+  assert_that (error_message, contains_string ("Given string is NULL"));
+  g_free (error_message);
+}
+
 /* Test suite. */
 
 int
@@ -820,6 +829,7 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, xmlutils, gvm_is_valid_xml_accepts_valid_xml);
   add_test_with_context (suite, xmlutils, gvm_is_valid_xml_rejects_invalid_xml);
+  add_test_with_context (suite, xmlutils, gvm_is_valid_xml_rejects_null);
 
   TestReporter *reporter = create_text_reporter ();
   if (argc > 1)

--- a/util/xmlutils_tests.c
+++ b/util/xmlutils_tests.c
@@ -30,9 +30,11 @@ write_temp_xml (const char *xml)
 Describe (xmlutils);
 BeforeEach (xmlutils)
 {
+  xmlInitParser ();
 }
 AfterEach (xmlutils)
 {
+  xmlCleanupParser ();
 }
 
 /* parse_entity */
@@ -746,6 +748,31 @@ Ensure (xmlutils, iterator_fails_on_unexpected_eof)
   element_free (e);
 }
 
+Ensure (xmlutils, gvm_is_valid_xml_accepts_valid_xml)
+{
+  gchar *error_message;
+
+  assert_that (gvm_is_valid_xml ("<test><x a=\"123\"/></test>", &error_message),
+               is_true);
+  assert_that (error_message, is_null);
+}
+
+Ensure (xmlutils, gvm_is_valid_xml_rejects_invalid_xml)
+{
+  gchar *error_message;
+
+  assert_that (
+    gvm_is_valid_xml ("<test><x a=\"123\"/></invalid>", &error_message),
+    is_false);
+  assert_that (error_message, contains_string ("tag mismatch"));
+  g_free (error_message);
+
+  assert_that (gvm_is_valid_xml ("<test><x a=\"123\"/>", &error_message),
+               is_false);
+  assert_that (error_message, contains_string ("Extra content at the end"));
+  g_free (error_message);
+}
+
 /* Test suite. */
 
 int
@@ -791,11 +818,16 @@ main (int argc, char **argv)
   add_test_with_context (suite, xmlutils, rewind_resets_state);
   add_test_with_context (suite, xmlutils, iterator_fails_on_unexpected_eof);
 
-  if (argc > 1)
-    ret = run_single_test (suite, argv[1], create_text_reporter ());
-  else
-    ret = run_test_suite (suite, create_text_reporter ());
+  add_test_with_context (suite, xmlutils, gvm_is_valid_xml_accepts_valid_xml);
+  add_test_with_context (suite, xmlutils, gvm_is_valid_xml_rejects_invalid_xml);
 
+  TestReporter *reporter = create_text_reporter ();
+  if (argc > 1)
+    ret = run_single_test (suite, argv[1], reporter);
+  else
+    ret = run_test_suite (suite, reporter);
+
+  destroy_reporter (reporter);
   destroy_test_suite (suite);
 
   return ret;


### PR DESCRIPTION
## What
A new function to check if a string is valid XML is added to `util/xmlutils`.

## Why
This is intended for validating XML file uploads in GSA

## References
GEA-2036

## Checklist
- [x] Tests


