### PR TITLE
Fix: free gz_file in gvm_gzip_open_file_reader

### DIFF
--- a/util/compressutils.c
+++ b/util/compressutils.c
@@ -318,6 +318,11 @@ gvm_gzip_open_file_reader (const char *path)
     }
 
   FILE *file = fopencookie (gz_file, "r", io_functions);
+  if (file == NULL)
+    {
+      gzclose (gz_file);
+      return NULL;
+    }
   return file;
 }
 
@@ -350,5 +355,10 @@ gvm_gzip_open_file_reader_fd (int fd)
     }
 
   FILE *file = fopencookie (gz_file, "r", io_functions);
+  if (file == NULL)
+    {
+      gzclose (gz_file);
+      return NULL;
+    }
   return file;
 }


### PR DESCRIPTION
## What

Close file on `fopencookie` failure in `gvm_gzip_open_file_reader`.

## Why

Technically a leak, so I'm cleaning it up.

## Testing

On main ran a small program that produced the leak in the Asan logs.
With patch ran the same program, leak was gone.